### PR TITLE
fix: デッキが0になる前にリセットされるバグを修正

### DIFF
--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -80,6 +80,7 @@ function SwipePageContent() {
   const [swipesUntilNextEmbed, setSwipesUntilNextEmbed] = useState<number | null>(null);
   const { decisionCount, incrementDecisionCount } = useDecisionCount();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const isLoggedInRef = useRef<boolean>(false);
   const [authReady, setAuthReady] = useState<boolean>(false);
   const guestLimit = Number(process.env.NEXT_PUBLIC_GUEST_DECISIONS_LIMIT || 20);
   const mainRef = useRef<HTMLDivElement | null>(null);
@@ -314,7 +315,7 @@ function SwipePageContent() {
           status: 'error',
           source: 'videos_feed',
           response_ms: Date.now() - requestStartedAt,
-          has_session: isLoggedIn,
+          has_session: isLoggedInRef.current,
           error_message: error.message,
         });
         return;
@@ -360,7 +361,7 @@ function SwipePageContent() {
         status: 'success',
         source: 'videos_feed',
         response_ms: Date.now() - requestStartedAt,
-        has_session: isLoggedIn,
+        has_session: isLoggedInRef.current,
         videos_count: fetchedCards.length,
         swipes_until_next_embed: metadata?.swipes_until_next_embed,
         decision_count: metadata?.decision_count,
@@ -372,13 +373,13 @@ function SwipePageContent() {
         status: 'error',
         source: 'videos_feed',
         response_ms: Date.now() - requestStartedAt,
-        has_session: isLoggedIn,
+        has_session: isLoggedInRef.current,
         error_message: message,
       });
     } finally {
       setIsFetchingVideos(false);
     }
-  }, [isLoggedIn]);
+  }, []);
 
   useEffect(() => {
     const recalc = () => {
@@ -469,6 +470,7 @@ function SwipePageContent() {
 
   useEffect(() => {
     const { data: authListener } = supabase.auth.onAuthStateChange((_event, session) => {
+      isLoggedInRef.current = !!session?.user;
       setIsLoggedIn(!!session?.user);
       setAuthReady(true);
       if (!!session?.user) {
@@ -570,8 +572,6 @@ function SwipePageContent() {
               console.error("Error calling embed-user:", error.message);
             } else {
               console.log("embed-user API call successful.");
-              // Optionally, refetch videos to get the new countdown
-              refetchVideos();
             }
           });
         }


### PR DESCRIPTION
## Summary
- `refetchVideos` の deps から `isLoggedIn` を削除し、stable な callback に変更
- ログイン状態変化時に `useEffect([authReady, refetchVideos])` が再実行されてデッキがリセットされていた問題を修正
- `embed-user` 成功後のデッキ途中 `refetchVideos()` 呼び出しも削除

## 根本原因
ゲストでスワイプ中にログインすると `isLoggedIn` が変わり → `refetchVideos` の参照が更新され → `useEffect` が再発火 → デッキがリセットされていた。

## Test plan
- [ ] ゲスト状態でスワイプを数枚進める
- [ ] ログインする → デッキがリセットされないことを確認
- [ ] デッキを最後まで使い切る → 新しいデッキが正常に読み込まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)