### PR TITLE
feat: 「さがす」「あなたの性癖」リニューアル + スワイプ変態度バッジ

### DIFF
--- a/frontend/src/app/insights/page.tsx
+++ b/frontend/src/app/insights/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useMemo, useRef, useState } from 'react';
-import { Share2, Info, Smile, Frown, TrendingUp, Tag as TagIcon, Users, Clock } from 'lucide-react';
+import { Share2, Tag as TagIcon, Users, Clock, ExternalLink } from 'lucide-react';
 import { toPng } from 'html-to-image';
 import ShareModal from '@/components/ShareModal';
 import AnalysisShareCard from '@/components/AnalysisShareCard';
 import { useAnalysisResults } from '@/hooks/useAnalysisResults';
+import type { AnalysisTag, AnalysisPerformer } from '@/hooks/useAnalysisResults';
 
 const WINDOW_OPTIONS: Array<{ label: string; value: number | null }> = [
   { label: '3日', value: 3 },
@@ -27,44 +28,107 @@ const formatDate = (value: string | null): string => {
   try {
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return '—';
-    return new Intl.DateTimeFormat('ja-JP', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-    }).format(date);
-  } catch {
-    return '—';
-  }
+    return new Intl.DateTimeFormat('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(date);
+  } catch { return '—'; }
 };
 
 const formatCount = (value: number): string => value.toLocaleString('ja-JP');
 
-function SummaryCard({
-  title,
-  value,
-  sub,
-  icon: Icon,
-}: {
-  title: string;
-  value: string;
-  sub?: string;
-  icon: React.ComponentType<{ size?: number }>;
-}) {
+// ── タイプ判定ロジック（AnalysisShareCardと共通） ─────────────────
+type TypeProfile = { keywords: string[]; typeName: string; highlight: string; headerCopy: string };
+
+const TYPE_PROFILES: TypeProfile[] = [
+  { keywords: ['美少女', 'ロリ', '制服', '女子校生', '妹'], typeName: '清楚ロリ系', highlight: '透明感あるかわいいムードでときめきがち。', headerCopy: 'あどけない雰囲気の作品を追いかける王道ロリ派。' },
+  { keywords: ['巨乳', '爆乳', 'お姉さん', 'むちむち', '痴女'], typeName: '巨乳お姉さん系', highlight: '包容力たっぷりの大人なお姉さんでとろけたい。', headerCopy: '余裕のあるお姉さんに甘やかされたい欲が爆発中。' },
+  { keywords: ['人妻', '不倫', '寝取られ', 'NTR', '禁断'], typeName: '背徳NTR系', highlight: '禁断のストーリーで心拍を上げるのが快感。', headerCopy: '日常では味わえない背徳展開に特大の刺さり方。' },
+  { keywords: ['ギャル', '日焼け', 'ビッチ', 'パリピ'], typeName: 'ギラギラギャル系', highlight: '勢いとノリで押してくるギャルに弱い。', headerCopy: '明るいギャルエネルギーでテンションを上げるタイプ。' },
+  { keywords: ['単体作品', '王道', 'ノーマル'], typeName: '王道単体派', highlight: '企画よりもシンプルな単体作で集中したい。', headerCopy: 'じっくり堪能できる王道スタイルを求める派。' },
+  { keywords: ['SM', '拘束', '調教', '支配', '主従'], typeName: '刺激スパイス系', highlight: 'ピリ辛な刺激で一気にスイッチが入る。', headerCopy: '刺激的なシチュをアクセントにしたい攻め志向。' },
+];
+
+const DEFAULT_PROFILE = { typeName: 'バランス型', highlight: 'ジャンルを渡り歩きつつ、その日の気分で決める柔軟派。', headerCopy: '王道からマニアックまで幅広くいける万能スタイル。' };
+
+function deriveTypeProfile(tags: AnalysisTag[]) {
+  const tagNames = tags.map((t) => t.tag_name);
+  return TYPE_PROFILES.find((p) => p.keywords.some((kw) => tagNames.some((n) => n.includes(kw)))) ?? DEFAULT_PROFILE;
+}
+
+// 変態度スコア（like_ratio・総判断数・タグ多様性から算出）
+function calcHentaiScore(likeRatio: number | null, sampleSize: number, tagCount: number): number {
+  const ratio = likeRatio ?? 0;
+  // like_ratioが極端（高すぎ or 低すぎ）ほど変態度が高い
+  const ratioPart = Math.abs(ratio - 0.4) * 1.5; // 0.4が平均的、そこからの乖離
+  // 判断数が多いほど変態度が高い（上限あり）
+  const activityPart = Math.min(sampleSize / 500, 1) * 0.3;
+  // タグ多様性（少ないほどこだわり強い→変態度高い）
+  const diversityPart = tagCount <= 2 ? 0.2 : tagCount <= 5 ? 0.1 : 0;
+  const raw = 0.35 + ratioPart + activityPart + diversityPart;
+  return Math.round(Math.min(Math.max(raw, 0.2), 0.99) * 100);
+}
+
+const RANK_COLORS = ['from-yellow-400 to-amber-500', 'from-slate-300 to-slate-400', 'from-amber-600 to-amber-700'];
+
+function RankBadge({ rank }: { rank: number }) {
+  const color = RANK_COLORS[rank - 1] ?? 'from-rose-400 to-fuchsia-500';
   return (
-    <div className="rounded-xl bg-white/80 backdrop-blur shadow-lg border border-white/40 p-4 text-gray-900 flex items-center gap-4">
-      <div className="flex items-center justify-center w-12 h-12 rounded-full bg-rose-100 text-rose-500 shadow-inner">
-        <Icon size={22} />
+    <span className={`w-7 h-7 rounded-full bg-gradient-to-br ${color} text-white text-xs font-black flex items-center justify-center shrink-0 shadow`}>
+      {rank}
+    </span>
+  );
+}
+
+function TagRankItem({ tag, rank }: { tag: AnalysisTag; rank: number }) {
+  const ratio = tag.like_ratio ?? 0;
+  return (
+    <div className="flex items-center gap-3 rounded-xl bg-white/70 border border-white/60 shadow-sm px-4 py-3">
+      <RankBadge rank={rank} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline justify-between gap-2 mb-1">
+          <span className="text-sm font-bold text-gray-900 truncate">#{tag.tag_name}</span>
+          <span className="text-sm font-black text-rose-500 shrink-0">{formatPercent(tag.like_ratio)}</span>
+        </div>
+        <div className="h-1.5 bg-rose-50 rounded-full overflow-hidden">
+          <div className="h-full rounded-full bg-gradient-to-r from-rose-400 to-fuchsia-500 transition-all" style={{ width: `${Math.round(ratio * 100)}%` }} />
+        </div>
+        <div className="flex justify-between mt-1 text-[10px] text-gray-400">
+          <span>気になる {formatCount(tag.likes)}件</span>
+          {tag.share != null && <span>シェア {formatPercent(tag.share)}</span>}
+        </div>
       </div>
-      <div className="flex flex-col">
-        <span className="text-sm font-semibold text-gray-500">{title}</span>
-        <span className="text-2xl font-bold">{value}</span>
-        {sub ? <span className="text-xs text-gray-500 mt-1">{sub}</span> : null}
-      </div>
+      {tag.representative_video?.product_url && (
+        <a href={tag.representative_video.product_url} target="_blank" rel="noopener noreferrer" className="shrink-0 text-gray-400 hover:text-rose-400 transition">
+          <ExternalLink size={14} />
+        </a>
+      )}
     </div>
   );
 }
 
-export default function AnalysisResultsPage() {
+function PerformerRankItem({ performer, rank }: { performer: AnalysisPerformer; rank: number }) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl bg-white/70 border border-white/60 shadow-sm px-4 py-3">
+      <RankBadge rank={rank} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-sm font-bold text-gray-900 truncate">{performer.performer_name}</span>
+          <span className="text-sm font-black text-indigo-500 shrink-0">{formatPercent(performer.like_ratio)}</span>
+        </div>
+        <div className="text-[10px] text-gray-400 mt-0.5">
+          気になる {formatCount(performer.likes)}件
+          {performer.share != null && <span className="ml-2">シェア {formatPercent(performer.share)}</span>}
+        </div>
+      </div>
+      {performer.representative_video?.product_url && (
+        <a href={performer.representative_video.product_url} target="_blank" rel="noopener noreferrer" className="shrink-0 text-gray-400 hover:text-indigo-400 transition">
+          <ExternalLink size={14} />
+        </a>
+      )}
+    </div>
+  );
+}
+
+// ── メインページ ──────────────────────────────────────────────────
+export default function InsightsPage() {
   const [windowDays, setWindowDays] = useState<number | null>(null);
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const [shareImageUrl, setShareImageUrl] = useState<string | null>(null);
@@ -84,372 +148,250 @@ export default function AnalysisResultsPage() {
 
   const windowLabel = useMemo(() => {
     if (!summary) return '';
-    if (summary.window_days === null) return '全期間';
-    return `直近 ${summary.window_days} 日`;
+    return summary.window_days === null ? '全期間' : `直近 ${summary.window_days} 日`;
   }, [summary]);
+
+  const typeProfile = useMemo(() => deriveTypeProfile(topTags), [topTags]);
+
+  const hentaiScore = useMemo(() => {
+    if (!summary) return null;
+    return calcHentaiScore(summary.like_ratio, summary.sample_size, topTags.length);
+  }, [summary, topTags]);
 
   const shareUrl = typeof window !== 'undefined' ? window.location.href : 'https://seiheki.me/insights';
   const primaryTag = topTags[0];
-  const secondaryTag = topTags[1];
   const primaryPerformer = topPerformers[0];
-  const shareTagNames = [primaryTag, secondaryTag].flatMap((tag) => (tag ? [`#${tag.tag_name}`] : []));
-  const sharePerformerNames = primaryPerformer ? [primaryPerformer.performer_name] : [];
+  const shareTagNames = topTags.slice(0, 2).map((t) => `#${t.tag_name}`);
   const shareText = (() => {
-    if (primaryTag && primaryPerformer) {
-      return `最近は ${primaryPerformer.performer_name} が出る #${primaryTag.tag_name} 系で毎回「気になる」。あなたも #あなたの性癖 を診断して抜けるポイントをシェアしよう。`;
-    }
-    if (shareTagNames.length > 0) {
-      return `今の抜けるタグは ${shareTagNames.join(' / ')}。あなたも #あなたの性癖 を診断して好みカードを作ろう。`;
-    }
-    if (sharePerformerNames.length > 0) {
-      return `${sharePerformerNames.join(' / ')} が出ていたら即「気になる」。あなたも #あなたの性癖 を診断して抜ける出演者を布教しよう。`;
-    }
-    if (summary) {
-      return `${windowLabel}の好み分析結果をシェアしました。あなたも #あなたの性癖 を診断してみて。`;
-    }
-    return 'あなたの性癖の結果をシェアしました。';
+    if (primaryTag && primaryPerformer) return `最近は ${primaryPerformer.performer_name} が出る #${primaryTag.tag_name} 系で毎回「気になる」。あなたも #あなたの性癖 を診断して抜けるポイントをシェアしよう。`;
+    if (shareTagNames.length > 0) return `今の抜けるタグは ${shareTagNames.join(' / ')}。あなたも #あなたの性癖 を診断して好みカードを作ろう。`;
+    if (primaryPerformer) return `${primaryPerformer.performer_name} が出ていたら即「気になる」。あなたも #あなたの性癖 を診断してみよう。`;
+    return `${windowLabel}の好み分析結果をシェアしました。あなたも #あなたの性癖 を診断してみて。`;
   })();
 
   const handleShare = async () => {
-    if (!cardRef.current || !summary) {
-      if (typeof window !== 'undefined') {
-        window.alert('データを取得してからシェアしてください。');
-      }
-      return;
-    }
+    if (!cardRef.current || !summary) { window.alert('データを取得してからシェアしてください。'); return; }
     try {
-      const dataUrl = await toPng(cardRef.current, {
-        cacheBust: true,
-        pixelRatio: 2,
-        backgroundColor: '#050113',
-      });
+      const dataUrl = await toPng(cardRef.current, { cacheBust: true, pixelRatio: 2, backgroundColor: '#050113' });
       setShareImageUrl(dataUrl);
       setIsShareModalOpen(true);
-    } catch (err) {
-      console.error('Failed to generate share image', err);
-      if (typeof navigator !== 'undefined' && navigator.share) {
-        try {
-          await navigator.share({
-            title: 'あなたの性癖分析結果',
-            text: shareText,
-            url: shareUrl,
-          });
-        } catch {
-          /* noop */
-        }
-      }
-    }
-  };
-
-  const handleOpenProduct = (url?: string | null) => {
-    if (!url) return;
-    try {
-      window.open(url, '_blank', 'noopener,noreferrer');
     } catch {
-      /* noop */
+      if (navigator.share) {
+        try { await navigator.share({ title: 'あなたの性癖分析結果', text: shareText, url: shareUrl }); } catch { /* noop */ }
+      }
     }
   };
 
   return (
     <>
       <main className="w-full min-h-screen px-0 sm:px-4 py-8">
-      <section className="w-full mx-auto rounded-2xl bg-white/20 backdrop-blur-xl border border-white/30 shadow-[0_20px_60px_rgba(0,0,0,0.25)] p-4 sm:p-8 text-white">
-        <header className="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div className="space-y-2">
-            <h1 className="text-xl sm:text-2xl font-extrabold tracking-tight">あなたの性癖</h1>
-            <p className="text-sm text-white/80">「気になる」 / 「スキップ」の履歴から好みの傾向を可視化します。</p>
-          </div>
-          <button
-            onClick={handleShare}
-            aria-label="共有"
-            className="inline-flex items-center gap-1 rounded-md bg-white/20 hover:bg-white/30 backdrop-blur px-3 py-2 text-sm font-semibold text-white transition"
-            title="共有"
-          >
-            <Share2 size={16} />
-            シェア（β版）
-          </button>
-        </header>
+        <div className="max-w-7xl mx-auto flex flex-col gap-5">
 
-        <div className="flex flex-col lg:flex-row gap-4 lg:items-center lg:justify-between mb-6">
-          <div className="flex flex-wrap gap-2">
-            {WINDOW_OPTIONS.map((option) => {
-              const active = option.value === windowDays || (option.value === null && windowDays === null);
-              return (
-                <button
-                  key={option.label}
-                  onClick={() => setWindowDays(option.value)}
-                  className={`px-3 py-1.5 rounded-full text-xs sm:text-sm font-semibold transition ${
-                    active ? 'bg-white text-rose-500 shadow-lg' : 'bg-white/20 text-white hover:bg-white/30'
-                  }`}
-                >
-                  {option.label}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-
-        {loading ? (
-          <div className="grid gap-4">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {Array.from({ length: 3 }).map((_, idx) => (
-                <div key={`summary-skeleton-${idx}`} className="h-24 rounded-xl bg-white/30 animate-pulse" />
-              ))}
-            </div>
-            <div className="h-32 rounded-xl bg-white/30 animate-pulse" />
-          </div>
-        ) : (
-          <>
-            {error ? (
-              <div className="rounded-xl bg-red-500/20 border border-red-400/60 text-white px-4 py-3 mb-6">
-                {error}
+          {/* ── ヒーロー：タイプ名・変態度 ── */}
+          <section className="w-full rounded-2xl overflow-hidden relative" style={{ background: 'linear-gradient(135deg, #1a0a2e 0%, #2d0a1f 50%, #0f1a3d 100%)' }}>
+            <div className="absolute inset-0 opacity-20" style={{ backgroundImage: 'radial-gradient(circle at 20% 50%, #f43f5e 0%, transparent 50%), radial-gradient(circle at 80% 20%, #8b5cf6 0%, transparent 50%)' }} />
+            <div className="relative px-6 py-8 sm:px-10 sm:py-10 flex flex-col sm:flex-row sm:items-end gap-6">
+              <div className="flex-1">
+                <p className="text-xs font-bold tracking-[0.4em] text-rose-400 uppercase mb-2">あなたの性癖タイプ</p>
+                {loading ? (
+                  <div className="h-10 w-48 bg-white/10 rounded-lg animate-pulse" />
+                ) : (
+                  <h1 className="text-3xl sm:text-4xl font-black text-white leading-tight">{typeProfile.typeName}</h1>
+                )}
+                <p className="text-sm text-white/70 mt-2 leading-relaxed">{loading ? '' : typeProfile.headerCopy}</p>
               </div>
-            ) : null}
 
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-              <SummaryCard
-                title="気になる数"
-                value={summary ? formatCount(summary.total_likes) : '—'}
-                sub={summary ? `${windowLabel}の「気になる」合計` : undefined}
-                icon={Smile}
-              />
-              <SummaryCard
-                title="スキップ数"
-                value={summary ? formatCount(summary.total_nope) : '—'}
-                sub={summary ? `${windowLabel}の「スキップ」合計` : undefined}
-                icon={Frown}
-              />
-              <SummaryCard
-                title="気になる比率"
-                value={summary ? formatPercent(summary.like_ratio) : '—'}
-                sub={summary ? `サンプル ${formatCount(summary.sample_size)} 件` : undefined}
-                icon={TrendingUp}
-              />
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
-              <section className="rounded-xl bg-white/85 backdrop-blur-md shadow-lg border border-white/50 p-5 text-gray-900">
-                <header className="flex items-start justify-between gap-3 mb-4">
-                  <div>
-                    <h2 className="text-lg font-bold flex items-center gap-2">
-                      <TagIcon size={18} className="text-rose-400" />
-                      好きなタグ Top {topTags.length}
-                    </h2>
-                    <p className="text-xs text-gray-500 mt-1">「気になる」が多いタグの傾向を表示します。</p>
+              {/* 変態度スコア */}
+              <div className="shrink-0 flex flex-col items-center gap-1">
+                <p className="text-[10px] font-bold tracking-[0.3em] text-white/50 uppercase">変態度</p>
+                <div className="relative w-24 h-24">
+                  <svg viewBox="0 0 100 100" className="w-full h-full -rotate-90">
+                    <circle cx="50" cy="50" r="42" fill="none" stroke="rgba(255,255,255,0.1)" strokeWidth="10" />
+                    <circle
+                      cx="50" cy="50" r="42" fill="none"
+                      stroke="url(#scoreGrad)" strokeWidth="10"
+                      strokeLinecap="round"
+                      strokeDasharray={`${2 * Math.PI * 42}`}
+                      strokeDashoffset={loading || hentaiScore === null ? 2 * Math.PI * 42 : 2 * Math.PI * 42 * (1 - hentaiScore / 100)}
+                      style={{ transition: 'stroke-dashoffset 1s ease' }}
+                    />
+                    <defs>
+                      <linearGradient id="scoreGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+                        <stop offset="0%" stopColor="#f43f5e" />
+                        <stop offset="100%" stopColor="#a855f7" />
+                      </linearGradient>
+                    </defs>
+                  </svg>
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <span className="text-2xl font-black text-white">
+                      {loading || hentaiScore === null ? '—' : `${hentaiScore}`}
+                    </span>
                   </div>
-                  <Info size={16} className="text-gray-400 shrink-0" />
-                </header>
-                {topTags.length === 0 ? (
-                  <div className="text-sm text-gray-500 bg-white/60 rounded-lg p-4">
-                    データがまだありません。作品に「気になる」を付けるとタグ分析が表示されます。
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-3">
-                    {topTags.map((tag) => (
-                      <div key={tag.tag_id} className="rounded-lg border border-gray-200 bg-white/80 shadow-sm p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                        <div className="flex flex-col">
-                          <span className="text-sm font-semibold text-gray-700">{tag.tag_name}</span>
-                          <span className="text-xs text-gray-500">
-                            気になる: {formatCount(tag.likes)} / スキップ: {formatCount(tag.nopes)}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-4 text-xs text-gray-500">
-                          <div className="flex flex-col text-right">
-                            <span>気になる比率</span>
-                            <span className="text-base font-bold text-gray-900">{formatPercent(tag.like_ratio)}</span>
-                          </div>
-                          <div className="flex flex-col text-right">
-                            <span>気になるシェア</span>
-                            <span className="text-base font-bold text-gray-900">{tag.share != null ? formatPercent(tag.share) : '—'}</span>
-                          </div>
-                          {tag.representative_video ? (
-                            <button
-                              onClick={() => handleOpenProduct(tag.representative_video?.product_url)}
-                              className="px-3 py-1.5 text-xs font-semibold rounded-full bg-rose-500/15 text-rose-500 hover:bg-rose-500/25 transition"
-                            >
-                              代表作を見る
-                            </button>
-                          ) : null}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </section>
-
-              <section className="rounded-xl bg-white/85 backdrop-blur-md shadow-lg border border-white/50 p-5 text-gray-900">
-                <header className="flex items-start justify-between gap-3 mb-4">
-                  <div>
-                    <h2 className="text-lg font-bold flex items-center gap-2">
-                      <Users size={18} className="text-rose-400" />
-                      好きな出演者 Top {topPerformers.length}
-                    </h2>
-                    <p className="text-xs text-gray-500 mt-1">「気になる」とした作品に多く登場する出演者の傾向を表示します。</p>
-                  </div>
-                  <Info size={16} className="text-gray-400 shrink-0" />
-                </header>
-                {topPerformers.length === 0 ? (
-                  <div className="text-sm text-gray-500 bg-white/60 rounded-lg p-4">
-                    データがまだありません。「気になる」とした作品の出演者がここに表示されます。
-                  </div>
-                ) : (
-                  <div className="flex flex-col gap-3">
-                    {topPerformers.map((performer) => (
-                      <div key={performer.performer_id} className="rounded-lg border border-gray-200 bg-white/80 shadow-sm p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                        <div className="flex flex-col">
-                          <span className="text-sm font-semibold text-gray-700">{performer.performer_name}</span>
-                          <span className="text-xs text-gray-500">
-                            気になる: {formatCount(performer.likes)} / スキップ: {formatCount(performer.nopes)}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-4 text-xs text-gray-500">
-                          <div className="flex flex-col text-right">
-                            <span>気になる比率</span>
-                            <span className="text-base font-bold text-gray-900">{formatPercent(performer.like_ratio)}</span>
-                          </div>
-                          <div className="flex flex-col text-right">
-                            <span>気になるシェア</span>
-                            <span className="text-base font-bold text-gray-900">{performer.share != null ? formatPercent(performer.share) : '—'}</span>
-                          </div>
-                          {performer.representative_video ? (
-                            <button
-                              onClick={() => handleOpenProduct(performer.representative_video?.product_url)}
-                              className="px-3 py-1.5 text-xs font-semibold rounded-full bg-rose-500/15 text-rose-500 hover:bg-rose-500/25 transition"
-                            >
-                              出演作を見る
-                            </button>
-                          ) : null}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </section>
-            </div>
-
-            <section className="rounded-xl bg-white/85 backdrop-blur-md shadow-lg border border-white/50 p-5 text-gray-900 mb-6">
-              <header className="flex items-start justify-between gap-3 mb-4">
-                <div>
-                  <h2 className="text-lg font-bold flex items-center gap-2">
-                    <Clock size={18} className="text-rose-400" />
-                    直近の判断履歴
-                  </h2>
-                  <p className="text-xs text-gray-500 mt-1">最新の「気になる」 / 「スキップ」を新しい順に表示します。</p>
                 </div>
-                <Info size={16} className="text-gray-400 shrink-0" />
+                <p className="text-[10px] text-white/40">/ 100</p>
+              </div>
+
+              {/* シェアボタン */}
+              <button
+                onClick={handleShare}
+                className="shrink-0 inline-flex items-center gap-2 rounded-full bg-white/15 hover:bg-white/25 border border-white/20 px-4 py-2 text-sm font-semibold text-white transition backdrop-blur"
+              >
+                <Share2 size={15} />
+                シェア
+              </button>
+            </div>
+
+            {/* 期間切替 */}
+            <div className="relative px-6 pb-5 sm:px-10 flex flex-wrap gap-2">
+              {WINDOW_OPTIONS.map((opt) => {
+                const active = opt.value === windowDays || (opt.value === null && windowDays === null);
+                return (
+                  <button
+                    key={opt.label}
+                    onClick={() => setWindowDays(opt.value)}
+                    className={`px-3 py-1 rounded-full text-xs font-semibold transition ${active ? 'bg-white text-rose-500 shadow' : 'bg-white/10 text-white/70 hover:bg-white/20'}`}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+              {summary && (
+                <span className="ml-auto text-xs text-white/40 self-center">
+                  判断数 {formatCount(summary.sample_size)}件
+                </span>
+              )}
+            </div>
+          </section>
+
+          {error && (
+            <div className="rounded-2xl bg-red-500/10 border border-red-400/40 text-red-400 px-4 py-3 text-sm">{error}</div>
+          )}
+
+          {/* ── サマリー数値 ── */}
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              { label: '気になる', value: summary ? formatCount(summary.total_likes) : '—', sub: windowLabel, color: 'text-rose-400' },
+              { label: 'スキップ', value: summary ? formatCount(summary.total_nope) : '—', sub: windowLabel, color: 'text-slate-400' },
+              { label: '気になる率', value: summary ? formatPercent(summary.like_ratio) : '—', sub: `${formatCount(summary?.sample_size ?? 0)}件中`, color: 'text-fuchsia-400' },
+            ].map((item) => (
+              <div key={item.label} className="rounded-2xl bg-white/15 backdrop-blur border border-white/20 px-4 py-4 text-center">
+                <p className="text-[11px] text-white/50 mb-1">{item.label}</p>
+                {loading ? (
+                  <div className="h-7 w-16 mx-auto bg-white/10 rounded animate-pulse" />
+                ) : (
+                  <p className={`text-2xl font-black ${item.color}`}>{item.value}</p>
+                )}
+                <p className="text-[10px] text-white/30 mt-0.5">{item.sub}</p>
+              </div>
+            ))}
+          </div>
+
+          {/* ── タグ・出演者ランキング ── */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <section className="rounded-2xl bg-white/85 backdrop-blur border border-white/50 shadow-lg p-5 text-gray-900 flex flex-col gap-3">
+              <header className="flex items-center gap-2 mb-1">
+                <TagIcon size={17} className="text-rose-400" />
+                <h2 className="text-base font-bold">好きなタグ Top {topTags.length}</h2>
               </header>
-              {recent.length === 0 ? (
-                <div className="text-sm text-gray-500 bg-white/60 rounded-lg p-4">
-                  まだ判断履歴がありません。スワイプ画面で評価するとここに表示されます。
-                </div>
+              {loading ? (
+                Array.from({ length: 3 }).map((_, i) => <div key={i} className="h-16 rounded-xl bg-gray-100 animate-pulse" />)
+              ) : topTags.length === 0 ? (
+                <p className="text-sm text-gray-400 py-4 text-center">「気になる」を付けるとここに表示されます</p>
               ) : (
-                <div className="overflow-x-auto">
-                  <table className="w-full table-fixed border-separate border-spacing-y-2 text-sm text-gray-700">
-                    <thead>
-                      <tr className="text-xs uppercase tracking-wide text-gray-500">
-                        <th className="px-3 py-2 text-left font-semibold w-[32%]">作品</th>
-                        <th className="px-3 py-2 text-left font-semibold w-[12%]">判断</th>
-                        <th className="px-3 py-2 text-left font-semibold w-[20%]">タグ</th>
-                        <th className="px-3 py-2 text-left font-semibold w-[20%]">出演者</th>
-                        <th className="px-3 py-2 text-left font-semibold w-[12%]">決定日</th>
-                        <th className="px-3 py-2 text-left font-semibold w-[8%]">操作</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {recent.map((item) => (
-                        <tr
-                          key={`${item.video_id}-${item.decided_at}`}
-                          className="bg-white/80 border border-gray-200/80 rounded-xl shadow-sm align-top"
-                        >
-                          <td className="px-3 py-3 align-top">
-                            <div className="flex items-start gap-3">
-                              <div className="h-14 w-20 shrink-0 rounded-lg overflow-hidden bg-gray-100 border border-gray-200">
-                                {item.thumbnail_url ? (
-                                  // eslint-disable-next-line @next/next/no-img-element
-                                  <img src={item.thumbnail_url} alt={item.title ?? 'thumbnail'} className="w-full h-full object-cover" />
-                                ) : null}
-                              </div>
-                              <div className="flex flex-col gap-1 w-full min-w-0">
-                                <span className="text-sm font-semibold text-gray-900 line-clamp-3">{item.title ?? 'タイトル未設定'}</span>
-                              </div>
-                            </div>
-                          </td>
-                          <td className="px-3 py-3 align-top">
-                            <span
-                              className={`inline-flex items-center justify-center min-w-[64px] px-2 py-0.5 text-xs font-bold rounded-full ${
-                                item.decision_type === 'like' ? 'bg-rose-500/15 text-rose-500' : 'bg-gray-200 text-gray-700'
-                              }`}
-                            >
-                              {item.decision_type === 'like' ? '気になる' : 'スキップ'}
-                            </span>
-                          </td>
-                          <td className="px-3 py-3 align-top">
-                            <div className="flex flex-wrap gap-1">
-                              {item.tags.slice(0, 4).map((tag) => (
-                                <span key={tag.id} className="px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-600 border border-gray-200/60 text-xs">
-                                  #{tag.name}
-                                </span>
-                              ))}
-                            </div>
-                          </td>
-                          <td className="px-3 py-3 align-top">
-                            <div className="flex flex-wrap gap-1">
-                              {item.performers.slice(0, 4).map((perf) => (
-                                <span key={perf.id} className="px-1.5 py-0.5 rounded-full bg-pink-100 text-pink-600 border border-pink-200/60 text-xs">
-                                  {perf.name}
-                                </span>
-                              ))}
-                            </div>
-                          </td>
-                          <td className="px-3 py-3 align-top text-xs text-gray-600">
-                            {formatDate(item.decided_at)}
-                          </td>
-                          <td className="px-3 py-3 align-top min-w-[110px]">
-                            {item.product_url ? (
-                              <button
-                                onClick={() => handleOpenProduct(item.product_url)}
-                                className="px-3 py-1.5 text-xs font-semibold rounded-full bg-rose-500/15 text-rose-500 hover:bg-rose-500/25 transition"
-                              >
-                                作品ページへ
-                              </button>
-                            ) : (
-                              <span className="text-xs text-gray-400">—</span>
-                            )}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+                topTags.map((tag, i) => <TagRankItem key={tag.tag_id} tag={tag} rank={i + 1} />)
               )}
             </section>
 
-            <section className="rounded-xl bg-white/85 backdrop-blur-md shadow-lg border border-white/50 p-5 text-gray-900">
-              <header className="flex items-start gap-3 mb-4">
-                <Info size={18} className="text-rose-400 mt-0.5" />
-                <div>
-                  <h2 className="text-lg font-bold">集計メモ</h2>
-                  <p className="text-xs text-gray-500 mt-1">
-                    集計対象は {windowLabel} に行った「気になる」 / 「スキップ」で、最大 {MAX_FETCH.toLocaleString('ja-JP')} 件までを対象にしています。
-                    タグ・出演者のシェアは「気になる」件数を母数に算出されます。
-                  </p>
-                </div>
+            <section className="rounded-2xl bg-white/85 backdrop-blur border border-white/50 shadow-lg p-5 text-gray-900 flex flex-col gap-3">
+              <header className="flex items-center gap-2 mb-1">
+                <Users size={17} className="text-indigo-400" />
+                <h2 className="text-base font-bold">よく見る出演者 Top {topPerformers.length}</h2>
               </header>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm text-gray-600">
-                <div className="rounded-lg border border-gray-200 bg-white/80 p-4">
-                  <div className="text-xs font-semibold text-gray-500 mb-1">最初の判断</div>
-                  <div className="text-base font-bold text-gray-900">{summary ? formatDate(summary.first_decision_at) : '—'}</div>
-                </div>
-                <div className="rounded-lg border border-gray-200 bg-white/80 p-4">
-                  <div className="text-xs font-semibold text-gray-500 mb-1">最新の判断</div>
-                  <div className="text-base font-bold text-gray-900">{summary ? formatDate(summary.latest_decision_at) : '—'}</div>
-                </div>
-              </div>
+              {loading ? (
+                Array.from({ length: 3 }).map((_, i) => <div key={i} className="h-14 rounded-xl bg-gray-100 animate-pulse" />)
+              ) : topPerformers.length === 0 ? (
+                <p className="text-sm text-gray-400 py-4 text-center">「気になる」とした作品の出演者がここに表示されます</p>
+              ) : (
+                topPerformers.map((perf, i) => <PerformerRankItem key={perf.performer_id} performer={perf} rank={i + 1} />)
+              )}
             </section>
-          </>
-        )}
-      </section>
+          </div>
+
+          {/* ── 直近の判断履歴 ── */}
+          <section className="rounded-2xl bg-white/85 backdrop-blur border border-white/50 shadow-lg p-5 text-gray-900">
+            <header className="flex items-center gap-2 mb-4">
+              <Clock size={17} className="text-rose-400" />
+              <h2 className="text-base font-bold">直近の判断履歴</h2>
+            </header>
+            {loading ? (
+              <div className="space-y-2">{Array.from({ length: 4 }).map((_, i) => <div key={i} className="h-16 rounded-xl bg-gray-100 animate-pulse" />)}</div>
+            ) : recent.length === 0 ? (
+              <p className="text-sm text-gray-400 py-4 text-center">まだ判断履歴がありません</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full table-fixed border-separate border-spacing-y-2 text-sm text-gray-700">
+                  <thead>
+                    <tr className="text-xs uppercase tracking-wide text-gray-400">
+                      <th className="px-3 py-2 text-left font-semibold w-[35%]">作品</th>
+                      <th className="px-3 py-2 text-left font-semibold w-[12%]">判断</th>
+                      <th className="px-3 py-2 text-left font-semibold w-[22%]">タグ</th>
+                      <th className="px-3 py-2 text-left font-semibold w-[18%]">出演者</th>
+                      <th className="px-3 py-2 text-left font-semibold w-[13%]">日時</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {recent.map((item) => (
+                      <tr key={`${item.video_id}-${item.decided_at}`} className="bg-white/80 border border-gray-200/80 rounded-xl align-top">
+                        <td className="px-3 py-3 align-top">
+                          <div className="flex items-start gap-2">
+                            <div className="h-12 w-16 shrink-0 rounded-lg overflow-hidden bg-gray-100 border border-gray-200">
+                              {item.thumbnail_url && (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img src={item.thumbnail_url} alt={item.title ?? ''} className="w-full h-full object-cover" />
+                              )}
+                            </div>
+                            <span className="text-xs font-semibold text-gray-900 line-clamp-3 leading-snug">{item.title ?? '—'}</span>
+                          </div>
+                        </td>
+                        <td className="px-3 py-3 align-top">
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${item.decision_type === 'like' ? 'bg-rose-100 text-rose-500' : 'bg-gray-100 text-gray-500'}`}>
+                            {item.decision_type === 'like' ? '💗 気になる' : 'スキップ'}
+                          </span>
+                        </td>
+                        <td className="px-3 py-3 align-top">
+                          <div className="flex flex-wrap gap-1">
+                            {item.tags.slice(0, 3).map((tag) => (
+                              <span key={tag.id} className="px-1.5 py-0.5 rounded-full bg-rose-50 text-rose-500 border border-rose-100 text-[10px]">#{tag.name}</span>
+                            ))}
+                          </div>
+                        </td>
+                        <td className="px-3 py-3 align-top">
+                          <div className="flex flex-wrap gap-1">
+                            {item.performers.slice(0, 2).map((p) => (
+                              <span key={p.id} className="px-1.5 py-0.5 rounded-full bg-indigo-50 text-indigo-500 border border-indigo-100 text-[10px]">{p.name}</span>
+                            ))}
+                          </div>
+                        </td>
+                        <td className="px-3 py-3 align-top text-xs text-gray-400">{formatDate(item.decided_at)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+
+          {/* ── 集計メモ ── */}
+          {summary && (
+            <div className="rounded-2xl bg-white/10 border border-white/20 px-5 py-4 text-xs text-white/40 flex flex-wrap gap-4">
+              <span>集計対象: {windowLabel}（最大 {MAX_FETCH.toLocaleString('ja-JP')} 件）</span>
+              <span>最初の判断: {formatDate(summary.first_decision_at)}</span>
+              <span>最新の判断: {formatDate(summary.latest_decision_at)}</span>
+            </div>
+          )}
+        </div>
       </main>
+
       <ShareModal
         isOpen={isShareModalOpen}
         onClose={() => setIsShareModalOpen(false)}
@@ -458,13 +400,7 @@ export default function AnalysisResultsPage() {
         shareText={shareText}
       />
       <div className="absolute -left-[9999px] top-0 pointer-events-none select-none" aria-hidden>
-        <AnalysisShareCard
-          ref={cardRef}
-          summary={summary ?? null}
-          topTags={topTags}
-          topPerformers={topPerformers}
-          shareUrl={SHARE_CARD_LANDING_URL}
-        />
+        <AnalysisShareCard ref={cardRef} summary={summary} topTags={topTags} topPerformers={topPerformers} shareUrl={SHARE_CARD_LANDING_URL} />
       </div>
     </>
   );

--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -71,6 +71,19 @@ interface VideosFeedMetadata {
 }
 
 const ORIGINAL_GRADIENT = 'linear-gradient(135deg, #1a0d2e 0%, #160d25 33%, #2a1020 66%, #1e0d1a 100%)';
+
+const HENTAI_MILESTONES: Array<{ threshold: number; label: string }> = [
+  { threshold: 30, label: '変態入門者' },
+  { threshold: 50, label: '変態中級者' },
+  { threshold: 70, label: '変態上級者' },
+  { threshold: 85, label: '変態エキスパート' },
+  { threshold: 95, label: '変態の神' },
+];
+
+function calcHentaiScore(count: number): number {
+  if (count === 0) return 0;
+  return Math.min(Math.round((Math.log10(count) / 3) * 100), 99);
+}
 const LEFT_SWIPE_GRADIENT = ORIGINAL_GRADIENT;
 const RIGHT_SWIPE_GRADIENT = ORIGINAL_GRADIENT;
 const ONBOARDING_STORAGE_KEY = 'seihekiLab_hasSeenOnboardingSlides';
@@ -120,6 +133,8 @@ function SwipePageContent() {
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showSpotlight, setShowSpotlight] = useState(false);
   const [spotlightReady, setSpotlightReady] = useState(false);
+  const [hentaiMilestone, setHentaiMilestone] = useState<{ score: number; label: string } | null>(null);
+  const prevMilestoneRef = useRef<number>(0);
   const likedListButtonRef = useRef<HTMLButtonElement | null>(null);
   const onboardingStartedRef = useRef(false);
   const spotlightStartedRef = useRef(false);
@@ -668,6 +683,21 @@ function SwipePageContent() {
     }
   }, [activeIndex, cards.length, isFetchingVideos, refetchVideos]);
 
+  // 変態度マイルストーン検知
+  useEffect(() => {
+    const score = calcHentaiScore(decisionCount);
+    const reached = HENTAI_MILESTONES.filter(
+      (m) => m.threshold <= score && m.threshold > prevMilestoneRef.current
+    );
+    if (reached.length > 0) {
+      const top = reached[reached.length - 1];
+      prevMilestoneRef.current = top.threshold;
+      setHentaiMilestone({ score, label: top.label });
+      const t = setTimeout(() => setHentaiMilestone(null), 3500);
+      return () => clearTimeout(t);
+    }
+  }, [decisionCount]);
+
   // デッキが完全に枯渇したときのフォールバック（プリフェッチが間に合わなかった場合）
   useEffect(() => {
     if (cards.length > 0 && activeIndex >= cards.length && !isFetchingVideos) {
@@ -773,6 +803,31 @@ function SwipePageContent() {
           </div>
         );
       })()}
+      {/* 変態度バッジ */}
+      {isLoggedIn && (
+        <div className="fixed top-3 left-3 z-40 flex items-center gap-1.5 rounded-full bg-black/40 border border-white/10 backdrop-blur px-2.5 py-1 select-none">
+          <span className="text-[10px] text-white/50 font-medium">変態度</span>
+          <span className="text-sm font-black text-rose-400">{calcHentaiScore(decisionCount)}</span>
+        </div>
+      )}
+
+      {/* マイルストーントースト */}
+      <AnimatePresence>
+        {hentaiMilestone && (
+          <motion.div
+            key="milestone"
+            initial={{ opacity: 0, y: 40, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 20, scale: 0.95 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+            className="fixed bottom-28 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-1 rounded-2xl bg-gradient-to-br from-rose-500 to-fuchsia-600 px-6 py-3 shadow-2xl text-white text-center pointer-events-none"
+          >
+            <p className="text-[11px] font-bold tracking-widest uppercase opacity-80">変態度 {hentaiMilestone.score} 突破！</p>
+            <p className="text-lg font-black">🎉 {hentaiMilestone.label} に昇格</p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <main
         ref={mainRef}
         className={`flex-grow flex w-full relative ${isMobile ? 'flex-col h-full' : 'items-center justify-center pt-10'}`}

--- a/frontend/src/hooks/useVideoSearch.ts
+++ b/frontend/src/hooks/useVideoSearch.ts
@@ -20,12 +20,18 @@ type UseVideoSearchOptions = {
   limit?: number;
 };
 
-export function useVideoSearch({ keyword, tagIds = [], performerIds = [], limit = 24 }: UseVideoSearchOptions) {
+export function useVideoSearch({ keyword, tagIds, performerIds, limit = 24 }: UseVideoSearchOptions) {
   const [results, setResults] = useState<VideoSearchItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 配列をキー文字列に変換して参照安定化（配列をdepsに入れると毎render変わる）
+  const tagIdsKey = (tagIds ?? []).join(',');
+  const performerIdsKey = (performerIds ?? []).join(',');
+
   const search = useCallback(async () => {
+    const tagIdsArr = tagIdsKey ? tagIdsKey.split(',') : [];
+    const performerIdsArr = performerIdsKey ? performerIdsKey.split(',') : [];
     const trimmed = keyword.trim();
     if (trimmed.length === 0) {
       setResults([]);
@@ -40,20 +46,20 @@ export function useVideoSearch({ keyword, tagIds = [], performerIds = [], limit 
       // タグ・出演者でビデオIDを絞り込む
       let filteredIds: Set<string> | null = null;
 
-      if (tagIds.length > 0) {
+      if (tagIdsArr.length > 0) {
         const { data: tagRows } = await supabase
           .from('video_tags')
           .select('video_id')
-          .in('tag_id', tagIds);
+          .in('tag_id', tagIdsArr);
         const ids = new Set((tagRows ?? []).map((r) => r.video_id as string));
         filteredIds = ids;
       }
 
-      if (performerIds.length > 0) {
+      if (performerIdsArr.length > 0) {
         const { data: perfRows } = await supabase
           .from('video_performers')
           .select('video_id')
-          .in('performer_id', performerIds);
+          .in('performer_id', performerIdsArr);
         const ids = new Set((perfRows ?? []).map((r) => r.video_id as string));
         filteredIds = filteredIds
           ? new Set([...filteredIds].filter((id) => ids.has(id)))
@@ -115,7 +121,8 @@ export function useVideoSearch({ keyword, tagIds = [], performerIds = [], limit 
     } finally {
       setLoading(false);
     }
-  }, [keyword, tagIds, performerIds, limit]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keyword, tagIdsKey, performerIdsKey, limit]);
 
   useEffect(() => {
     search();


### PR DESCRIPTION
## Summary

- 「AIで探す」を「さがす」にリニューアル（キーワード検索 + AIレコメンド）
- 「あなたの性癖」ページをビジュアル刷新（タイプ名・変態度スコア）
- スワイプページに変態度バッジ・マイルストーン演出を追加
- `useVideoSearch` 無限ループバグを修正

## 変更詳細

### 「さがす」（/search）
- タイトル・キーワードでの直接DB検索を新規追加（debounce 400ms）
- 「条件を適用」ボタンを廃止 → タグ/出演者変更で自動適用（debounce 600ms）
- 横スクロールセクション → 縦グリッド（2〜4列レスポンシブ）に変更
- キーワードあり時は検索結果、なし時はAIおすすめを表示する2モード切り替え
- ナビゲーション全箇所のラベルを「AIで探す」→「さがす」に更新

### 「あなたの性癖」（/insights）
- ヒーローセクション：性癖タイプ名（清楚ロリ系・背徳NTR系など）を大きく表示
- 変態度スコアを円形ゲージで表示（like_ratio・判断数・タグ多様性から算出）
- タグ・出演者ランキングを金銀銅バッジ + プログレスバー付きに刷新
- スケルトンローディング・空状態メッセージを整備

### スワイプ（/swipe）
- 左上に変態度スコアバッジを常時表示（ログイン時）
- スコアは `log10(判断数) / 3 × 100` で成長（スワイプするほど上昇）
- 30 / 50 / 70 / 85 / 95 突破時にアニメーション付きトーストで昇格通知

### バグ修正
- `useVideoSearch`: `tagIds=[]` のデフォルト値が毎レンダーで新参照を生成しuseCallbackの依存が毎回変わり無限ループしていた → `join(',')` で文字列キー化して解消

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>