### PR TITLE
fix: CI PRテストを ci:run-tests ラベルのみに制限

### DIFF
--- a/.github/workflows/cicd-pr-tests.yml
+++ b/.github/workflows/cicd-pr-tests.yml
@@ -2,11 +2,13 @@ name: "[CiCd] Ops - PR Test Suite"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [labeled]
     branches:
       - main
       - develop
   workflow_dispatch: {}
+
+# ci:run-tests ラベルが付いた場合のみ実行する
 
 permissions:
   contents: read
@@ -18,6 +20,7 @@ concurrency:
 jobs:
   migration_tests:
     name: Migration Tests
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ci:run-tests'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -97,6 +100,7 @@ jobs:
 
   function_tests:
     name: Supabase Function Tests
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ci:run-tests'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -121,6 +125,7 @@ jobs:
 
   frontend_tests:
     name: Frontend Tests
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'ci:run-tests'
     runs-on: ubuntu-latest
     env:
       NEXT_TELEMETRY_DISABLED: 1
@@ -157,7 +162,7 @@ jobs:
   discord_notify:
     name: Notify Discord (CI/CD)
     needs: [migration_tests, function_tests, frontend_tests]
-    if: ${{ always() }}
+    if: always() && (github.event_name == 'workflow_dispatch' || github.event.label.name == 'ci:run-tests')
     runs-on: ubuntu-latest
     steps:
       - name: Notify Discord


### PR DESCRIPTION
## Summary

- PR テストスイートが全PR（opened/synchronize/reopened）で自動起動していた問題を修正
- `ci:run-tests` ラベルが付いた場合か手動 `workflow_dispatch` のみ実行するように変更

## 変更内容

- `pull_request.types` を `[labeled]` のみに変更
- 各ジョブに `if: github.event.label.name == 'ci:run-tests'` 条件を追加
- `discord_notify` ジョブも同条件でガード

## 運用フロー

1. PR を作成（テストは走らない）
2. レビュー後、`ci:run-tests` ラベルを付ける → テスト起動
3. テストパス後にマージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)