### PR TITLE
feat: ヘッダーをハンバーガーメニューに変更（スマホ対応）

### DIFF
--- a/frontend/src/app/quiz/QuizHeader.tsx
+++ b/frontend/src/app/quiz/QuizHeader.tsx
@@ -2,9 +2,11 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useState } from 'react';
 
 export default function QuizHeader() {
   const pathname = usePathname();
+  const [open, setOpen] = useState(false);
 
   const links = [
     { href: '/quiz', label: '診断する' },
@@ -13,33 +15,53 @@ export default function QuizHeader() {
   ];
 
   return (
-    <header className="w-full border-b border-[#e8c9a0]/40 bg-[#fff8f0]/80 backdrop-blur-sm sticky top-0 z-50">
-      <div className="max-w-lg mx-auto px-4 h-14 flex items-center justify-between">
-        {/* タイトル */}
-        <Link href="/quiz" className="font-black text-[16px] text-[#5c2e00] leading-tight">
-          性癖16タイプ診断
-        </Link>
+    <>
+      <header className="w-full border-b border-[#e8c9a0]/40 bg-[#fff8f0]/80 backdrop-blur-sm sticky top-0 z-50">
+        <div className="max-w-lg mx-auto px-4 h-14 flex items-center justify-between">
+          <Link href="/quiz" className="font-black text-[16px] text-[#5c2e00] leading-tight">
+            性癖16タイプ診断
+          </Link>
 
-        {/* ナビ */}
-        <nav className="flex items-center gap-1">
-          {links.map((link) => {
-            const isActive = pathname === link.href;
-            return (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={`px-3 py-1.5 rounded-full text-[12px] font-bold transition-colors ${
-                  isActive
-                    ? 'bg-[#ffb347] text-white'
-                    : 'text-[#b5541a] hover:bg-[#ffb347]/20'
-                }`}
-              >
-                {link.label}
-              </Link>
-            );
-          })}
-        </nav>
-      </div>
-    </header>
+          <button
+            onClick={() => setOpen((v) => !v)}
+            aria-label="メニューを開く"
+            className="flex flex-col justify-center items-center w-10 h-10 gap-1.5"
+          >
+            <span className={`block w-6 h-0.5 bg-[#b5541a] transition-transform duration-200 ${open ? 'translate-y-2 rotate-45' : ''}`} />
+            <span className={`block w-6 h-0.5 bg-[#b5541a] transition-opacity duration-200 ${open ? 'opacity-0' : ''}`} />
+            <span className={`block w-6 h-0.5 bg-[#b5541a] transition-transform duration-200 ${open ? '-translate-y-2 -rotate-45' : ''}`} />
+          </button>
+        </div>
+      </header>
+
+      {/* ドロワー */}
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setOpen(false)}
+          />
+          <nav className="fixed top-14 right-0 z-50 w-48 bg-[#fff8f0] border border-[#e8c9a0]/60 rounded-bl-2xl shadow-lg py-2">
+            {links.map((link) => {
+              const isActive = pathname === link.href;
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  onClick={() => setOpen(false)}
+                  className={`block px-5 py-3 text-[14px] font-bold transition-colors ${
+                    isActive
+                      ? 'text-[#ff8c00] bg-[#ffb347]/10'
+                      : 'text-[#b5541a] hover:bg-[#ffb347]/10'
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- スマホでヘッダーのナビが詰まる問題を解消
- ナビ3項目（診断する・キャラ一覧・この診断とは）をハンバーガーアイコンに収納
- タップで右側にドロワー表示、ドロワー外タップで閉じる
- ハンバーガーアイコンはX字アニメーション付き

## Test plan
- [ ] スマホ幅でヘッダーが崩れないことを確認
- [ ] ハンバーガーアイコンのタップでドロワーが開閉することを確認
- [ ] 各リンクをタップするとページ遷移しドロワーが閉じることを確認
- [ ] アクティブなページのリンクがハイライトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)