### PR TITLE
feat: 診断結果ページに相性の良いタイプ表示 + シェア画像のキャラ未表示バグ修正

### DIFF
--- a/frontend/src/app/quiz/data.ts
+++ b/frontend/src/app/quiz/data.ts
@@ -138,6 +138,29 @@ export function calcResult(answers: Record<number, number>): QuizResult {
   return { typeKey, scores };
 }
 
+// 相性の良いタイプ: ds軸が逆（S↔M）で他の軸が近いほど相性◎
+// [最高相性, 高相性, 良相性] の順
+export const COMPATIBILITY: Record<QuizTypeKey, [QuizTypeKey, QuizTypeKey, QuizTypeKey]> = {
+  spnc: ['mpnc', 'mpnw', 'menc'],
+  spnw: ['mpnw', 'mpnc', 'menw'],
+  senc: ['menc', 'menw', 'mpnc'],
+  senw: ['menw', 'menc', 'mpnw'],
+  spxc: ['mpxc', 'mpxw', 'mexc'],
+  spxw: ['mpxw', 'mpxc', 'mexw'],
+  sexc: ['mexc', 'mexw', 'mpxc'],
+  sexw: ['mexw', 'mexc', 'mpxw'],
+  mpnc: ['spnc', 'spnw', 'senc'],
+  mpnw: ['spnw', 'spnc', 'senw'],
+  menc: ['senc', 'senw', 'spnc'],
+  menw: ['senw', 'senc', 'spnw'],
+  mpxc: ['spxc', 'spxw', 'sexc'],
+  mpxw: ['spxw', 'spxc', 'sexw'],
+  mexc: ['sexc', 'sexw', 'spxc'],
+  mexw: ['sexw', 'sexc', 'spxw'],
+};
+
+export const COMPATIBILITY_LABELS: [string, string, string] = ['最高相性', '高相性', '良相性'];
+
 export const QUIZ_TYPES: Record<QuizTypeKey, QuizType> = {
   spnc: {
     key: 'spnc', name: 'グルメな狩人', emoji: '🔥',

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { toPng } from 'html-to-image';
 import QRCode from 'qrcode';
-import { QUIZ_TYPES, AXIS_META, QuizTypeKey, QuizType, Axis } from '../../data';
+import { QUIZ_TYPES, AXIS_META, COMPATIBILITY, COMPATIBILITY_LABELS, QuizTypeKey, QuizType, Axis } from '../../data';
 import { trackEvent } from '@/lib/analytics';
 
 const CTA_SHOWN_KEY = 'quiz_male_cta_shown';
@@ -410,6 +410,57 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
         >
           🔗 リンクをコピー
         </button>
+      </div>
+
+      {/* 相性の良いタイプ */}
+      <div className="w-full max-w-sm mb-6">
+        <p className="text-[11px] font-black tracking-[0.3em] uppercase mb-4 text-center" style={{ color: 'rgba(180,150,80,0.5)' }}>✦ 相性の良いタイプ ✦</p>
+        <div className="space-y-3">
+          {COMPATIBILITY[typeKey].map((compatKey, index) => {
+            const compatType = QUIZ_TYPES[compatKey];
+            const rankLabel = COMPATIBILITY_LABELS[index];
+            const rankColors = ['#FF6B6B', '#FDCB6E', '#74B9FF'];
+            const rankColor = rankColors[index];
+            return (
+              <Link
+                key={compatKey}
+                href={`/quiz/result/${compatKey}`}
+                className="flex items-center gap-4 rounded-2xl p-4 active:scale-[0.98] transition-transform"
+                style={{
+                  background: 'rgba(28,24,18,0.9)',
+                  border: `1px solid ${compatType.color}40`,
+                  boxShadow: '0 2px 12px rgba(0,0,0,0.3)',
+                }}
+              >
+                <Image
+                  src={`/quiz/${compatKey}.png`}
+                  alt={compatType.name}
+                  width={56}
+                  height={56}
+                  className="rounded-xl object-contain flex-shrink-0"
+                  style={{ background: `${compatType.color}22` }}
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-0.5">
+                    <span
+                      className="text-[9px] font-black px-2 py-0.5 rounded-full flex-shrink-0"
+                      style={{ background: `${rankColor}22`, color: rankColor, border: `1px solid ${rankColor}55` }}
+                    >
+                      {rankLabel}
+                    </span>
+                    <span className="text-[10px] font-black tracking-widest" style={{ color: 'rgba(180,150,80,0.4)' }}>
+                      {compatKey.toUpperCase()}
+                    </span>
+                  </div>
+                  <p className="text-[15px] font-black leading-tight truncate" style={{ color: '#f0e6d3' }}>
+                    {compatType.emoji} {compatType.name}
+                  </p>
+                  <p className="text-[11px] mt-0.5 truncate" style={{ color: compatType.color }}>{compatType.tagline}</p>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
       </div>
 
       {/* 男性向けCTA（インライン） */}

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -18,12 +18,14 @@ function ShareCard({
   quizType,
   axes,
   qrDataUrl,
+  charDataUrl,
   cardRef,
 }: {
   typeKey: QuizTypeKey;
   quizType: QuizType;
   axes: { axis: Axis; pct: number }[];
   qrDataUrl: string;
+  charDataUrl: string;
   cardRef: React.RefObject<HTMLDivElement | null>;
 }) {
   return (
@@ -45,10 +47,9 @@ function ShareCard({
         <div style={{ position: 'absolute', inset: 0, background: `radial-gradient(ellipse at center, ${quizType.color}22 0%, transparent 70%)` }} />
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src={`/quiz/${typeKey}.png`}
+          src={charDataUrl || `/quiz/${typeKey}.png`}
           alt={quizType.name}
           style={{ width: '380px', height: '380px', objectFit: 'contain', filter: 'drop-shadow(0 12px 32px rgba(0,0,0,0.85))', position: 'relative' }}
-          crossOrigin="anonymous"
         />
         {/* ヘッダーバー */}
         <div style={{ position: 'absolute', top: 0, left: 0, right: 0, padding: '12px 22px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -129,14 +130,7 @@ function SaveImageButton({
     setLoading(true);
     trackEvent('quiz_save_image', { type: typeKey });
     try {
-      // キャラクター画像をpreloadしてからキャプチャ
-      await new Promise<void>((resolve) => {
-        const img = new window.Image();
-        img.onload = () => resolve();
-        img.onerror = () => resolve();
-        img.src = `/quiz/${typeKey}.png?v=${Date.now()}`;
-      });
-      const dataUrl = await toPng(cardRef.current, { pixelRatio: 2, cacheBust: true });
+      const dataUrl = await toPng(cardRef.current, { pixelRatio: 2, cacheBust: false });
       const blob = await (await fetch(dataUrl)).blob();
       const file = new File([blob], `seiheki_${typeKey}.png`, { type: 'image/png' });
 
@@ -221,12 +215,26 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
   const shareCardRef = useRef<HTMLDivElement>(null);
   const [showCTA, setShowCTA] = useState(false);
   const [qrDataUrl, setQrDataUrl] = useState('');
+  const [charDataUrl, setCharDataUrl] = useState('');
 
   useEffect(() => {
     QRCode.toDataURL('https://seihekilab.com/quiz', { width: 128, margin: 1, color: { dark: '#000000', light: '#ffffff' } })
       .then(setQrDataUrl)
       .catch(() => {});
   }, []);
+
+  // キャラ画像をデータURLとして事前取得（html-to-imageがネットワーク未取得の画像を空で描画するのを防ぐ）
+  useEffect(() => {
+    fetch(`/quiz/${typeKey}.png`)
+      .then((r) => r.blob())
+      .then((blob) => new Promise<string>((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.readAsDataURL(blob);
+      }))
+      .then(setCharDataUrl)
+      .catch(() => {});
+  }, [typeKey]);
 
   const gender = searchParams.get('gender') ?? 'other';
   const isMale = gender === 'male';
@@ -288,7 +296,7 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
 
       {/* キャプチャ用シェアカード（画面外非表示） */}
       <div style={{ position: 'absolute', left: '-9999px', top: 0, overflow: 'hidden', pointerEvents: 'none' }}>
-        <ShareCard typeKey={typeKey} quizType={quizType} axes={axes} qrDataUrl={qrDataUrl} cardRef={shareCardRef} />
+        <ShareCard typeKey={typeKey} quizType={quizType} axes={axes} qrDataUrl={qrDataUrl} charDataUrl={charDataUrl} cardRef={shareCardRef} />
       </div>
 
       <p className="text-[11px] font-black tracking-[0.3em] uppercase mb-5" style={{ color: 'rgba(180,150,80,0.5)' }}>✦ 診断結果 ✦</p>

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -386,32 +386,6 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
         </div>
       </div>
 
-      {/* シェアボタン */}
-      <div className="w-full max-w-sm space-y-3 mb-6">
-        <SaveImageButton cardRef={shareCardRef} typeKey={typeKey} quizType={quizType} />
-        <button
-          onClick={shareToX}
-          className="w-full rounded-2xl py-4 font-black text-white flex items-center justify-center gap-2 text-[15px] active:translate-y-[1px] transition-transform"
-          style={{ background: 'rgba(255,255,255,0.08)', boxShadow: '0 4px 0 rgba(0,0,0,0.4)', border: '1px solid rgba(255,255,255,0.2)', color: '#f0e6d3' }}
-        >
-          <span className="text-lg">𝕏</span> ポストして友だちに教える
-        </button>
-        <button
-          onClick={shareToLine}
-          className="w-full rounded-2xl py-4 font-black text-white flex items-center justify-center gap-2 text-[15px] active:translate-y-[1px] transition-transform"
-          style={{ background: '#06C755', boxShadow: '0 4px 0 #04a344', border: '1px solid #08e060' }}
-        >
-          <span className="text-lg">💬</span> LINEで送る
-        </button>
-        <button
-          onClick={copyLink}
-          className="w-full rounded-2xl py-4 font-black flex items-center justify-center gap-2 text-[15px] active:translate-y-[1px] transition-transform"
-          style={{ background: 'rgba(180,150,80,0.1)', border: '1px solid rgba(180,150,80,0.35)', color: '#e8d5a0' }}
-        >
-          🔗 リンクをコピー
-        </button>
-      </div>
-
       {/* 相性の良いタイプ */}
       <div className="w-full max-w-sm mb-6">
         <p className="text-[11px] font-black tracking-[0.3em] uppercase mb-4 text-center" style={{ color: 'rgba(180,150,80,0.5)' }}>✦ 相性の良いタイプ ✦</p>
@@ -461,6 +435,32 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
             );
           })}
         </div>
+      </div>
+
+      {/* シェアボタン */}
+      <div className="w-full max-w-sm space-y-3 mb-6">
+        <SaveImageButton cardRef={shareCardRef} typeKey={typeKey} quizType={quizType} />
+        <button
+          onClick={shareToX}
+          className="w-full rounded-2xl py-4 font-black text-white flex items-center justify-center gap-2 text-[15px] active:translate-y-[1px] transition-transform"
+          style={{ background: 'rgba(255,255,255,0.08)', boxShadow: '0 4px 0 rgba(0,0,0,0.4)', border: '1px solid rgba(255,255,255,0.2)', color: '#f0e6d3' }}
+        >
+          <span className="text-lg">𝕏</span> ポストして友だちに教える
+        </button>
+        <button
+          onClick={shareToLine}
+          className="w-full rounded-2xl py-4 font-black text-white flex items-center justify-center gap-2 text-[15px] active:translate-y-[1px] transition-transform"
+          style={{ background: '#06C755', boxShadow: '0 4px 0 #04a344', border: '1px solid #08e060' }}
+        >
+          <span className="text-lg">💬</span> LINEで送る
+        </button>
+        <button
+          onClick={copyLink}
+          className="w-full rounded-2xl py-4 font-black flex items-center justify-center gap-2 text-[15px] active:translate-y-[1px] transition-transform"
+          style={{ background: 'rgba(180,150,80,0.1)', border: '1px solid rgba(180,150,80,0.35)', color: '#e8d5a0' }}
+        >
+          🔗 リンクをコピー
+        </button>
       </div>
 
       {/* 男性向けCTA（インライン） */}


### PR DESCRIPTION
## 変更内容

### feat: 相性の良いタイプセクションを追加
診断結果ページのメインカード直下（シェアボタンの上）に、相性の良いタイプを3件表示するセクションを追加。

**相性ロジック**
- ds軸（S/M）が逆であることを必須条件とし、pe/nx/cw軸が近いほど上位にランク
- 最高相性・高相性・良相性の3段階バッジを表示
- 各タイプのキャラ画像・タイプ名・タグラインを表示し、タップでそのタイプの結果ページへ遷移（回遊性向上）

**変更ファイル**
- `frontend/src/app/quiz/data.ts` — `COMPATIBILITY` マップ（16タイプ×3件）と `COMPATIBILITY_LABELS` を追加
- `frontend/src/app/quiz/result/[type]/ResultContent.tsx` — 相性セクションのUI実装

### fix: シェアカード画像の未読み込み問題を修正
「画像を保存してシェア」を押したとき、キャラクター画像が空のまま保存される事象を修正。

**根本原因**
`html-to-image` はオフスクリーン（`left: -9999px`）に配置した `<img>` 要素を描画する際、ブラウザが遅延ロードした画像をまだ取得していない状態で出力することがある。`cacheBust: true` による再フェッチも実行タイミング次第で間に合わなかった。

**修正内容**
- ページロード時に `fetch` でキャラ画像をblobとして取得し、`FileReader` でデータURLに変換して state に保持
- `ShareCard` の `<img src>` にデータURLを直接渡すことで、html-to-image がネットワーク待ちなしで確実にインライン化できるようにした
- `crossOrigin="anonymous"` を削除（データURL使用により不要）
- `cacheBust: false` に変更（データURL埋め込み済みのため余分な再フェッチを排除）

## レビュアーへの補足
- 相性ロジックはハードコードのマップで管理しており、将来的にスコアベースの動的計算に変更可能
- キャラ画像の事前fetch失敗時はフォールバックで元のパスを使うため、エラー時も壊れない