### PR TITLE
fix: ALTER ROLE service_role をマネージド環境向けに削除

### DIFF
--- a/supabase/migrations/20260428100000_grant_service_role_tables.sql
+++ b/supabase/migrations/20260428100000_grant_service_role_tables.sql
@@ -1,8 +1,6 @@
 -- service_role に public スキーマの全テーブルへのアクセスを付与する
--- Supabase マネージド環境では自動付与されるが、セルフホスト環境では明示的に必要
+-- Supabase マネージド環境では BYPASSRLS は自動付与されるため ALTER ROLE は不要
 
--- RLS をバイパスできるよう BYPASSRLS 属性を付与
-ALTER ROLE service_role BYPASSRLS;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO service_role;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO service_role;
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO service_role;


### PR DESCRIPTION
## Summary

- `20260428100000_grant_service_role_tables.sql` の `ALTER ROLE service_role BYPASSRLS` が Supabase マネージド環境では予約済みロールのため実行不可だったのを修正
- Supabase マネージド環境では `BYPASSRLS` は自動付与されるため、この行は不要

## Test plan

- [ ] `supabase db push` がエラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)