### PR TITLE
feat: 個人嗜好適合度統計を debug オーバーレイに追加

### DIFF
--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -44,9 +44,23 @@ interface GuestDecision {
   recommendation_type?: string | null;
 }
 
+interface UserStatsBucket {
+  likes: number;
+  total: number;
+  like_rate: number;
+}
+
+interface UserStats {
+  window: number;
+  like_rate: number;
+  by_source: Partial<Record<'exploitation' | 'popularity' | 'exploration', UserStatsBucket>>;
+  by_score: Partial<Record<'low' | 'mid' | 'high', UserStatsBucket>>;
+}
+
 interface VideosFeedMetadata {
   swipes_until_next_embed: number;
   decision_count: number;
+  user_stats: UserStats | null;
 }
 
 const ORIGINAL_GRADIENT = 'linear-gradient(135deg, #1a0d2e 0%, #160d25 33%, #2a1020 66%, #1e0d1a 100%)';
@@ -78,6 +92,7 @@ function SwipePageContent() {
   const { height: windowHeight } = useWindowSize();
   const [cardWidth, setCardWidth] = useState<number | undefined>(400);
   const [swipesUntilNextEmbed, setSwipesUntilNextEmbed] = useState<number | null>(null);
+  const [userStats, setUserStats] = useState<UserStats | null>(null);
   const { decisionCount, incrementDecisionCount } = useDecisionCount();
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
   const isLoggedInRef = useRef<boolean>(false);
@@ -327,6 +342,7 @@ function SwipePageContent() {
 
       if (metadata) {
         setSwipesUntilNextEmbed(metadata.swipes_until_next_embed);
+        setUserStats(metadata.user_stats ?? null);
       }
 
       const normalizeHttps = (u?: string) => u?.startsWith('http://') ? u.replace('http://', 'https://') : u;
@@ -652,6 +668,34 @@ function SwipePageContent() {
                 <p>embed in: <span className="text-green-300">{swipesUntilNextEmbed ?? '—'}</span></p>
                 <p>auth: <span className={isLoggedIn ? 'text-green-300' : 'text-red-400'}>{isLoggedIn ? 'in' : 'guest'}</span></p>
               </div>
+              {userStats && (
+                <div className="mt-1.5 border-t border-white/10 pt-1.5 space-y-0.5">
+                  <p className="text-[9px] uppercase tracking-widest text-amber-300/60">好み適合度 (直近{userStats.window}件)</p>
+                  <p>like率: <span className={userStats.like_rate >= 0.4 ? 'text-green-300' : userStats.like_rate >= 0.25 ? 'text-yellow-300' : 'text-red-400'}>{(userStats.like_rate * 100).toFixed(0)}%</span></p>
+                  <div className="text-[10px] space-y-0.5">
+                    {(['exploitation', 'popularity', 'exploration'] as const).map(src => {
+                      const d = userStats.by_source[src];
+                      if (!d) return null;
+                      const label = src === 'exploitation' ? '個人' : src === 'popularity' ? '人気' : '探索';
+                      const color = src === 'exploitation' ? 'text-violet-300' : src === 'popularity' ? 'text-yellow-300' : 'text-gray-400';
+                      return (
+                        <p key={src}><span className={color}>{label}</span>: {(d.like_rate * 100).toFixed(0)}% <span className="text-white/40">({d.likes}/{d.total})</span></p>
+                      );
+                    })}
+                  </div>
+                  <div className="text-[10px] space-y-0.5 mt-0.5">
+                    {(['low', 'mid', 'high'] as const).map(bucket => {
+                      const d = userStats.by_score[bucket];
+                      if (!d) return null;
+                      const label = bucket === 'low' ? '低' : bucket === 'mid' ? '中' : '高';
+                      const color = bucket === 'high' ? 'text-green-300' : bucket === 'mid' ? 'text-yellow-300' : 'text-red-400';
+                      return (
+                        <p key={bucket}>スコア<span className={color}>{label}</span>: {(d.like_rate * 100).toFixed(0)}% <span className="text-white/40">({d.total}件)</span></p>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         );

--- a/supabase/functions/videos-feed/index.ts
+++ b/supabase/functions/videos-feed/index.ts
@@ -292,6 +292,57 @@ Deno.serve(async (req) => {
     const remainder = decisionCount % EMBED_INTERVAL
     const swipes_until_next_embed = EMBED_INTERVAL - remainder || EMBED_INTERVAL
 
+    // 個人の嗜好適合度統計（直近 N 件の回数窓）
+    type UserStats = {
+      window: number
+      like_rate: number
+      by_source: Record<string, { likes: number; total: number; like_rate: number }>
+      by_score: Record<string, { likes: number; total: number; like_rate: number }>
+    }
+    let userStats: UserStats | null = null
+    if (userId) {
+      const STATS_WINDOW = 50
+      const { data: recentDecisions, error: statsError } = await supabase
+        .from('user_video_decisions')
+        .select('decision_type, recommendation_source, recommendation_score')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(STATS_WINDOW)
+      if (statsError) {
+        console.error('user stats query error:', statsError.message)
+      } else if (recentDecisions && recentDecisions.length > 0) {
+        const rows = recentDecisions as { decision_type: string; recommendation_source: string | null; recommendation_score: number | null }[]
+        const totalLikes = rows.filter(r => r.decision_type === 'like').length
+        const likeRate = (n: number, d: number) => d > 0 ? Math.round(n / d * 1000) / 1000 : 0
+
+        const bySource: UserStats['by_source'] = {}
+        for (const src of ['exploitation', 'popularity', 'exploration']) {
+          const subset = rows.filter(r => r.recommendation_source === src)
+          const likes = subset.filter(r => r.decision_type === 'like').length
+          if (subset.length > 0) bySource[src] = { likes, total: subset.length, like_rate: likeRate(likes, subset.length) }
+        }
+
+        const scoreBuckets: [string, (s: number) => boolean][] = [
+          ['low',  s => s < 0.3],
+          ['mid',  s => s >= 0.3 && s < 0.6],
+          ['high', s => s >= 0.6],
+        ]
+        const byScore: UserStats['by_score'] = {}
+        for (const [label, pred] of scoreBuckets) {
+          const subset = rows.filter(r => r.recommendation_score !== null && pred(r.recommendation_score!))
+          const likes = subset.filter(r => r.decision_type === 'like').length
+          if (subset.length > 0) byScore[label] = { likes, total: subset.length, like_rate: likeRate(likes, subset.length) }
+        }
+
+        userStats = {
+          window: rows.length,
+          like_rate: likeRate(totalLikes, rows.length),
+          by_source: bySource,
+          by_score: byScore,
+        }
+      }
+    }
+
     const payload = {
       videos: final.slice(0, adjustedPageLimit).map((item) => ({
         ...item,
@@ -309,6 +360,7 @@ Deno.serve(async (req) => {
       metadata: {
         swipes_until_next_embed: swipes_until_next_embed,
         decision_count: decisionCount,
+        user_stats: userStats,
       },
     }
 


### PR DESCRIPTION
## Summary
- `videos-feed` で直近50件（回数窓）の個人like率・ソース別・スコア帯別を集計し `metadata.user_stats` に追加
- `?debug=1` 時に「好み適合度」セクションを表示
  - 全体like率（緑/黄/赤で色分け）
  - ソース別like率（個人/人気/探索）
  - スコアキャリブレーション（高スコア → like率高いか検証）

## 見方
- `個人 > 探索` → 個人化モデルが機能している
- `スコア高 > 中 > 低` → TwoTower のスコアが信頼できる
- ゲストは `user_stats: null` のためセクション非表示

## Test plan
- [ ] ログイン状態で `?debug=1` を開き、「好み適合度」セクションが表示されることを確認
- [ ] ゲスト状態では非表示になることを確認
- [ ] 数枚スワイプ後にデッキを更新し、数値が変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)