### PR TITLE
Add video metadata fields and ingestion updates

### DIFF
--- a/db/migrations/20250818000000000_initial.sql
+++ b/db/migrations/20250818000000000_initial.sql
@@ -14,9 +14,22 @@ create table public.videos (
   duration_seconds int,
   thumbnail_url text,
   preview_video_url text,
+  distribution_code text,
+  maker_code text,
+  director text,
+  series text,
+  maker text,
+  label text,
+  genre text,
+  price numeric,
+  distribution_started_at timestamptz,
+  product_released_at timestamptz,
+  sample_video_url text,
+  image_urls text[],
   source text not null,
   published_at timestamptz,
-  created_at timestamptz default now()
+  created_at timestamptz default now(),
+  unique (source, distribution_code, maker_code)
 );
 
 -- 動画埋め込み

--- a/scripts/fanza_ingest.ts
+++ b/scripts/fanza_ingest.ts
@@ -1,0 +1,51 @@
+export interface VideoRecord {
+  external_id: string;
+  title: string;
+  description?: string;
+  categories?: string[];
+  performers?: string[];
+  duration_seconds?: number;
+  thumbnail_url?: string;
+  preview_video_url?: string;
+  distribution_code?: string;
+  maker_code?: string;
+  director?: string;
+  series?: string;
+  maker?: string;
+  label?: string;
+  genre?: string;
+  price?: number;
+  distribution_started_at?: string;
+  product_released_at?: string;
+  sample_video_url?: string;
+  image_urls?: string[];
+  source: string;
+  published_at?: string;
+}
+
+export function mapFanzaItem(item: any): VideoRecord {
+  return {
+    external_id: item.product_id,
+    title: item.title,
+    description: item.description,
+    categories: item.categories,
+    performers: item.cast,
+    duration_seconds: item.duration,
+    thumbnail_url: item.thumbnail,
+    preview_video_url: item.preview,
+    distribution_code: item.dvd_id,
+    maker_code: item.maker_id,
+    director: item.director,
+    series: item.series,
+    maker: item.maker,
+    label: item.label,
+    genre: item.genre,
+    price: item.price,
+    distribution_started_at: item.sale_start,
+    product_released_at: item.release_date,
+    sample_video_url: item.sample_movie,
+    image_urls: item.images,
+    source: 'fanza',
+    published_at: item.release_date,
+  };
+}


### PR DESCRIPTION
## Summary
- extend `videos` table with distribution, maker, and release metadata
- enforce uniqueness for `(source, distribution_code, maker_code)`
- add Fanza ingestion mapping that fills new metadata fields

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a47b6ffbc8832a901ab12e1c1bdb78