### PR TITLE
fix: クイズ選択UIの改善（A/B表示と選択ボタンの役割を明確化）

### DIFF
--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -259,23 +259,26 @@ export default function QuizPage() {
               ✦ どちらが好きですか？ ✦
             </p>
 
-            {/* A / B の選択肢 */}
+            {/* A / B の選択肢（タップで選択） */}
             <div className="flex gap-3">
               {[
-                { option: currentQ.optionA, label: 'A', color: '#FF6B6B', isSelected: selected !== null && selected <= 2 },
-                { option: currentQ.optionB, label: 'B', color: '#55EFC4', isSelected: selected !== null && selected >= 4 },
-              ].map(({ option, label, color, isSelected }) => (
-                <div
+                { option: currentQ.optionA, label: 'A', color: '#FF6B6B', selectValue: 1, isSelected: selected !== null && selected <= 2 },
+                { option: currentQ.optionB, label: 'B', color: '#55EFC4', selectValue: 5, isSelected: selected !== null && selected >= 4 },
+              ].map(({ option, label, color, selectValue, isSelected }) => (
+                <button
                   key={label}
-                  className="flex-1 rounded-2xl p-4 text-center transition-all duration-200"
+                  onClick={() => handleSelect(selectValue)}
+                  className="flex-1 rounded-2xl p-4 text-center transition-all duration-200 active:scale-[0.97]"
                   style={{
                     background: isSelected ? `${color}20` : 'rgba(255,255,255,0.04)',
-                    border: `1px solid ${isSelected ? color + '60' : 'rgba(255,255,255,0.1)'}`,
+                    border: `1px solid ${isSelected ? color + '80' : 'rgba(255,255,255,0.1)'}`,
+                    boxShadow: isSelected ? `0 0 12px ${color}30` : 'none',
+                    cursor: 'pointer',
                   }}
                 >
                   <p className="text-[11px] font-black tracking-[0.2em] mb-2" style={{ color }}>{label}</p>
                   <p className="text-[14px] font-bold leading-snug" style={{ color: isSelected ? '#ffffff' : 'rgba(240,230,211,0.75)' }}>{option}</p>
-                </div>
+                </button>
               ))}
             </div>
 

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -260,51 +260,62 @@ export default function QuizPage() {
             </p>
 
             {/* A / B の選択肢（表示のみ） */}
-            <div className="flex gap-px" style={{ borderBottom: '1px solid rgba(180,150,80,0.15)' }}>
+            <div className="flex gap-3">
               {[
                 { option: currentQ.optionA, label: 'A', color: '#FF6B6B', isSelected: selected !== null && selected <= 2 },
                 { option: currentQ.optionB, label: 'B', color: '#55EFC4', isSelected: selected !== null && selected >= 4 },
-              ].map(({ option, label, color, isSelected }, i) => (
+              ].map(({ option, label, color, isSelected }) => (
                 <div
                   key={label}
-                  className="flex-1 px-3 pb-5 text-center"
-                  style={{ borderLeft: i === 1 ? '1px solid rgba(180,150,80,0.15)' : 'none' }}
+                  className="flex-1 rounded-2xl p-4 text-center transition-all duration-200"
+                  style={{
+                    background: isSelected ? `${color}18` : 'rgba(255,255,255,0.03)',
+                    border: `1px solid ${isSelected ? color + '55' : 'rgba(255,255,255,0.07)'}`,
+                  }}
                 >
-                  <p className="text-[11px] font-black tracking-[0.2em] mb-2" style={{ color: isSelected ? color : `${color}66` }}>{label}</p>
-                  <p className="text-[14px] font-bold leading-snug" style={{ color: isSelected ? '#ffffff' : 'rgba(240,230,211,0.55)' }}>{option}</p>
+                  <p className="text-[11px] font-black tracking-[0.2em] mb-2" style={{ color }}>{label}</p>
+                  <p className="text-[14px] font-bold leading-snug" style={{ color: isSelected ? '#ffffff' : 'rgba(240,230,211,0.7)' }}>{option}</p>
                 </div>
               ))}
             </div>
 
-            {/* 5段階選択ボタン */}
-            <div className="flex gap-2">
+            {/* 5段階スケール — ドットサイズ＋ボタン枠で選べることを明示 */}
+            <div className="flex gap-2 items-end justify-between px-1">
               {[1, 2, 3, 4, 5].map((v) => {
                 const isA = v <= 2;
                 const isB = v >= 4;
-                const color = isA ? '#FF6B6B' : isB ? '#55EFC4' : 'rgba(232,213,160,0.9)';
-                const labels = ['A強', 'Aやや', 'どちら', 'Bやや', 'B強'];
+                const color = isA ? '#FF6B6B' : isB ? '#55EFC4' : 'rgba(232,213,160,0.8)';
+                const dotSizes = [20, 14, 9, 14, 20];
+                const dotSize = dotSizes[v - 1];
                 const isSelected = selected === v;
                 return (
                   <button
                     key={v}
                     onClick={() => handleSelect(v)}
-                    className="flex-1 rounded-2xl py-3 font-black text-[11px] transition-all duration-150 active:scale-[0.95]"
-                    style={
-                      isSelected
-                        ? {
-                            background: isA ? 'rgba(255,107,107,0.2)' : isB ? 'rgba(85,239,196,0.15)' : 'rgba(232,213,160,0.12)',
-                            border: `1.5px solid ${color}`,
-                            color,
-                            boxShadow: `0 2px 0 rgba(0,0,0,0.3), 0 0 10px ${color}40`,
-                          }
-                        : {
-                            background: 'rgba(255,255,255,0.05)',
-                            border: '1.5px solid rgba(180,150,80,0.15)',
-                            color: 'rgba(200,180,140,0.4)',
-                          }
-                    }
+                    className="flex-1 flex flex-col items-center gap-2 py-3 rounded-2xl transition-all duration-150 active:scale-[0.95]"
+                    style={{
+                      background: isSelected
+                        ? (isA ? 'rgba(255,107,107,0.15)' : isB ? 'rgba(85,239,196,0.12)' : 'rgba(232,213,160,0.08)')
+                        : 'rgba(255,255,255,0.04)',
+                      border: isSelected
+                        ? `1.5px solid ${color}`
+                        : '1.5px solid rgba(180,150,80,0.18)',
+                      transform: isSelected ? 'translateY(-2px)' : 'none',
+                      boxShadow: isSelected ? `0 4px 0 rgba(0,0,0,0.3), 0 0 10px ${color}30` : '0 2px 0 rgba(0,0,0,0.2)',
+                    }}
                   >
-                    {labels[v - 1]}
+                    <div
+                      className="rounded-full transition-all duration-150"
+                      style={{
+                        width: `${dotSize}px`,
+                        height: `${dotSize}px`,
+                        background: isSelected ? color : isA ? 'rgba(255,107,107,0.3)' : isB ? 'rgba(85,239,196,0.25)' : 'rgba(232,213,160,0.2)',
+                        boxShadow: isSelected ? `0 0 8px ${color}80` : 'none',
+                      }}
+                    />
+                    <span className="text-[9px] font-bold" style={{ color: isSelected ? color : 'rgba(200,180,140,0.4)' }}>
+                      {['A強', 'Aやや', 'どちら', 'Bやや', 'B強'][v - 1]}
+                    </span>
                   </button>
                 );
               })}

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -267,14 +267,10 @@ export default function QuizPage() {
               ].map(({ option, label, color, isSelected }) => (
                 <div
                   key={label}
-                  className="flex-1 rounded-2xl p-4 text-center transition-all duration-200"
-                  style={{
-                    background: isSelected ? `${color}18` : 'rgba(255,255,255,0.03)',
-                    border: `1px solid ${isSelected ? color + '55' : 'rgba(255,255,255,0.07)'}`,
-                  }}
+                  className="flex-1 p-4 text-center transition-all duration-200"
                 >
-                  <p className="text-[11px] font-black tracking-[0.2em] mb-2" style={{ color }}>{label}</p>
-                  <p className="text-[14px] font-bold leading-snug" style={{ color: isSelected ? '#ffffff' : 'rgba(240,230,211,0.7)' }}>{option}</p>
+                  <p className="text-[11px] font-black tracking-[0.2em] mb-2" style={{ color: isSelected ? color : `${color}55` }}>{label}</p>
+                  <p className="text-[14px] font-bold leading-snug" style={{ color: isSelected ? '#ffffff' : 'rgba(240,230,211,0.5)' }}>{option}</p>
                 </div>
               ))}
             </div>

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -259,62 +259,52 @@ export default function QuizPage() {
               ✦ どちらが好きですか？ ✦
             </p>
 
-            {/* A / B の選択肢（タップで選択） */}
-            <div className="flex gap-3">
+            {/* A / B の選択肢（表示のみ） */}
+            <div className="flex gap-px" style={{ borderBottom: '1px solid rgba(180,150,80,0.15)' }}>
               {[
-                { option: currentQ.optionA, label: 'A', color: '#FF6B6B', selectValue: 1, isSelected: selected !== null && selected <= 2 },
-                { option: currentQ.optionB, label: 'B', color: '#55EFC4', selectValue: 5, isSelected: selected !== null && selected >= 4 },
-              ].map(({ option, label, color, selectValue, isSelected }) => (
-                <button
+                { option: currentQ.optionA, label: 'A', color: '#FF6B6B', isSelected: selected !== null && selected <= 2 },
+                { option: currentQ.optionB, label: 'B', color: '#55EFC4', isSelected: selected !== null && selected >= 4 },
+              ].map(({ option, label, color, isSelected }, i) => (
+                <div
                   key={label}
-                  onClick={() => handleSelect(selectValue)}
-                  className="flex-1 rounded-2xl p-4 text-center transition-all duration-200 active:scale-[0.97]"
-                  style={{
-                    background: isSelected ? `${color}20` : 'rgba(255,255,255,0.04)',
-                    border: `1px solid ${isSelected ? color + '80' : 'rgba(255,255,255,0.1)'}`,
-                    boxShadow: isSelected ? `0 0 12px ${color}30` : 'none',
-                    cursor: 'pointer',
-                  }}
+                  className="flex-1 px-3 pb-5 text-center"
+                  style={{ borderLeft: i === 1 ? '1px solid rgba(180,150,80,0.15)' : 'none' }}
                 >
-                  <p className="text-[11px] font-black tracking-[0.2em] mb-2" style={{ color }}>{label}</p>
-                  <p className="text-[14px] font-bold leading-snug" style={{ color: isSelected ? '#ffffff' : 'rgba(240,230,211,0.75)' }}>{option}</p>
-                </button>
+                  <p className="text-[11px] font-black tracking-[0.2em] mb-2" style={{ color: isSelected ? color : `${color}66` }}>{label}</p>
+                  <p className="text-[14px] font-bold leading-snug" style={{ color: isSelected ? '#ffffff' : 'rgba(240,230,211,0.55)' }}>{option}</p>
+                </div>
               ))}
             </div>
 
-            {/* 5段階スケール — ドットサイズでA/B強度を表現 */}
-            <div className="flex gap-2 items-end justify-between px-1">
+            {/* 5段階選択ボタン */}
+            <div className="flex gap-2">
               {[1, 2, 3, 4, 5].map((v) => {
                 const isA = v <= 2;
                 const isB = v >= 4;
-                const color = isA ? '#FF6B6B' : isB ? '#55EFC4' : 'rgba(232,213,160,0.6)';
-                // ドットサイズ: 端ほど大きい (1→20, 2→14, 3→9, 4→14, 5→20)
-                const dotSizes = [20, 14, 9, 14, 20];
-                const dotSize = dotSizes[v - 1];
+                const color = isA ? '#FF6B6B' : isB ? '#55EFC4' : 'rgba(232,213,160,0.9)';
+                const labels = ['A強', 'Aやや', 'どちら', 'Bやや', 'B強'];
                 const isSelected = selected === v;
                 return (
                   <button
                     key={v}
                     onClick={() => handleSelect(v)}
-                    className="flex-1 flex flex-col items-center gap-2 py-3 rounded-2xl transition-all duration-150"
-                    style={{
-                      background: isSelected ? (isA ? 'rgba(255,107,107,0.15)' : isB ? 'rgba(85,239,196,0.12)' : 'rgba(232,213,160,0.08)') : 'transparent',
-                      border: isSelected ? `1px solid ${color}` : '1px solid transparent',
-                      transform: isSelected ? 'translateY(-2px)' : 'none',
-                    }}
+                    className="flex-1 rounded-2xl py-3 font-black text-[11px] transition-all duration-150 active:scale-[0.95]"
+                    style={
+                      isSelected
+                        ? {
+                            background: isA ? 'rgba(255,107,107,0.2)' : isB ? 'rgba(85,239,196,0.15)' : 'rgba(232,213,160,0.12)',
+                            border: `1.5px solid ${color}`,
+                            color,
+                            boxShadow: `0 2px 0 rgba(0,0,0,0.3), 0 0 10px ${color}40`,
+                          }
+                        : {
+                            background: 'rgba(255,255,255,0.05)',
+                            border: '1.5px solid rgba(180,150,80,0.15)',
+                            color: 'rgba(200,180,140,0.4)',
+                          }
+                    }
                   >
-                    <div
-                      className="rounded-full transition-all duration-150"
-                      style={{
-                        width: `${dotSize}px`,
-                        height: `${dotSize}px`,
-                        background: isSelected ? color : isA ? 'rgba(255,107,107,0.25)' : isB ? 'rgba(85,239,196,0.2)' : 'rgba(232,213,160,0.15)',
-                        boxShadow: isSelected ? `0 0 8px ${color}80` : 'none',
-                      }}
-                    />
-                    <span className="text-[9px] font-bold" style={{ color: isSelected ? color : 'rgba(200,180,140,0.3)' }}>
-                      {['A強', 'Aやや', 'どちら', 'Bやや', 'B強'][v - 1]}
-                    </span>
+                    {labels[v - 1]}
                   </button>
                 );
               })}

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -260,14 +260,15 @@ export default function QuizPage() {
             </p>
 
             {/* A / B の選択肢（表示のみ） */}
-            <div className="flex gap-3">
+            <div className="flex" style={{ gap: 0 }}>
               {[
                 { option: currentQ.optionA, label: 'A', color: '#FF6B6B', isSelected: selected !== null && selected <= 2 },
                 { option: currentQ.optionB, label: 'B', color: '#55EFC4', isSelected: selected !== null && selected >= 4 },
-              ].map(({ option, label, color, isSelected }) => (
+              ].map(({ option, label, color, isSelected }, i) => (
                 <div
                   key={label}
-                  className="flex-1 p-4 text-center transition-all duration-200"
+                  className="flex-1 px-5 py-3 text-center transition-all duration-200"
+                  style={i === 0 ? { borderRight: '1px solid rgba(180,150,80,0.2)' } : {}}
                 >
                   <p className="text-[11px] font-black tracking-[0.2em] mb-2" style={{ color: isSelected ? color : `${color}55` }}>{label}</p>
                   <p className="text-[14px] font-bold leading-snug" style={{ color: isSelected ? '#ffffff' : 'rgba(240,230,211,0.5)' }}>{option}</p>


### PR DESCRIPTION
## 変更内容

クイズ画面のA/B選択UIについて、「A/Bカードがボタンに見えるのに押せない」というFBを受けて改善。

### 方針
情報表示エリア（A/B）と操作エリア（選択ボタン）を明確に分離する。

### 変更詳細
- **A/Bカード**: 枠・背景を撤廃してテキストのみの表示に。左右に余白（`px-5`）を追加し、中央に薄い縦線（`rgba(180,150,80,0.2)`）を入れてA/Bを区切る
- **選択ボタン**: ドットサイズ表現（端ほど大きい）を維持しつつ、未選択時も薄い枠を付けて「押せる」ことが視覚的に伝わるように改善。選択時は枠強調＋浮き上がり＋グロー

## 関連
クイズ診断ページ `/quiz`