### PR TITLE
feat: GHA Discord 通知を Embed 形式に刷新

### DIFF
--- a/.github/workflows/apprelease-deploy-frontend.yml
+++ b/.github/workflows/apprelease-deploy-frontend.yml
@@ -100,14 +100,34 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          SHA: ${{ github.sha }}
+          ENVIRONMENT: ${{ inputs.environment || 'production' }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            STATUS="✅ success"
-            if [ "$JOB_STATUS" != "success" ]; then
-              STATUS="❌ $JOB_STATUS"
-            fi
-            curl -X POST -H "Content-Type: application/json" -d "{\"content\":\"[AppRelease Frontend] $STATUS\"}" "$DISCORD_WEBHOOK_URL"
-          fi
+          [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
+          if   [ "$JOB_STATUS" = "success" ]; then COLOR=2278246;  ICON="✅"
+          elif [ "$JOB_STATUS" = "failure" ]; then COLOR=15682074; ICON="❌"
+          else                                     COLOR=16032867; ICON="⚠️"; fi
+          SHORT_SHA="${SHA:0:7}"
+          jq -n \
+            --arg title  "Frontend Deploy" \
+            --arg url    "$RUN_URL" \
+            --argjson color "$COLOR" \
+            --arg status "${ICON} ${JOB_STATUS}" \
+            --arg env    "$ENVIRONMENT" \
+            --arg branch "$REF_NAME" \
+            --arg actor  "$ACTOR" \
+            --arg commit "$SHORT_SHA" \
+            '{embeds:[{title:$title,url:$url,color:$color,fields:[
+              {name:"Status",      value:$status, inline:true},
+              {name:"Environment", value:$env,    inline:true},
+              {name:"Branch",      value:$branch, inline:true},
+              {name:"Actor",       value:$actor,  inline:true},
+              {name:"Commit",      value:$commit, inline:true}
+            ],timestamp:(now|todate)}]}' \
+          | curl -fsSL -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"
 
     # Notes:
     # - Configure repo secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID

--- a/.github/workflows/cicd-deploy-db.yml
+++ b/.github/workflows/cicd-deploy-db.yml
@@ -61,14 +61,34 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          SHA: ${{ github.sha }}
+          TARGET: ${{ inputs.target || secrets.SUPABASE_PROJECT_ID }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            STATUS="✅ success"
-            if [ "$JOB_STATUS" != "success" ]; then
-              STATUS="❌ $JOB_STATUS"
-            fi
-            curl -X POST -H "Content-Type: application/json" -d "{\"content\":\"[CiCd Deploy DB] $STATUS\"}" "$DISCORD_WEBHOOK_URL"
-          fi
+          [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
+          if   [ "$JOB_STATUS" = "success" ]; then COLOR=2278246;  ICON="✅"
+          elif [ "$JOB_STATUS" = "failure" ]; then COLOR=15682074; ICON="❌"
+          else                                     COLOR=16032867; ICON="⚠️"; fi
+          SHORT_SHA="${SHA:0:7}"
+          jq -n \
+            --arg title  "DB Migrations Deploy" \
+            --arg url    "$RUN_URL" \
+            --argjson color "$COLOR" \
+            --arg status "${ICON} ${JOB_STATUS}" \
+            --arg target "$TARGET" \
+            --arg branch "$REF_NAME" \
+            --arg actor  "$ACTOR" \
+            --arg commit "$SHORT_SHA" \
+            '{embeds:[{title:$title,url:$url,color:$color,fields:[
+              {name:"Status",  value:$status, inline:true},
+              {name:"Target",  value:$target, inline:true},
+              {name:"Branch",  value:$branch, inline:true},
+              {name:"Actor",   value:$actor,  inline:true},
+              {name:"Commit",  value:$commit, inline:true}
+            ],timestamp:(now|todate)}]}' \
+          | curl -fsSL -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"
 
     # Notes:
     # - Configure repo secrets: SUPABASE_ACCESS_TOKEN, SUPABASE_PROJECT_ID, SUPABASE_DB_PASSWORD

--- a/.github/workflows/cicd-deploy-functions.yml
+++ b/.github/workflows/cicd-deploy-functions.yml
@@ -61,14 +61,34 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          SHA: ${{ github.sha }}
+          FUNCTION_NAME: ${{ inputs.function || 'all' }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            STATUS="✅ success"
-            if [ "$JOB_STATUS" != "success" ]; then
-              STATUS="❌ $JOB_STATUS"
-            fi
-            curl -X POST -H "Content-Type: application/json" -d "{\"content\":\"[CiCd Deploy Functions] $STATUS\"}" "$DISCORD_WEBHOOK_URL"
-          fi
+          [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
+          if   [ "$JOB_STATUS" = "success" ]; then COLOR=2278246;  ICON="✅"
+          elif [ "$JOB_STATUS" = "failure" ]; then COLOR=15682074; ICON="❌"
+          else                                     COLOR=16032867; ICON="⚠️"; fi
+          SHORT_SHA="${SHA:0:7}"
+          jq -n \
+            --arg title    "Edge Functions Deploy" \
+            --arg url      "$RUN_URL" \
+            --argjson color "$COLOR" \
+            --arg status   "${ICON} ${JOB_STATUS}" \
+            --arg func     "$FUNCTION_NAME" \
+            --arg branch   "$REF_NAME" \
+            --arg actor    "$ACTOR" \
+            --arg commit   "$SHORT_SHA" \
+            '{embeds:[{title:$title,url:$url,color:$color,fields:[
+              {name:"Status",   value:$status, inline:true},
+              {name:"Function", value:$func,   inline:true},
+              {name:"Branch",   value:$branch, inline:true},
+              {name:"Actor",    value:$actor,  inline:true},
+              {name:"Commit",   value:$commit, inline:true}
+            ],timestamp:(now|todate)}]}' \
+          | curl -fsSL -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"
 
     # Notes:
     # - Configure repo secrets: SUPABASE_ACCESS_TOKEN, SUPABASE_PROJECT_ID, SUPABASE_DB_PASSWORD

--- a/.github/workflows/cicd-pr-tests.yml
+++ b/.github/workflows/cicd-pr-tests.yml
@@ -168,11 +168,56 @@ jobs:
       - name: Notify Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          MIG_RESULT: ${{ needs.migration_tests.result }}
+          FUN_RESULT: ${{ needs.function_tests.result }}
+          FRT_RESULT: ${{ needs.frontend_tests.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REF_NAME: ${{ github.ref_name }}
+          ACTOR: ${{ github.actor }}
+          SHA: ${{ github.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title || github.ref_name }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            MIG_STATUS=${{ needs.migration_tests.result }}
-            FUN_STATUS=${{ needs.function_tests.result }}
-            FRT_STATUS=${{ needs.frontend_tests.result }}
-            MSG="[CiCd PR Tests] migration=${MIG_STATUS}, functions=${FUN_STATUS}, frontend=${FRT_STATUS}"
-            curl -X POST -H "Content-Type: application/json" -d "{\"content\":\"$MSG\"}" "$DISCORD_WEBHOOK_URL"
-          fi
+          [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
+          status_icon() {
+            case "$1" in
+              success)  echo "✅" ;;
+              failure)  echo "❌" ;;
+              skipped)  echo "⏭️" ;;
+              *)        echo "⚠️" ;;
+            esac
+          }
+          # 全体ステータスは failure > cancelled > success の優先順位
+          OVERALL="success"
+          for s in "$MIG_RESULT" "$FUN_RESULT" "$FRT_RESULT"; do
+            [ "$s" = "failure"   ] && OVERALL="failure"   && break
+            [ "$s" = "cancelled" ] && [ "$OVERALL" != "failure" ] && OVERALL="cancelled"
+          done
+          if   [ "$OVERALL" = "success"   ]; then COLOR=2278246;  OVERALL_ICON="✅"
+          elif [ "$OVERALL" = "failure"   ]; then COLOR=15682074; OVERALL_ICON="❌"
+          else                                    COLOR=16032867; OVERALL_ICON="⚠️"; fi
+          SHORT_SHA="${SHA:0:7}"
+          MIG_VAL="$(status_icon "$MIG_RESULT") ${MIG_RESULT}"
+          FUN_VAL="$(status_icon "$FUN_RESULT") ${FUN_RESULT}"
+          FRT_VAL="$(status_icon "$FRT_RESULT") ${FRT_RESULT}"
+          jq -n \
+            --arg title   "PR Test Suite" \
+            --arg url     "$RUN_URL" \
+            --argjson color "$COLOR" \
+            --arg overall "${OVERALL_ICON} ${OVERALL}" \
+            --arg branch  "$REF_NAME" \
+            --arg actor   "$ACTOR" \
+            --arg commit  "$SHORT_SHA" \
+            --arg pr      "$PR_TITLE" \
+            --arg mig     "$MIG_VAL" \
+            --arg fun     "$FUN_VAL" \
+            --arg frt     "$FRT_VAL" \
+            '{embeds:[{title:$title,url:$url,color:$color,fields:[
+              {name:"Overall",    value:$overall, inline:true},
+              {name:"Branch",     value:$branch,  inline:true},
+              {name:"Actor",      value:$actor,   inline:true},
+              {name:"PR",         value:$pr,      inline:false},
+              {name:"Migration",  value:$mig,     inline:true},
+              {name:"Functions",  value:$fun,     inline:true},
+              {name:"Frontend",   value:$frt,     inline:true}
+            ],timestamp:(now|todate)}]}' \
+          | curl -fsSL -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- プレーンテキスト通知 → Discord Embed（色付き・フィールド・タイムスタンプ）
- ✅ 成功=緑 / ❌ 失敗=赤 / ⚠️ その他=黄
- 全ワークフローにブランチ・コミット・実行者・実行URLを追加
- PR テストはジョブ別（Migration / Functions / Frontend）ステータスも個別表示

## 変更ファイル
- `apprelease-deploy-frontend.yml` — Environment フィールド追加
- `cicd-deploy-db.yml` — Target プロジェクト ref フィールド追加
- `cicd-deploy-functions.yml` — Function 名フィールド追加
- `cicd-pr-tests.yml` — ジョブ別ステータス + 全体判定（failure > cancelled > success）

## Test plan
- [ ] 各ワークフローを workflow_dispatch で手動実行し Discord に Embed が届くことを確認
- [ ] 失敗時に赤色になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)