### PR TITLE
Remove deprecated user_events table and use likes for metrics

### DIFF
--- a/docs/batch_jobs.yaml
+++ b/docs/batch_jobs.yaml
@@ -20,8 +20,8 @@ batch_jobs:
       新しい学習済みモデルを Supabase Edge Function で利用可能にする。
     schedule: "0 4 * * 0"   # 毎週日曜 04:00 JST 実行
     input:
-      - training_data: public.user_events
-      - features: ["views", "likes", "dismisses"]
+      - training_data: public.likes
+      - features: ["likes"]
     output:
       - update: public.video_embeddings
       - update: public.user_embeddings


### PR DESCRIPTION
## Summary
- remove obsolete event_type enum and user_events table
- rebuild video_popularity_daily to aggregate daily likes
- update batch job docs to train models from likes table

## Testing
- `npm test` *(fails: Missing script "test" error)*

------
https://chatgpt.com/codex/tasks/task_e_68a47b6dd68c832a9757cc97f90db4f5