### PR TITLE
fix: videos-feed params をデッキ実構成数に修正・adjustedPageLimit を適用

### DIFF
--- a/supabase/functions/videos-feed/index.ts
+++ b/supabase/functions/videos-feed/index.ts
@@ -259,15 +259,15 @@ Deno.serve(async (req) => {
     let exploitIdx = 0
     let popIdx = 0
     let exploreIdx = 0
-    while (final.length < pageLimit) {
+    while (final.length < adjustedPageLimit) {
       if (exploitIdx < exploitation.length) {
         final.push(exploitation[exploitIdx++])
       }
-      if (final.length >= pageLimit) break
+      if (final.length >= adjustedPageLimit) break
       if (popIdx < popularity.length) {
         final.push(popularity[popIdx++])
       }
-      if (final.length >= pageLimit) break
+      if (final.length >= adjustedPageLimit) break
       if (exploreIdx < exploration.length) {
         final.push(exploration[exploreIdx++])
       }
@@ -276,13 +276,17 @@ Deno.serve(async (req) => {
       }
     }
 
-    if (final.length < pageLimit) {
+    if (final.length < adjustedPageLimit) {
       const remaining = [...exploitation.slice(exploitIdx), ...popularity.slice(popIdx), ...exploration.slice(exploreIdx)]
       for (const item of remaining) {
-        if (final.length >= pageLimit) break
+        if (final.length >= adjustedPageLimit) break
         final.push(item)
       }
     }
+
+    const finalExploitCount = final.filter(v => v.source === 'exploitation').length
+    const finalPopularityCount = final.filter(v => v.source === 'popularity').length
+    const finalExplorationCount = final.filter(v => v.source === 'exploration').length
 
     const EMBED_INTERVAL = 10
     const remainder = decisionCount % EMBED_INTERVAL
@@ -297,9 +301,9 @@ Deno.serve(async (req) => {
           popularity_ratio: adjustedPopularityRatio,
           exploration_ratio: Math.max(0, 1 - adjustedExploitationRatio - adjustedPopularityRatio),
           popularity_lookback_days: popularLookbackDays,
-          exploitation_returned: exploitation.length,
-          popularity_returned: popularity.length,
-          exploration_returned: exploration.length,
+          exploitation_returned: finalExploitCount,
+          popularity_returned: finalPopularityCount,
+          exploration_returned: finalExplorationCount,
         },
       })),
       metadata: {


### PR DESCRIPTION
## Summary
- `exploitation_returned` 等の params を候補取得数ではなく最終デッキの実内訳に変更（デバッグ表示が実態と一致）
- while ループの上限を `pageLimit(20)` → `adjustedPageLimit` に修正（100スワイプ超ユーザーが30件受け取れていなかったバグも修正）

## Test plan
- [ ] `?debug=1` でスワイプし、個人/人気/探索の合計がデッキ枚数と一致することを確認
- [ ] 100スワイプ超ユーザーでデッキが30件になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)