### PR TITLE
feat: maker 多様性 reranking と偏り監視パイプラインを追加

### DIFF
--- a/.github/workflows/ml-audit-maker-bias.yml
+++ b/.github/workflows/ml-audit-maker-bias.yml
@@ -1,0 +1,63 @@
+name: "[ML] Ops - Audit Maker Bias"
+
+on:
+  workflow_dispatch:
+    inputs:
+      window_days:
+        description: '集計対象の日数'
+        required: false
+        default: '30'
+      threshold:
+        description: '偏り警告閾値（0.0〜1.0）'
+        required: false
+        default: '0.20'
+  schedule:
+    - cron: '0 3 1 * *' # 毎月1日 03:00 UTC
+
+jobs:
+  audit:
+    name: Maker Bias Audit
+    runs-on: ubuntu-latest
+    env:
+      REMOTE_DATABASE_URL: ${{ secrets.REMOTE_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r scripts/audit_maker_bias/requirements.txt
+
+      - name: Run audit
+        env:
+          WINDOW_DAYS: ${{ github.event.inputs.window_days || '30' }}
+          THRESHOLD: ${{ github.event.inputs.threshold || '0.20' }}
+        run: |
+          python scripts/audit_maker_bias/audit_maker_bias.py \
+            --db-url "$REMOTE_DATABASE_URL" \
+            --window-days "$WINDOW_DAYS" \
+            --threshold "$THRESHOLD" \
+            --log-csv docs/ml/maker_bias_log.csv \
+            --summary-json docs/ml/maker_bias_latest.json \
+          && echo "BIAS_EXIT=0" >> "$GITHUB_ENV" \
+          || { code=$?; echo "BIAS_EXIT=$code" >> "$GITHUB_ENV"; }
+
+      - name: Upload bias log as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maker-bias-log-${{ github.run_id }}
+          path: |
+            docs/ml/maker_bias_log.csv
+            docs/ml/maker_bias_latest.json
+
+      - name: Report bias status
+        if: always()
+        run: |
+          if [[ "${BIAS_EXIT:-0}" == "2" ]]; then
+            echo "::warning::maker 偏りが閾値を超えています。docs/ml/maker_bias_latest.json を確認してください。"
+          fi
+          echo "Exit code: ${BIAS_EXIT:-0}"

--- a/scripts/audit_maker_bias/Dockerfile
+++ b/scripts/audit_maker_bias/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim-bookworm
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY audit_maker_bias.py .
+ENTRYPOINT ["python", "audit_maker_bias.py"]

--- a/scripts/audit_maker_bias/audit_maker_bias.py
+++ b/scripts/audit_maker_bias/audit_maker_bias.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+maker 偏り監視スクリプト
+
+user_video_decisions の推薦履歴から maker 別分布を集計し、
+偏りが閾値を超えた場合に警告する。結果は CSV に追記する。
+
+使用例:
+  python audit_maker_bias.py --db-url postgresql://... --log-csv docs/ml/maker_bias_log.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import psycopg2
+import psycopg2.extras
+
+
+QUERY = """
+select
+    v.maker,
+    count(*) as recommendations,
+    count(distinct uvd.video_id) as unique_items,
+    count(distinct uvd.user_id) as user_coverage
+from public.user_video_decisions uvd
+join public.videos v on v.id = uvd.video_id
+where uvd.recommendation_type is not null
+  and uvd.created_at >= now() - interval '{days} days'
+group by v.maker
+order by recommendations desc
+"""
+
+TOTAL_QUERY = """
+select count(*) as total
+from public.user_video_decisions uvd
+where uvd.recommendation_type is not null
+  and uvd.created_at >= now() - interval '{days} days'
+"""
+
+LOG_HEADER = [
+    "measured_at",
+    "window_days",
+    "maker",
+    "recommendations",
+    "unique_items",
+    "user_coverage",
+    "share",
+    "bias_flagged",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Audit maker bias in recommendations")
+    p.add_argument("--db-url", default=os.environ.get("REMOTE_DATABASE_URL", ""))
+    p.add_argument("--window-days", type=int, default=30, help="集計対象の日数")
+    p.add_argument("--threshold", type=float, default=0.20, help="偏り警告閾値（share）")
+    p.add_argument("--log-csv", default="docs/ml/maker_bias_log.csv", help="追記先 CSV")
+    p.add_argument("--summary-json", default="", help="結果を JSON に出力する場合のパス")
+    p.add_argument("--top-n", type=int, default=20, help="表示する上位 maker 数")
+    return p.parse_args()
+
+
+def connect(db_url: str) -> psycopg2.extensions.connection:
+    return psycopg2.connect(db_url, cursor_factory=psycopg2.extras.RealDictCursor)
+
+
+def fetch_distribution(conn, window_days: int) -> tuple[pd.DataFrame, int]:
+    with conn.cursor() as cur:
+        cur.execute(TOTAL_QUERY.format(days=window_days))
+        total = int((cur.fetchone() or {}).get("total", 0))
+
+    with conn.cursor() as cur:
+        cur.execute(QUERY.format(days=window_days))
+        rows = cur.fetchall()
+
+    df = pd.DataFrame([dict(r) for r in rows])
+    if df.empty:
+        return df, total
+
+    df["recommendations"] = df["recommendations"].astype(int)
+    df["unique_items"] = df["unique_items"].astype(int)
+    df["user_coverage"] = df["user_coverage"].astype(int)
+    df["share"] = df["recommendations"] / total if total > 0 else 0.0
+    return df, total
+
+
+def append_log(log_path: Path, rows: list[dict], measured_at: str) -> None:
+    exists = log_path.exists()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=LOG_HEADER)
+        if not exists:
+            writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not args.db_url:
+        print("[error] --db-url または REMOTE_DATABASE_URL が未設定", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[audit] DB 接続中...")
+    conn = connect(args.db_url)
+
+    print(f"[audit] 直近 {args.window_days} 日間の推薦分布を集計中...")
+    df, total = fetch_distribution(conn, args.window_days)
+    conn.close()
+
+    if df.empty or total == 0:
+        print(f"[audit] 推薦データなし（window={args.window_days}日）。スキップ。")
+        return
+
+    print(f"\n[audit] 総推薦数: {total:,}  window: {args.window_days}日  閾値: {args.threshold:.0%}")
+    print(f"\n{'maker':<30} {'推薦数':>8} {'ユニーク':>8} {'ユーザー':>8} {'share':>7} {'⚠️ 偏り'}")
+    print("-" * 75)
+
+    flagged = []
+    measured_at = datetime.now(timezone.utc).isoformat()
+    log_rows = []
+    bias_detected = False
+
+    for _, row in df.head(args.top_n).iterrows():
+        flag = row["share"] >= args.threshold
+        if flag:
+            flagged.append(row["maker"])
+            bias_detected = True
+        marker = "⚠️ " if flag else "   "
+        print(
+            f"{str(row['maker']):<30} {int(row['recommendations']):>8,} "
+            f"{int(row['unique_items']):>8,} {int(row['user_coverage']):>8,} "
+            f"{row['share']:>6.1%}  {marker}"
+        )
+        log_rows.append({
+            "measured_at": measured_at,
+            "window_days": args.window_days,
+            "maker": row["maker"],
+            "recommendations": int(row["recommendations"]),
+            "unique_items": int(row["unique_items"]),
+            "user_coverage": int(row["user_coverage"]),
+            "share": round(float(row["share"]), 6),
+            "bias_flagged": flag,
+        })
+
+    if flagged:
+        print(f"\n[audit] ⚠️  偏り検出: {', '.join(flagged)} が閾値 {args.threshold:.0%} を超えています。")
+    else:
+        print(f"\n[audit] ✅ 偏りなし（全 maker が閾値 {args.threshold:.0%} 以下）")
+
+    log_path = Path(args.log_csv)
+    append_log(log_path, log_rows, measured_at)
+    print(f"[audit] CSV に追記: {log_path}  ({len(log_rows)} 行)")
+
+    if args.summary_json:
+        summary = {
+            "measured_at": measured_at,
+            "window_days": args.window_days,
+            "total_recommendations": total,
+            "threshold": args.threshold,
+            "bias_detected": bias_detected,
+            "flagged_makers": flagged,
+            "top_makers": df.head(args.top_n).to_dict(orient="records"),
+        }
+        Path(args.summary_json).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.summary_json).write_text(json.dumps(summary, ensure_ascii=False, indent=2))
+        print(f"[audit] JSON 出力: {args.summary_json}")
+
+    if bias_detected:
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_maker_bias/requirements.txt
+++ b/scripts/audit_maker_bias/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.0
+psycopg2-binary>=2.9

--- a/scripts/audit_maker_bias/run.sh
+++ b/scripts/audit_maker_bias/run.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+
+ENV_FILE=${AUDIT_MAKER_ENV_FILE:-docker/env/prd.env}
+WINDOW_DAYS=${AUDIT_MAKER_WINDOW_DAYS:-30}
+THRESHOLD=${AUDIT_MAKER_THRESHOLD:-0.20}
+LOG_CSV=${AUDIT_MAKER_LOG_CSV:-docs/ml/maker_bias_log.csv}
+SUMMARY_JSON=${AUDIT_MAKER_SUMMARY_JSON:-}
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "[audit-maker] env file not found: $ENV_FILE" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+DB_URL="${REMOTE_DATABASE_URL:-}"
+if [[ -z "$DB_URL" ]]; then
+  echo "[audit-maker] REMOTE_DATABASE_URL が未設定" >&2
+  exit 1
+fi
+
+EXTRA_ARGS=()
+if [[ -n "$SUMMARY_JSON" ]]; then
+  EXTRA_ARGS+=(--summary-json "$SUMMARY_JSON")
+fi
+
+cd "$REPO_ROOT"
+
+docker build -q -t audit-maker-bias "$SCRIPT_DIR"
+
+docker run --rm \
+  -e REMOTE_DATABASE_URL="$DB_URL" \
+  -v "$REPO_ROOT/docs/ml:/app/docs/ml" \
+  audit-maker-bias \
+  --db-url "$DB_URL" \
+  --window-days "$WINDOW_DAYS" \
+  --threshold "$THRESHOLD" \
+  --log-csv "docs/ml/$LOG_CSV" \
+  "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}" \
+  || EXIT_CODE=$?
+
+echo "[audit-maker] 完了 (exit=${EXIT_CODE:-0})"
+# exit 2 = 偏り検出（警告のみ、CI は失敗させない）
+exit 0

--- a/scripts/ml_weekly_pipeline/run.sh
+++ b/scripts/ml_weekly_pipeline/run.sh
@@ -161,4 +161,9 @@ if [[ "$RUN_RELEASE" == "true" ]]; then
     --run-id "$RUN_ID"
 fi
 
+echo "[ml-weekly] Audit: maker 偏り集計"
+AUDIT_MAKER_ENV_FILE="$ENV_FILE" \
+AUDIT_MAKER_LOG_CSV="docs/ml/maker_bias_log.csv" \
+  bash "$REPO_ROOT/scripts/audit_maker_bias/run.sh" || true
+
 echo "[ml-weekly] Completed."

--- a/supabase/migrations/20260430100000_maker_diversity_reranking.sql
+++ b/supabase/migrations/20260430100000_maker_diversity_reranking.sql
@@ -1,0 +1,143 @@
+-- get_videos_recommendations に maker 多様性 reranking を追加
+--
+-- 問題: 特定 maker（エスワン, ムーディーズ等）が推薦の 10-15% を占める偏りがある。
+-- 対策: 候補を page_limit * 5 件取得し、同一 maker の k 番目の出現に
+--       penalty = 1 / (1 + (k-1) * 0.3) を掛けて rerank する。
+--       これにより maker シェアが分散され、多様性が向上する。
+
+create or replace function public.get_videos_recommendations(user_uuid uuid, page_limit int default 20)
+returns table (
+  id uuid,
+  title text,
+  description text,
+  external_id text,
+  thumbnail_url text,
+  thumbnail_vertical_url text,
+  sample_video_url text,
+  product_url text,
+  product_released_at timestamptz,
+  performers jsonb,
+  tags jsonb,
+  score double precision,
+  model_version text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  user_vec halfvec(128);
+  approx_vec halfvec(128);
+  latest_version text;
+  candidate_limit int;
+begin
+  candidate_limit := page_limit * 5;
+
+  -- 近似ユーザー埋め込み: いいね済み動画の埋め込み平均（直近200件）
+  select avg(ve.embedding)::halfvec(128)
+    into approx_vec
+  from (
+    select uvd.video_id
+    from public.user_video_decisions uvd
+    where uvd.user_id = user_uuid
+      and uvd.decision_type = 'like'
+    order by uvd.created_at desc
+    limit 200
+  ) recent_likes
+  join public.video_embeddings ve on ve.video_id = recent_likes.video_id;
+
+  -- いいねがゼロの場合はバッチ生成済み埋め込みにフォールバック
+  if approx_vec is null then
+    select ue.embedding into user_vec
+    from public.user_embeddings ue
+    where ue.user_id = user_uuid;
+  end if;
+
+  user_vec := coalesce(approx_vec, user_vec);
+
+  if user_vec is null then
+    return;
+  end if;
+
+  select ve.model_version
+    into latest_version
+  from public.video_embeddings ve
+  where ve.model_version is not null
+  order by ve.updated_at desc
+  limit 1;
+
+  return query
+  with candidates as (
+    select
+      v.id,
+      v.title,
+      v.description,
+      v.external_id,
+      v.thumbnail_url,
+      v.thumbnail_vertical_url,
+      v.sample_video_url,
+      coalesce(v.affiliate_url, v.product_url) as product_url,
+      v.product_released_at,
+      coalesce(v.maker, 'unknown') as maker,
+      coalesce(
+        (
+          select jsonb_agg(jsonb_build_object('id', p.id, 'name', p.name) order by p.name)
+          from public.video_performers vp
+          join public.performers p on p.id = vp.performer_id
+          where vp.video_id = v.id
+        ), '[]'::jsonb
+      ) as performers,
+      coalesce(
+        (
+          select jsonb_agg(jsonb_build_object('id', t.id, 'name', t.name) order by t.name)
+          from public.video_tags vt
+          join public.tags t on t.id = vt.tag_id
+          left join public.tag_groups tg on tg.id = t.tag_group_id
+          where vt.video_id = v.id
+            and coalesce(tg.show_in_ui, true)
+        ), '[]'::jsonb
+      ) as tags,
+      1 - (ve.embedding <-> user_vec) as raw_score,
+      ve.model_version
+    from public.video_embeddings ve
+    join public.videos v on v.id = ve.video_id
+    where v.sample_video_url is not null
+      and (latest_version is null or ve.model_version = latest_version)
+      and not exists (
+        select 1 from public.user_video_decisions uvd
+        where uvd.video_id = v.id
+          and uvd.user_id = user_uuid
+      )
+    order by ve.embedding <-> user_vec
+    limit candidate_limit
+  ),
+  ranked as (
+    select
+      *,
+      -- 同一 maker 内での出現順（1始まり）
+      row_number() over (partition by maker order by raw_score desc) as maker_rank,
+      -- penalty = 1 / (1 + (maker_rank - 1) * 0.3)
+      raw_score / (1.0 + (row_number() over (partition by maker order by raw_score desc) - 1) * 0.3) as diversified_score
+    from candidates
+  )
+  select
+    r.id,
+    r.title,
+    r.description,
+    r.external_id,
+    r.thumbnail_url,
+    r.thumbnail_vertical_url,
+    r.sample_video_url,
+    r.product_url,
+    r.product_released_at,
+    r.performers,
+    r.tags,
+    r.diversified_score as score,
+    r.model_version
+  from ranked r
+  order by r.diversified_score desc
+  limit page_limit;
+end;
+$$;
+
+grant execute on function public.get_videos_recommendations(uuid, int) to anon, authenticated;


### PR DESCRIPTION
## Summary

エスワン（14.6%）・ムーディーズ（13.2%）など特定 maker への推薦偏りを解消する。

- **DB reranking** (`get_videos_recommendations`): 候補を `page_limit * 5` 件取得し、同一 maker の k 番目の出現に `1 / (1 + (k-1) * 0.3)` のペナルティを掛けて再ランク
- **偏り監視スクリプト** (`scripts/audit_maker_bias/`): `user_video_decisions` から maker 別推薦分布を集計し、閾値（デフォルト 20%）超えを検出して `docs/ml/maker_bias_log.csv` に追記
- **GitHub Action** (`ml-audit-maker-bias.yml`): 毎月1日 or 手動実行、偏り検出時は `::warning::` を出力
- **週次パイプライン**: `ml_weekly_pipeline/run.sh` の末尾に audit ステップを追加

## ペナルティ計算式

```
diversified_score = raw_score / (1 + (maker_rank - 1) * 0.3)
```
- maker_rank=1（その maker の最高スコア動画）: ペナルティなし
- maker_rank=2: スコア × 0.77
- maker_rank=3: スコア × 0.63
- maker_rank=4: スコア × 0.53

## Test plan

- [ ] `/swipe` でスワイプ時に推薦が返ることを確認
- [ ] 同一 maker の連続推薦が減少していることをデバッグモード（`?debug=1`）で確認
- [ ] `audit_maker_bias.py` をローカルで実行して CSV が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)