### PR TITLE
fix: 人気推薦が0件になるバグを修正（video_popularity_daily）

### DIFF
--- a/.github/workflows/ml-refresh-popularity.yml
+++ b/.github/workflows/ml-refresh-popularity.yml
@@ -1,0 +1,22 @@
+name: "[ML] Ops - Refresh Popularity Matview"
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '30 0 * * *' # 毎日 00:30 UTC（JST 09:30）
+
+jobs:
+  refresh:
+    name: Refresh video_popularity_daily
+    runs-on: ubuntu-latest
+    env:
+      REMOTE_DATABASE_URL: ${{ secrets.REMOTE_DATABASE_URL }}
+    steps:
+      - name: Install psql client
+        run: sudo apt-get install -y postgresql-client
+
+      - name: Refresh materialized view
+        run: |
+          psql "$REMOTE_DATABASE_URL" \
+            -c "refresh materialized view concurrently public.video_popularity_daily;" \
+            -c "select count(*), min(d), max(d) from public.video_popularity_daily;"

--- a/supabase/migrations/20260501000000_fix_video_popularity_matview.sql
+++ b/supabase/migrations/20260501000000_fix_video_popularity_matview.sql
@@ -1,0 +1,25 @@
+-- video_popularity_daily を likes テーブルから user_video_decisions ベースに修正
+--
+-- 問題: matview が旧 likes テーブルを参照しており、user_video_decisions 移行後は
+--       常に空だった。get_popular_videos が 0 件を返すのはこれが原因。
+
+drop materialized view if exists public.video_popularity_daily cascade;
+
+create materialized view public.video_popularity_daily as
+select
+  uvd.video_id,
+  date_trunc('day', uvd.created_at at time zone 'UTC') as d,
+  count(*) as likes
+from public.user_video_decisions uvd
+where uvd.decision_type = 'like'
+group by uvd.video_id, date_trunc('day', uvd.created_at at time zone 'UTC');
+
+-- CONCURRENT REFRESH に必要なユニークインデックス
+create unique index mv_pop_daily_uidx
+  on public.video_popularity_daily (video_id, d);
+
+-- 初回データを即時投入
+refresh materialized view public.video_popularity_daily;
+
+-- アクセス権限を再付与
+grant select on public.video_popularity_daily to anon, authenticated, service_role;


### PR DESCRIPTION
## 原因

`video_popularity_daily` マテリアライズドビューが旧 `likes` テーブルを参照していた。
アプリは `user_video_decisions` に移行済みのため、matview が常に空 → `get_popular_videos` が 0 件返却 → デバッグパネルで `人気=0` になっていた。

## 修正内容

- **migration**: matview を `user_video_decisions` (`decision_type = 'like'`) ベースに再作成し、初回 REFRESH を実行
- **GHA** `[ML] Ops - Refresh Popularity Matview`: 毎日 00:30 UTC（JST 09:30）に `refresh materialized view concurrently` を自動実行

## 確認方法

マージ後に `/swipe?debug=1` で `人気` が 0 より大きくなることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)