### PR TITLE
fix: シェア画像のキャラ空白をoncloneで根本修正・シェア時テキスト削除

### DIFF
--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -28,6 +28,22 @@ function ShareCard({
   charDataUrl: string;
   cardRef: React.RefObject<HTMLDivElement | null>;
 }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  // charDataUrl が揃ったら canvas に描画（html-to-image がフェッチ不要になる）
+  useEffect(() => {
+    if (!charDataUrl || !canvasRef.current) return;
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const img = new window.Image();
+    img.onload = () => {
+      ctx.clearRect(0, 0, 380, 380);
+      ctx.drawImage(img, 0, 0, 380, 380);
+    };
+    img.src = charDataUrl;
+  }, [charDataUrl]);
+
   return (
     <div
       ref={cardRef}
@@ -45,11 +61,11 @@ function ShareCard({
       {/* キャラクター画像エリア */}
       <div style={{ height: '450px', background: `${quizType.color}38`, display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative', flexShrink: 0 }}>
         <div style={{ position: 'absolute', inset: 0, background: `radial-gradient(ellipse at center, ${quizType.color}22 0%, transparent 70%)` }} />
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={charDataUrl || `/quiz/${typeKey}.png`}
-          alt={quizType.name}
-          style={{ width: '380px', height: '380px', objectFit: 'contain', filter: 'drop-shadow(0 12px 32px rgba(0,0,0,0.85))', position: 'relative' }}
+        <canvas
+          ref={canvasRef}
+          width={380}
+          height={380}
+          style={{ position: 'relative', filter: 'drop-shadow(0 12px 32px rgba(0,0,0,0.85))' }}
         />
         {/* ヘッダーバー */}
         <div style={{ position: 'absolute', top: 0, left: 0, right: 0, padding: '12px 22px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -134,30 +150,20 @@ function SaveImageButton({
     setLoading(true);
     trackEvent('quiz_save_image', { type: typeKey });
     try {
-      // キャラ画像のデータURLを確保（未取得なら今すぐfetch）
-      let resolvedCharDataUrl = charDataUrl;
-      if (!resolvedCharDataUrl) {
-        resolvedCharDataUrl = await fetch(`/quiz/${typeKey}.png`)
+      // charDataUrl未取得なら今すぐfetchしてcanvasに描画されるまで待つ
+      if (!charDataUrl) {
+        const url = await fetch(`/quiz/${typeKey}.png`)
           .then((r) => r.blob())
           .then((blob) => new Promise<string>((resolve) => {
             const reader = new FileReader();
             reader.onload = () => resolve(reader.result as string);
             reader.readAsDataURL(blob);
           }));
-        onCharDataUrlReady(resolvedCharDataUrl);
+        onCharDataUrlReady(url);
+        // canvasへの描画完了を待つ
+        await new Promise((r) => setTimeout(r, 200));
       }
 
-      // オフスクリーンカード内のimg要素にデータURLを直接セットしてからキャプチャ
-      const imgEl = cardRef.current.querySelector('img') as HTMLImageElement | null;
-      if (imgEl) {
-        imgEl.src = resolvedCharDataUrl;
-        if (!imgEl.complete) {
-          await new Promise<void>((resolve) => {
-            imgEl.onload = () => resolve();
-            imgEl.onerror = () => resolve();
-          });
-        }
-      }
       const capturedDataUrl = await toPng(cardRef.current, { pixelRatio: 2, cacheBust: false });
 
       const blob = await (await fetch(capturedDataUrl)).blob();

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -114,9 +114,6 @@ async function buildShareImage(params: {
       };
       qr.onerror = () => resolve(); qr.src = qrDataUrl;
     });
-    ctx.font = `400 15px ${JP_FONT}`; ctx.fillStyle = 'rgba(180,150,80,0.5)';
-    ctx.textAlign = 'right'; ctx.fillText('seihekilab.com', W - 100, charH - 46);
-    ctx.textAlign = 'left';
   }
 
   // ── テキストエリア（下詰め）──
@@ -148,14 +145,18 @@ async function buildShareImage(params: {
     else if (pct >= 20) degreeLabel = meta.degreesLow[1];
     else                degreeLabel = meta.degreesLow[0];
 
-    // 左: 軸ラベル(高側)  中: バー  右: 度合いバッジ
-    const axisLabelW = 52, degreeW = 110;
-    const barX = tx + axisLabelW + 8, barW = W - tx * 2 - axisLabelW - degreeW - 16;
+    // 左: labelHigh  中: バー  右: labelLow  度合いバッジ
+    const axisLabelW = 52, degreeW = 88;
+    const barX = tx + axisLabelW + 8, barW = W - tx * 2 - axisLabelW * 2 - degreeW - 24;
 
     ctx.font = `700 14px ${JP_FONT}`;
     ctx.textAlign = 'right';
-    ctx.fillStyle = 'rgba(200,180,140,0.4)';
+    ctx.fillStyle = isHigh ? color : 'rgba(200,180,140,0.35)';
     ctx.fillText(meta.labelHigh, tx + axisLabelW, ty + 9);
+
+    ctx.textAlign = 'left';
+    ctx.fillStyle = !isHigh ? color : 'rgba(200,180,140,0.35)';
+    ctx.fillText(meta.labelLow, barX + barW + 8, ty + 9);
 
     ctx.fillStyle = 'rgba(180,150,80,0.1)';
     roundRect(ctx, barX, ty, barW, 10, 5); ctx.fill();
@@ -165,16 +166,16 @@ async function buildShareImage(params: {
     ctx.fillStyle = color;
     roundRect(ctx, isHigh ? barX + barW / 2 - fillW : barX + barW / 2, ty, fillW, 10, 5); ctx.fill();
 
-    // 度合いバッジ（バー右）
-    const badgeX = barX + barW + 8;
+    // 度合いバッジ（右端）
+    const badgeX = tx + axisLabelW + 8 + barW + axisLabelW + 16;
     const badgeH = 20, badgeY = ty - 5;
     ctx.font = `700 12px ${JP_FONT}`;
     ctx.fillStyle = color + '28';
-    roundRect(ctx, badgeX, badgeY, degreeW - 8, badgeH, 10); ctx.fill();
+    roundRect(ctx, badgeX, badgeY, degreeW, badgeH, 10); ctx.fill();
     ctx.strokeStyle = color + '66'; ctx.lineWidth = 1;
-    roundRect(ctx, badgeX, badgeY, degreeW - 8, badgeH, 10); ctx.stroke();
+    roundRect(ctx, badgeX, badgeY, degreeW, badgeH, 10); ctx.stroke();
     ctx.fillStyle = color;
-    ctx.textAlign = 'center'; ctx.fillText(degreeLabel, badgeX + (degreeW - 8) / 2, badgeY + 13);
+    ctx.textAlign = 'center'; ctx.fillText(degreeLabel, badgeX + degreeW / 2, badgeY + 13);
 
     ctx.textAlign = 'left'; ty += 36;
   }

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -147,15 +147,18 @@ function SaveImageButton({
         onCharDataUrlReady(resolvedCharDataUrl);
       }
 
-      // oncloneでクローン後のimg要素にデータURLを直接差し込む
-      const capturedDataUrl = await toPng(cardRef.current, {
-        pixelRatio: 2,
-        cacheBust: false,
-        onclone: (_doc, el) => {
-          const img = el.querySelector('img') as HTMLImageElement | null;
-          if (img) img.src = resolvedCharDataUrl;
-        },
-      });
+      // オフスクリーンカード内のimg要素にデータURLを直接セットしてからキャプチャ
+      const imgEl = cardRef.current.querySelector('img') as HTMLImageElement | null;
+      if (imgEl) {
+        imgEl.src = resolvedCharDataUrl;
+        if (!imgEl.complete) {
+          await new Promise<void>((resolve) => {
+            imgEl.onload = () => resolve();
+            imgEl.onerror = () => resolve();
+          });
+        }
+      }
+      const capturedDataUrl = await toPng(cardRef.current, { pixelRatio: 2, cacheBust: false });
 
       const blob = await (await fetch(capturedDataUrl)).blob();
       const file = new File([blob], `seiheki_${typeKey}.png`, { type: 'image/png' });

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -134,33 +134,38 @@ function SaveImageButton({
     setLoading(true);
     trackEvent('quiz_save_image', { type: typeKey });
     try {
-      // charDataUrlがまだ未取得なら押下時にインラインfetchして待つ
-      if (!charDataUrl) {
-        const url = await fetch(`/quiz/${typeKey}.png`)
+      // キャラ画像のデータURLを確保（未取得なら今すぐfetch）
+      let resolvedCharDataUrl = charDataUrl;
+      if (!resolvedCharDataUrl) {
+        resolvedCharDataUrl = await fetch(`/quiz/${typeKey}.png`)
           .then((r) => r.blob())
           .then((blob) => new Promise<string>((resolve) => {
             const reader = new FileReader();
             reader.onload = () => resolve(reader.result as string);
             reader.readAsDataURL(blob);
           }));
-        onCharDataUrlReady(url);
-        // DOMへの反映を待つ
-        await new Promise((r) => setTimeout(r, 100));
+        onCharDataUrlReady(resolvedCharDataUrl);
       }
-      const dataUrl = await toPng(cardRef.current, { pixelRatio: 2, cacheBust: false });
-      const blob = await (await fetch(dataUrl)).blob();
+
+      // oncloneでクローン後のimg要素にデータURLを直接差し込む
+      const capturedDataUrl = await toPng(cardRef.current, {
+        pixelRatio: 2,
+        cacheBust: false,
+        onclone: (_doc, el) => {
+          const img = el.querySelector('img') as HTMLImageElement | null;
+          if (img) img.src = resolvedCharDataUrl;
+        },
+      });
+
+      const blob = await (await fetch(capturedDataUrl)).blob();
       const file = new File([blob], `seiheki_${typeKey}.png`, { type: 'image/png' });
 
       if (navigator.share && navigator.canShare?.({ files: [file] })) {
-        await navigator.share({
-          files: [file],
-          title: `私の性癖16タイプは「${quizType.name}」でした！`,
-          text: quizType.tagline,
-        });
+        await navigator.share({ files: [file] });
         trackEvent('quiz_image_shared', { type: typeKey, method: 'webshare' });
       } else {
         const a = document.createElement('a');
-        a.href = dataUrl;
+        a.href = capturedDataUrl;
         a.download = `seiheki_${typeKey}.png`;
         a.click();
         trackEvent('quiz_image_shared', { type: typeKey, method: 'download' });

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -13,7 +13,7 @@ const AXES: Axis[] = ['ds', 'pe', 'nx', 'cw'];
 
 const JP_FONT = '"Hiragino Kaku Gothic ProN","Hiragino Sans","Yu Gothic","Noto Sans JP",sans-serif';
 
-// ─── Canvas で直接シェア画像を生成（3:4） ─────────────────────────────────────
+// ─── Canvas で直接シェア画像を生成（縦長・下詰め） ───────────────────────────
 async function buildShareImage(params: {
   typeKey: QuizTypeKey;
   quizType: QuizType;
@@ -22,45 +22,60 @@ async function buildShareImage(params: {
   qrDataUrl: string;
 }): Promise<string> {
   const { typeKey, quizType, axes, charDataUrl, qrDataUrl } = params;
-  const W = 750, H = 1000;
+  const W = 750;
+  const tx = 36; // 横余白
+
+  // ── テキストエリアの高さを先に計算 ──
+  const offCtx = document.createElement('canvas').getContext('2d')!;
+  offCtx.font = `400 18px ${JP_FONT}`;
+  let textH = 32; // 上パディング
+  textH += 58;    // タイトル (52px)
+  textH += 8;     // gap
+  textH += 28;    // タグライン
+  textH += 20;    // gap
+  // 説明文の行数を計算
+  let line = '';
+  let descLines = 1;
+  for (const ch of quizType.description.split('')) {
+    const test = line + ch;
+    if (offCtx.measureText(test).width > W - tx * 2 && line) { line = ch; descLines++; }
+    else line = test;
+  }
+  textH += descLines * 28; // 説明文
+  textH += 24;  // gap + 区切り線
+  textH += 20;  // 区切り線後gap
+  textH += axes.length * 32; // 軸バー
+  textH += 36;  // フッター + 下パディング
+  const H = textH + 600; // 残り全部がキャラエリア（最低600px）
+  const charH = H - textH;
+
   const canvas = document.createElement('canvas');
   canvas.width = W; canvas.height = H;
   const ctx = canvas.getContext('2d')!;
-
-  // フォントロード待ち
   await document.fonts.ready;
 
   // 背景
   const bg = ctx.createLinearGradient(0, 0, 0, H);
-  bg.addColorStop(0, '#0d0b08');
-  bg.addColorStop(1, '#1a1510');
-  ctx.fillStyle = bg;
-  ctx.fillRect(0, 0, W, H);
+  bg.addColorStop(0, '#0d0b08'); bg.addColorStop(1, '#1a1510');
+  ctx.fillStyle = bg; ctx.fillRect(0, 0, W, H);
 
   // キャラエリア背景
-  const charH = 480;
-  ctx.fillStyle = quizType.color + '38';
-  ctx.fillRect(0, 0, W, charH);
+  ctx.fillStyle = quizType.color + '38'; ctx.fillRect(0, 0, W, charH);
   const rg = ctx.createRadialGradient(W / 2, charH / 2, 0, W / 2, charH / 2, W * 0.6);
-  rg.addColorStop(0, quizType.color + '30');
-  rg.addColorStop(1, 'transparent');
-  ctx.fillStyle = rg;
-  ctx.fillRect(0, 0, W, charH);
+  rg.addColorStop(0, quizType.color + '30'); rg.addColorStop(1, 'transparent');
+  ctx.fillStyle = rg; ctx.fillRect(0, 0, W, charH);
 
   // キャラ画像
   if (charDataUrl) {
     await new Promise<void>((resolve) => {
       const img = new window.Image();
       img.onload = () => {
-        const size = 400;
+        const size = Math.min(charH - 60, 480);
         const x = (W - size) / 2, y = (charH - size) / 2 + 10;
         ctx.save();
-        ctx.shadowColor = 'rgba(0,0,0,0.9)';
-        ctx.shadowBlur = 40;
-        ctx.shadowOffsetY = 16;
+        ctx.shadowColor = 'rgba(0,0,0,0.9)'; ctx.shadowBlur = 40; ctx.shadowOffsetY = 16;
         ctx.drawImage(img, x, y, size, size);
-        ctx.restore();
-        resolve();
+        ctx.restore(); resolve();
       };
       img.onerror = () => resolve();
       img.src = charDataUrl;
@@ -68,32 +83,23 @@ async function buildShareImage(params: {
   }
 
   // キャラエリア下フェード
-  const fade = ctx.createLinearGradient(0, charH - 100, 0, charH);
-  fade.addColorStop(0, 'transparent');
-  fade.addColorStop(1, '#0d0b08');
-  ctx.fillStyle = fade;
-  ctx.fillRect(0, charH - 100, W, 100);
+  const fade = ctx.createLinearGradient(0, charH - 120, 0, charH);
+  fade.addColorStop(0, 'transparent'); fade.addColorStop(1, '#0d0b08');
+  ctx.fillStyle = fade; ctx.fillRect(0, charH - 120, W, 120);
 
-  // ヘッダー: ラベル
-  ctx.font = `600 22px ${JP_FONT}`;
-  ctx.fillStyle = 'rgba(180,150,80,0.65)';
+  // ヘッダーラベル
+  ctx.font = `600 22px ${JP_FONT}`; ctx.fillStyle = 'rgba(180,150,80,0.65)';
   ctx.fillText('性癖16タイプ分析', 28, 44);
 
-  // ヘッダー: タイプキーバッジ
+  // タイプキーバッジ
   const letters = typeKey.toUpperCase().split('');
   let bx = W - 24;
   for (let i = letters.length - 1; i >= 0; i--) {
-    const bw = 42;
-    bx -= bw + 6;
-    ctx.fillStyle = quizType.color + '30';
-    ctx.strokeStyle = quizType.color + '66';
-    ctx.lineWidth = 1.5;
-    roundRect(ctx, bx, 20, bw, 28, 14);
-    ctx.fill(); ctx.stroke();
-    ctx.font = `900 15px ${JP_FONT}`;
-    ctx.fillStyle = quizType.color;
-    ctx.textAlign = 'center';
-    ctx.fillText(letters[i], bx + bw / 2, 39);
+    const bw = 42; bx -= bw + 6;
+    ctx.fillStyle = quizType.color + '30'; ctx.strokeStyle = quizType.color + '66'; ctx.lineWidth = 1.5;
+    roundRect(ctx, bx, 20, bw, 28, 14); ctx.fill(); ctx.stroke();
+    ctx.font = `900 15px ${JP_FONT}`; ctx.fillStyle = quizType.color;
+    ctx.textAlign = 'center'; ctx.fillText(letters[i], bx + bw / 2, 39);
   }
   ctx.textAlign = 'left';
 
@@ -103,48 +109,32 @@ async function buildShareImage(params: {
       const qr = new window.Image();
       qr.onload = () => {
         ctx.fillStyle = 'white';
-        roundRect(ctx, W - 100, charH - 96, 76, 76, 8);
-        ctx.fill();
-        ctx.drawImage(qr, W - 96, charH - 92, 68, 68);
-        resolve();
+        roundRect(ctx, W - 100, charH - 96, 76, 76, 8); ctx.fill();
+        ctx.drawImage(qr, W - 96, charH - 92, 68, 68); resolve();
       };
-      qr.onerror = () => resolve();
-      qr.src = qrDataUrl;
+      qr.onerror = () => resolve(); qr.src = qrDataUrl;
     });
-    ctx.font = `400 18px ${JP_FONT}`;
-    ctx.fillStyle = 'rgba(180,150,80,0.5)';
-    ctx.textAlign = 'right';
-    ctx.fillText('seihekilab.com', W - 20, charH - 8);
+    ctx.font = `400 16px ${JP_FONT}`; ctx.fillStyle = 'rgba(180,150,80,0.5)';
+    ctx.textAlign = 'right'; ctx.fillText('seihekilab.com', W - 20, charH - 8);
     ctx.textAlign = 'left';
   }
 
-  // テキストエリア
-  const tx = 36;
+  // ── テキストエリア（下詰め）──
   let ty = charH + 32;
 
-  ctx.font = `900 52px ${JP_FONT}`;
-  ctx.fillStyle = '#f0e6d3';
-  ctx.fillText(quizType.name, tx, ty);
-  ty += 16;
+  ctx.font = `900 52px ${JP_FONT}`; ctx.fillStyle = '#f0e6d3';
+  ctx.fillText(quizType.name, tx, ty + 52); ty += 58 + 8;
 
-  ctx.font = `700 22px ${JP_FONT}`;
-  ctx.fillStyle = quizType.color;
-  ctx.fillText(quizType.tagline, tx, ty + 22);
-  ty += 52;
+  ctx.font = `700 22px ${JP_FONT}`; ctx.fillStyle = quizType.color;
+  ctx.fillText(quizType.tagline, tx, ty + 22); ty += 28 + 20;
 
-  // 説明文
-  ctx.font = `400 18px ${JP_FONT}`;
-  ctx.fillStyle = 'rgba(200,180,140,0.65)';
-  ty = wrapText(ctx, quizType.description, tx, ty, W - tx * 2, 28) + 28;
+  ctx.font = `400 18px ${JP_FONT}`; ctx.fillStyle = 'rgba(200,180,140,0.65)';
+  ty = wrapText(ctx, quizType.description, tx, ty, W - tx * 2, 28) + 24;
 
   // 区切り線
-  ctx.strokeStyle = 'rgba(180,150,80,0.2)';
-  ctx.lineWidth = 1;
-  ctx.beginPath();
-  ctx.moveTo(tx, ty);
-  ctx.lineTo(W - tx, ty);
-  ctx.stroke();
-  ty += 24;
+  ctx.strokeStyle = 'rgba(180,150,80,0.2)'; ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(tx, ty); ctx.lineTo(W - tx, ty); ctx.stroke();
+  ty += 20;
 
   // 軸バー
   for (const { axis, pct } of axes) {
@@ -152,51 +142,28 @@ async function buildShareImage(params: {
     const isHigh = pct >= 50;
     const color = isHigh ? meta.colorHigh : meta.colorLow;
     const label = isHigh ? meta.labelHigh : meta.labelLow;
-    const labelW = 60;
-    const barX = tx + labelW + 8;
-    const barW = W - tx * 2 - labelW * 2 - 16;
+    const labelW = 56, barX = tx + labelW + 8, barW = W - tx * 2 - labelW * 2 - 16;
 
-    ctx.font = `700 17px ${JP_FONT}`;
-    ctx.fillStyle = 'rgba(200,180,140,0.5)';
-    ctx.textAlign = 'right';
-    ctx.fillText(meta.labelHigh, tx + labelW, ty + 8);
-    ctx.textAlign = 'left';
-    ctx.fillText(meta.labelLow, barX + barW + 8, ty + 8);
+    ctx.font = `700 17px ${JP_FONT}`; ctx.fillStyle = 'rgba(200,180,140,0.5)';
+    ctx.textAlign = 'right'; ctx.fillText(meta.labelHigh, tx + labelW, ty + 9);
+    ctx.textAlign = 'left'; ctx.fillText(meta.labelLow, barX + barW + 8, ty + 9);
 
-    // バー背景
     ctx.fillStyle = 'rgba(180,150,80,0.1)';
-    roundRect(ctx, barX, ty - 1, barW, 10, 5);
-    ctx.fill();
+    roundRect(ctx, barX, ty, barW, 10, 5); ctx.fill();
+    ctx.fillStyle = 'rgba(180,150,80,0.3)'; ctx.fillRect(barX + barW / 2, ty, 1.5, 10);
 
-    // 中央線
-    ctx.fillStyle = 'rgba(180,150,80,0.3)';
-    ctx.fillRect(barX + barW / 2, ty - 1, 1.5, 10);
-
-    // バー本体
     const fillW = Math.abs(pct - 50) / 50 * (barW / 2);
     ctx.fillStyle = color;
-    if (isHigh) {
-      roundRect(ctx, barX + barW / 2 - fillW, ty - 1, fillW, 10, 5);
-    } else {
-      roundRect(ctx, barX + barW / 2, ty - 1, fillW, 10, 5);
-    }
-    ctx.fill();
+    roundRect(ctx, isHigh ? barX + barW / 2 - fillW : barX + barW / 2, ty, fillW, 10, 5); ctx.fill();
 
-    // ラベル
-    ctx.font = `900 17px ${JP_FONT}`;
-    ctx.fillStyle = color;
-    ctx.textAlign = 'right';
-    ctx.fillText(label, W - tx, ty + 8);
-    ctx.textAlign = 'left';
-
-    ty += 32;
+    ctx.font = `900 17px ${JP_FONT}`; ctx.fillStyle = color;
+    ctx.textAlign = 'right'; ctx.fillText(label, W - tx, ty + 9);
+    ctx.textAlign = 'left'; ty += 32;
   }
 
   // フッター
-  ctx.font = `700 16px ${JP_FONT}`;
-  ctx.fillStyle = 'rgba(180,150,80,0.3)';
-  ctx.textAlign = 'right';
-  ctx.fillText('✦ 性癖16タイプ分析 ✦', W - tx, H - 24);
+  ctx.font = `600 15px ${JP_FONT}`; ctx.fillStyle = 'rgba(180,150,80,0.3)';
+  ctx.textAlign = 'right'; ctx.fillText('✦ 性癖16タイプ分析 ✦', W - tx, ty + 16);
   ctx.textAlign = 'left';
 
   return canvas.toDataURL('image/png');

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -11,7 +11,9 @@ import { trackEvent } from '@/lib/analytics';
 const CTA_SHOWN_KEY = 'quiz_male_cta_shown';
 const AXES: Axis[] = ['ds', 'pe', 'nx', 'cw'];
 
-// ─── Canvas で直接シェア画像を生成 ────────────────────────────────────────────
+const JP_FONT = '"Hiragino Kaku Gothic ProN","Hiragino Sans","Yu Gothic","Noto Sans JP",sans-serif';
+
+// ─── Canvas で直接シェア画像を生成（3:4） ─────────────────────────────────────
 async function buildShareImage(params: {
   typeKey: QuizTypeKey;
   quizType: QuizType;
@@ -20,12 +22,15 @@ async function buildShareImage(params: {
   qrDataUrl: string;
 }): Promise<string> {
   const { typeKey, quizType, axes, charDataUrl, qrDataUrl } = params;
-  const W = 750, H = 750;
+  const W = 750, H = 1000;
   const canvas = document.createElement('canvas');
   canvas.width = W; canvas.height = H;
   const ctx = canvas.getContext('2d')!;
 
-  // 背景グラデーション
+  // フォントロード待ち
+  await document.fonts.ready;
+
+  // 背景
   const bg = ctx.createLinearGradient(0, 0, 0, H);
   bg.addColorStop(0, '#0d0b08');
   bg.addColorStop(1, '#1a1510');
@@ -33,13 +38,11 @@ async function buildShareImage(params: {
   ctx.fillRect(0, 0, W, H);
 
   // キャラエリア背景
-  const charH = 440;
+  const charH = 480;
   ctx.fillStyle = quizType.color + '38';
   ctx.fillRect(0, 0, W, charH);
-
-  // ラジアルグラデーション
-  const rg = ctx.createRadialGradient(W / 2, charH / 2, 0, W / 2, charH / 2, W / 2);
-  rg.addColorStop(0, quizType.color + '22');
+  const rg = ctx.createRadialGradient(W / 2, charH / 2, 0, W / 2, charH / 2, W * 0.6);
+  rg.addColorStop(0, quizType.color + '30');
   rg.addColorStop(1, 'transparent');
   ctx.fillStyle = rg;
   ctx.fillRect(0, 0, W, charH);
@@ -49,12 +52,12 @@ async function buildShareImage(params: {
     await new Promise<void>((resolve) => {
       const img = new window.Image();
       img.onload = () => {
-        const size = 360;
-        const x = (W - size) / 2, y = (charH - size) / 2;
+        const size = 400;
+        const x = (W - size) / 2, y = (charH - size) / 2 + 10;
         ctx.save();
-        ctx.shadowColor = 'rgba(0,0,0,0.85)';
-        ctx.shadowBlur = 32;
-        ctx.shadowOffsetY = 12;
+        ctx.shadowColor = 'rgba(0,0,0,0.9)';
+        ctx.shadowBlur = 40;
+        ctx.shadowOffsetY = 16;
         ctx.drawImage(img, x, y, size, size);
         ctx.restore();
         resolve();
@@ -65,33 +68,32 @@ async function buildShareImage(params: {
   }
 
   // キャラエリア下フェード
-  const fade = ctx.createLinearGradient(0, charH - 80, 0, charH);
+  const fade = ctx.createLinearGradient(0, charH - 100, 0, charH);
   fade.addColorStop(0, 'transparent');
   fade.addColorStop(1, '#0d0b08');
   ctx.fillStyle = fade;
-  ctx.fillRect(0, charH - 80, W, 80);
+  ctx.fillRect(0, charH - 100, W, 100);
 
   // ヘッダー: ラベル
-  ctx.font = '700 11px sans-serif';
+  ctx.font = `600 22px ${JP_FONT}`;
   ctx.fillStyle = 'rgba(180,150,80,0.65)';
-  ctx.letterSpacing = '0.22em';
-  ctx.fillText('性癖16タイプ分析', 22, 30);
+  ctx.fillText('性癖16タイプ分析', 28, 44);
 
   // ヘッダー: タイプキーバッジ
   const letters = typeKey.toUpperCase().split('');
-  let bx = W - 22;
+  let bx = W - 24;
   for (let i = letters.length - 1; i >= 0; i--) {
-    const bw = 32;
-    bx -= bw + 5;
+    const bw = 42;
+    bx -= bw + 6;
     ctx.fillStyle = quizType.color + '30';
-    ctx.strokeStyle = quizType.color + '55';
-    ctx.lineWidth = 1;
-    roundRect(ctx, bx, 14, bw, 18, 9);
+    ctx.strokeStyle = quizType.color + '66';
+    ctx.lineWidth = 1.5;
+    roundRect(ctx, bx, 20, bw, 28, 14);
     ctx.fill(); ctx.stroke();
-    ctx.font = '900 11px sans-serif';
+    ctx.font = `900 15px ${JP_FONT}`;
     ctx.fillStyle = quizType.color;
     ctx.textAlign = 'center';
-    ctx.fillText(letters[i], bx + bw / 2, 27);
+    ctx.fillText(letters[i], bx + bw / 2, 39);
   }
   ctx.textAlign = 'left';
 
@@ -101,81 +103,101 @@ async function buildShareImage(params: {
       const qr = new window.Image();
       qr.onload = () => {
         ctx.fillStyle = 'white';
-        roundRect(ctx, W - 90, charH - 86, 72, 72, 6);
+        roundRect(ctx, W - 100, charH - 96, 76, 76, 8);
         ctx.fill();
-        ctx.drawImage(qr, W - 86, charH - 82, 64, 64);
+        ctx.drawImage(qr, W - 96, charH - 92, 68, 68);
         resolve();
       };
       qr.onerror = () => resolve();
       qr.src = qrDataUrl;
     });
-    ctx.font = '400 9px sans-serif';
-    ctx.fillStyle = 'rgba(180,150,80,0.55)';
+    ctx.font = `400 18px ${JP_FONT}`;
+    ctx.fillStyle = 'rgba(180,150,80,0.5)';
     ctx.textAlign = 'right';
-    ctx.fillText('seihekilab.com', W - 16, charH - 6);
+    ctx.fillText('seihekilab.com', W - 20, charH - 8);
     ctx.textAlign = 'left';
   }
 
   // テキストエリア
-  const tx = 28, ty = charH + 18;
-  ctx.font = '900 36px sans-serif';
+  const tx = 36;
+  let ty = charH + 32;
+
+  ctx.font = `900 52px ${JP_FONT}`;
   ctx.fillStyle = '#f0e6d3';
-  ctx.fillText(quizType.name, tx, ty + 34);
+  ctx.fillText(quizType.name, tx, ty);
+  ty += 16;
 
-  ctx.font = '700 14px sans-serif';
+  ctx.font = `700 22px ${JP_FONT}`;
   ctx.fillStyle = quizType.color;
-  ctx.fillText(quizType.tagline, tx, ty + 60);
+  ctx.fillText(quizType.tagline, tx, ty + 22);
+  ty += 52;
 
-  // 説明文（折り返し）
-  ctx.font = '400 11px sans-serif';
+  // 説明文
+  ctx.font = `400 18px ${JP_FONT}`;
   ctx.fillStyle = 'rgba(200,180,140,0.65)';
-  wrapText(ctx, quizType.description, tx, ty + 85, W - tx * 2, 17);
+  ty = wrapText(ctx, quizType.description, tx, ty, W - tx * 2, 28) + 28;
+
+  // 区切り線
+  ctx.strokeStyle = 'rgba(180,150,80,0.2)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(tx, ty);
+  ctx.lineTo(W - tx, ty);
+  ctx.stroke();
+  ty += 24;
 
   // 軸バー
-  let by = ty + 160;
   for (const { axis, pct } of axes) {
     const meta = AXIS_META[axis];
     const isHigh = pct >= 50;
     const color = isHigh ? meta.colorHigh : meta.colorLow;
     const label = isHigh ? meta.labelHigh : meta.labelLow;
-    const barW = W - tx * 2 - 100;
-    const barX = tx + 38;
+    const labelW = 60;
+    const barX = tx + labelW + 8;
+    const barW = W - tx * 2 - labelW * 2 - 16;
 
-    ctx.font = '700 11px sans-serif';
+    ctx.font = `700 17px ${JP_FONT}`;
     ctx.fillStyle = 'rgba(200,180,140,0.5)';
     ctx.textAlign = 'right';
-    ctx.fillText(meta.labelHigh, barX - 4, by + 6);
+    ctx.fillText(meta.labelHigh, tx + labelW, ty + 8);
     ctx.textAlign = 'left';
-    ctx.fillText(meta.labelLow, barX + barW + 4, by + 6);
+    ctx.fillText(meta.labelLow, barX + barW + 8, ty + 8);
 
     // バー背景
     ctx.fillStyle = 'rgba(180,150,80,0.1)';
-    roundRect(ctx, barX, by - 3, barW, 7, 3.5);
+    roundRect(ctx, barX, ty - 1, barW, 10, 5);
     ctx.fill();
 
     // 中央線
-    ctx.fillStyle = 'rgba(180,150,80,0.25)';
-    ctx.fillRect(barX + barW / 2, by - 3, 1, 7);
+    ctx.fillStyle = 'rgba(180,150,80,0.3)';
+    ctx.fillRect(barX + barW / 2, ty - 1, 1.5, 10);
 
     // バー本体
     const fillW = Math.abs(pct - 50) / 50 * (barW / 2);
     ctx.fillStyle = color;
     if (isHigh) {
-      roundRect(ctx, barX + barW / 2 - fillW, by - 3, fillW, 7, 3.5);
+      roundRect(ctx, barX + barW / 2 - fillW, ty - 1, fillW, 10, 5);
     } else {
-      roundRect(ctx, barX + barW / 2, by - 3, fillW, 7, 3.5);
+      roundRect(ctx, barX + barW / 2, ty - 1, fillW, 10, 5);
     }
     ctx.fill();
 
     // ラベル
-    ctx.font = '900 11px sans-serif';
+    ctx.font = `900 17px ${JP_FONT}`;
     ctx.fillStyle = color;
     ctx.textAlign = 'right';
-    ctx.fillText(label, W - tx, by + 6);
+    ctx.fillText(label, W - tx, ty + 8);
     ctx.textAlign = 'left';
 
-    by += 22;
+    ty += 32;
   }
+
+  // フッター
+  ctx.font = `700 16px ${JP_FONT}`;
+  ctx.fillStyle = 'rgba(180,150,80,0.3)';
+  ctx.textAlign = 'right';
+  ctx.fillText('✦ 性癖16タイプ分析 ✦', W - tx, H - 24);
+  ctx.textAlign = 'left';
 
   return canvas.toDataURL('image/png');
 }
@@ -194,11 +216,10 @@ function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: numbe
   ctx.closePath();
 }
 
-function wrapText(ctx: CanvasRenderingContext2D, text: string, x: number, y: number, maxW: number, lineH: number) {
-  const words = text.split('');
+function wrapText(ctx: CanvasRenderingContext2D, text: string, x: number, y: number, maxW: number, lineH: number): number {
   let line = '';
   let cy = y;
-  for (const ch of words) {
+  for (const ch of text.split('')) {
     const test = line + ch;
     if (ctx.measureText(test).width > maxW && line) {
       ctx.fillText(line, x, cy);
@@ -209,6 +230,7 @@ function wrapText(ctx: CanvasRenderingContext2D, text: string, x: number, y: num
     }
   }
   if (line) ctx.fillText(line, x, cy);
+  return cy;
 }
 
 // ─── 「画像で保存/シェア」ボタン ────────────────────────────────────────────

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { useSearchParams, useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
-import { toPng } from 'html-to-image';
 import QRCode from 'qrcode';
 import { QUIZ_TYPES, AXIS_META, COMPATIBILITY, COMPATIBILITY_LABELS, QuizTypeKey, QuizType, Axis } from '../../data';
 import { trackEvent } from '@/lib/analytics';
@@ -12,159 +11,245 @@ import { trackEvent } from '@/lib/analytics';
 const CTA_SHOWN_KEY = 'quiz_male_cta_shown';
 const AXES: Axis[] = ['ds', 'pe', 'nx', 'cw'];
 
-// ─── シェアカード（html-to-image でキャプチャ用） ────────────────────────────
-function ShareCard({
-  typeKey,
-  quizType,
-  axes,
-  qrDataUrl,
-  charDataUrl,
-  cardRef,
-}: {
+// ─── Canvas で直接シェア画像を生成 ────────────────────────────────────────────
+async function buildShareImage(params: {
   typeKey: QuizTypeKey;
   quizType: QuizType;
   axes: { axis: Axis; pct: number }[];
-  qrDataUrl: string;
   charDataUrl: string;
-  cardRef: React.RefObject<HTMLDivElement | null>;
-}) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
+  qrDataUrl: string;
+}): Promise<string> {
+  const { typeKey, quizType, axes, charDataUrl, qrDataUrl } = params;
+  const W = 750, H = 750;
+  const canvas = document.createElement('canvas');
+  canvas.width = W; canvas.height = H;
+  const ctx = canvas.getContext('2d')!;
 
-  // charDataUrl が揃ったら canvas に描画（html-to-image がフェッチ不要になる）
-  useEffect(() => {
-    if (!charDataUrl || !canvasRef.current) return;
-    const canvas = canvasRef.current;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-    const img = new window.Image();
-    img.onload = () => {
-      ctx.clearRect(0, 0, 380, 380);
-      ctx.drawImage(img, 0, 0, 380, 380);
-    };
-    img.src = charDataUrl;
-  }, [charDataUrl]);
+  // 背景グラデーション
+  const bg = ctx.createLinearGradient(0, 0, 0, H);
+  bg.addColorStop(0, '#0d0b08');
+  bg.addColorStop(1, '#1a1510');
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, W, H);
 
-  return (
-    <div
-      ref={cardRef}
-      style={{
-        position: 'relative',
-        width: '750px',
-        height: '750px',
-        background: 'linear-gradient(170deg, #0d0b08 0%, #1a1510 100%)',
-        fontFamily: 'sans-serif',
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-      }}
-    >
-      {/* キャラクター画像エリア */}
-      <div style={{ height: '450px', background: `${quizType.color}38`, display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative', flexShrink: 0 }}>
-        <div style={{ position: 'absolute', inset: 0, background: `radial-gradient(ellipse at center, ${quizType.color}22 0%, transparent 70%)` }} />
-        <canvas
-          ref={canvasRef}
-          width={380}
-          height={380}
-          style={{ position: 'relative', filter: 'drop-shadow(0 12px 32px rgba(0,0,0,0.85))' }}
-        />
-        {/* ヘッダーバー */}
-        <div style={{ position: 'absolute', top: 0, left: 0, right: 0, padding: '12px 22px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-          <p style={{ color: 'rgba(180,150,80,0.65)', fontSize: '11px', letterSpacing: '0.22em', textTransform: 'uppercase', margin: 0 }}>性癖16タイプ分析</p>
-          <div style={{ display: 'flex', gap: '5px' }}>
-            {typeKey.toUpperCase().split('').map((c, i) => (
-              <span key={i} style={{ background: `${quizType.color}30`, color: quizType.color, fontSize: '11px', fontWeight: 900, padding: '3px 10px', borderRadius: '100px', border: `1px solid ${quizType.color}55` }}>{c}</span>
-            ))}
-          </div>
-        </div>
-        <div style={{ position: 'absolute', bottom: 0, left: 0, right: 0, height: '80px', background: 'linear-gradient(to bottom, transparent, #0d0b08)' }} />
-        {/* QRコード（画像エリア右下） */}
-        {qrDataUrl && (
-          <div style={{ position: 'absolute', bottom: '14px', right: '16px', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '4px' }}>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={qrDataUrl} alt="QR" style={{ width: '64px', height: '64px', borderRadius: '6px', background: 'white', padding: '4px', display: 'block' }} />
-            <p style={{ color: 'rgba(180,150,80,0.55)', fontSize: '9px', margin: 0, letterSpacing: '0.05em' }}>seihekilab.com</p>
-          </div>
-        )}
-      </div>
+  // キャラエリア背景
+  const charH = 440;
+  ctx.fillStyle = quizType.color + '38';
+  ctx.fillRect(0, 0, W, charH);
 
-      {/* テキストエリア */}
-      <div style={{ padding: '18px 28px 20px', display: 'flex', flexDirection: 'column', gap: '12px', flex: 1 }}>
-        {/* 名前・タグライン */}
-        <div>
-          <h2 style={{ color: '#f0e6d3', fontSize: '38px', fontWeight: 900, margin: '0 0 5px', lineHeight: 1.1 }}>{quizType.name}</h2>
-          <p style={{ color: quizType.color, fontSize: '15px', fontWeight: 700, margin: 0, lineHeight: 1.4 }}>{quizType.tagline}</p>
-        </div>
+  // ラジアルグラデーション
+  const rg = ctx.createRadialGradient(W / 2, charH / 2, 0, W / 2, charH / 2, W / 2);
+  rg.addColorStop(0, quizType.color + '22');
+  rg.addColorStop(1, 'transparent');
+  ctx.fillStyle = rg;
+  ctx.fillRect(0, 0, W, charH);
 
-        {/* 説明文 */}
-        <p style={{ color: 'rgba(200,180,140,0.65)', fontSize: '12px', lineHeight: 1.7, margin: 0 }}>
-          {quizType.description}
-        </p>
+  // キャラ画像
+  if (charDataUrl) {
+    await new Promise<void>((resolve) => {
+      const img = new window.Image();
+      img.onload = () => {
+        const size = 360;
+        const x = (W - size) / 2, y = (charH - size) / 2;
+        ctx.save();
+        ctx.shadowColor = 'rgba(0,0,0,0.85)';
+        ctx.shadowBlur = 32;
+        ctx.shadowOffsetY = 12;
+        ctx.drawImage(img, x, y, size, size);
+        ctx.restore();
+        resolve();
+      };
+      img.onerror = () => resolve();
+      img.src = charDataUrl;
+    });
+  }
 
-        {/* 軸バー */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '9px' }}>
-          {axes.map(({ axis, pct }) => {
-            const meta = AXIS_META[axis];
-            const isHigh = pct >= 50;
-            const color = isHigh ? meta.colorHigh : meta.colorLow;
-            const label = isHigh ? meta.labelHigh : meta.labelLow;
-            const barWidth = Math.abs(pct - 50) * 2;
-            return (
-              <div key={axis} style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                <span style={{ color: 'rgba(200,180,140,0.5)', fontSize: '11px', fontWeight: 700, width: '34px', textAlign: 'right', flexShrink: 0 }}>{meta.labelHigh}</span>
-                <div style={{ flex: 1, background: 'rgba(180,150,80,0.1)', borderRadius: '100px', height: '7px', overflow: 'hidden', position: 'relative' }}>
-                  <div style={{ position: 'absolute', left: '50%', top: 0, bottom: 0, width: '1px', background: 'rgba(180,150,80,0.25)' }} />
-                  {isHigh
-                    ? <div style={{ position: 'absolute', right: '50%', top: 0, bottom: 0, width: `${barWidth}%`, background: color, borderRadius: '100px' }} />
-                    : <div style={{ position: 'absolute', left: '50%', top: 0, bottom: 0, width: `${barWidth}%`, background: color, borderRadius: '100px' }} />
-                  }
-                </div>
-                <span style={{ color: 'rgba(200,180,140,0.5)', fontSize: '11px', fontWeight: 700, width: '34px', flexShrink: 0 }}>{meta.labelLow}</span>
-                <span style={{ color, fontSize: '11px', fontWeight: 900, width: '44px', textAlign: 'right', flexShrink: 0 }}>{label}</span>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
+  // キャラエリア下フェード
+  const fade = ctx.createLinearGradient(0, charH - 80, 0, charH);
+  fade.addColorStop(0, 'transparent');
+  fade.addColorStop(1, '#0d0b08');
+  ctx.fillStyle = fade;
+  ctx.fillRect(0, charH - 80, W, 80);
+
+  // ヘッダー: ラベル
+  ctx.font = '700 11px sans-serif';
+  ctx.fillStyle = 'rgba(180,150,80,0.65)';
+  ctx.letterSpacing = '0.22em';
+  ctx.fillText('性癖16タイプ分析', 22, 30);
+
+  // ヘッダー: タイプキーバッジ
+  const letters = typeKey.toUpperCase().split('');
+  let bx = W - 22;
+  for (let i = letters.length - 1; i >= 0; i--) {
+    const bw = 32;
+    bx -= bw + 5;
+    ctx.fillStyle = quizType.color + '30';
+    ctx.strokeStyle = quizType.color + '55';
+    ctx.lineWidth = 1;
+    roundRect(ctx, bx, 14, bw, 18, 9);
+    ctx.fill(); ctx.stroke();
+    ctx.font = '900 11px sans-serif';
+    ctx.fillStyle = quizType.color;
+    ctx.textAlign = 'center';
+    ctx.fillText(letters[i], bx + bw / 2, 27);
+  }
+  ctx.textAlign = 'left';
+
+  // QRコード
+  if (qrDataUrl) {
+    await new Promise<void>((resolve) => {
+      const qr = new window.Image();
+      qr.onload = () => {
+        ctx.fillStyle = 'white';
+        roundRect(ctx, W - 90, charH - 86, 72, 72, 6);
+        ctx.fill();
+        ctx.drawImage(qr, W - 86, charH - 82, 64, 64);
+        resolve();
+      };
+      qr.onerror = () => resolve();
+      qr.src = qrDataUrl;
+    });
+    ctx.font = '400 9px sans-serif';
+    ctx.fillStyle = 'rgba(180,150,80,0.55)';
+    ctx.textAlign = 'right';
+    ctx.fillText('seihekilab.com', W - 16, charH - 6);
+    ctx.textAlign = 'left';
+  }
+
+  // テキストエリア
+  const tx = 28, ty = charH + 18;
+  ctx.font = '900 36px sans-serif';
+  ctx.fillStyle = '#f0e6d3';
+  ctx.fillText(quizType.name, tx, ty + 34);
+
+  ctx.font = '700 14px sans-serif';
+  ctx.fillStyle = quizType.color;
+  ctx.fillText(quizType.tagline, tx, ty + 60);
+
+  // 説明文（折り返し）
+  ctx.font = '400 11px sans-serif';
+  ctx.fillStyle = 'rgba(200,180,140,0.65)';
+  wrapText(ctx, quizType.description, tx, ty + 85, W - tx * 2, 17);
+
+  // 軸バー
+  let by = ty + 160;
+  for (const { axis, pct } of axes) {
+    const meta = AXIS_META[axis];
+    const isHigh = pct >= 50;
+    const color = isHigh ? meta.colorHigh : meta.colorLow;
+    const label = isHigh ? meta.labelHigh : meta.labelLow;
+    const barW = W - tx * 2 - 100;
+    const barX = tx + 38;
+
+    ctx.font = '700 11px sans-serif';
+    ctx.fillStyle = 'rgba(200,180,140,0.5)';
+    ctx.textAlign = 'right';
+    ctx.fillText(meta.labelHigh, barX - 4, by + 6);
+    ctx.textAlign = 'left';
+    ctx.fillText(meta.labelLow, barX + barW + 4, by + 6);
+
+    // バー背景
+    ctx.fillStyle = 'rgba(180,150,80,0.1)';
+    roundRect(ctx, barX, by - 3, barW, 7, 3.5);
+    ctx.fill();
+
+    // 中央線
+    ctx.fillStyle = 'rgba(180,150,80,0.25)';
+    ctx.fillRect(barX + barW / 2, by - 3, 1, 7);
+
+    // バー本体
+    const fillW = Math.abs(pct - 50) / 50 * (barW / 2);
+    ctx.fillStyle = color;
+    if (isHigh) {
+      roundRect(ctx, barX + barW / 2 - fillW, by - 3, fillW, 7, 3.5);
+    } else {
+      roundRect(ctx, barX + barW / 2, by - 3, fillW, 7, 3.5);
+    }
+    ctx.fill();
+
+    // ラベル
+    ctx.font = '900 11px sans-serif';
+    ctx.fillStyle = color;
+    ctx.textAlign = 'right';
+    ctx.fillText(label, W - tx, by + 6);
+    ctx.textAlign = 'left';
+
+    by += 22;
+  }
+
+  return canvas.toDataURL('image/png');
+}
+
+function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.arcTo(x + w, y, x + w, y + r, r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+  ctx.lineTo(x + r, y + h);
+  ctx.arcTo(x, y + h, x, y + h - r, r);
+  ctx.lineTo(x, y + r);
+  ctx.arcTo(x, y, x + r, y, r);
+  ctx.closePath();
+}
+
+function wrapText(ctx: CanvasRenderingContext2D, text: string, x: number, y: number, maxW: number, lineH: number) {
+  const words = text.split('');
+  let line = '';
+  let cy = y;
+  for (const ch of words) {
+    const test = line + ch;
+    if (ctx.measureText(test).width > maxW && line) {
+      ctx.fillText(line, x, cy);
+      line = ch;
+      cy += lineH;
+    } else {
+      line = test;
+    }
+  }
+  if (line) ctx.fillText(line, x, cy);
 }
 
 // ─── 「画像で保存/シェア」ボタン ────────────────────────────────────────────
 function SaveImageButton({
-  cardRef,
   typeKey,
   quizType,
+  axes,
   charDataUrl,
+  qrDataUrl,
   onCharDataUrlReady,
 }: {
-  cardRef: React.RefObject<HTMLDivElement | null>;
   typeKey: QuizTypeKey;
   quizType: QuizType;
+  axes: { axis: Axis; pct: number }[];
   charDataUrl: string;
+  qrDataUrl: string;
   onCharDataUrlReady: (url: string) => void;
 }) {
   const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
 
   const handleSave = async () => {
-    if (!cardRef.current || loading) return;
+    if (loading) return;
     setLoading(true);
+    setErrorMsg('');
     trackEvent('quiz_save_image', { type: typeKey });
     try {
-      // charDataUrl未取得なら今すぐfetchしてcanvasに描画されるまで待つ
-      if (!charDataUrl) {
-        const url = await fetch(`/quiz/${typeKey}.png`)
+      // データURLを確保（未取得なら今すぐfetch）
+      let resolvedCharDataUrl = charDataUrl;
+      if (!resolvedCharDataUrl) {
+        resolvedCharDataUrl = await fetch(`/quiz/${typeKey}.png`)
           .then((r) => r.blob())
           .then((blob) => new Promise<string>((resolve) => {
             const reader = new FileReader();
             reader.onload = () => resolve(reader.result as string);
             reader.readAsDataURL(blob);
           }));
-        onCharDataUrlReady(url);
-        // canvasへの描画完了を待つ
-        await new Promise((r) => setTimeout(r, 200));
+        onCharDataUrlReady(resolvedCharDataUrl);
       }
 
-      const capturedDataUrl = await toPng(cardRef.current, { pixelRatio: 2, cacheBust: false });
+      const capturedDataUrl = await buildShareImage({ typeKey, quizType, axes, charDataUrl: resolvedCharDataUrl, qrDataUrl });
 
       const blob = await (await fetch(capturedDataUrl)).blob();
       const file = new File([blob], `seiheki_${typeKey}.png`, { type: 'image/png' });
@@ -173,32 +258,45 @@ function SaveImageButton({
         await navigator.share({ files: [file] });
         trackEvent('quiz_image_shared', { type: typeKey, method: 'webshare' });
       } else {
-        const a = document.createElement('a');
-        a.href = capturedDataUrl;
-        a.download = `seiheki_${typeKey}.png`;
-        a.click();
+        const newTab = window.open();
+        if (newTab) {
+          newTab.document.write(`<img src="${capturedDataUrl}" style="max-width:100%;display:block;" />`);
+          newTab.document.close();
+        } else {
+          const a = document.createElement('a');
+          a.href = capturedDataUrl;
+          a.download = `seiheki_${typeKey}.png`;
+          a.click();
+        }
         trackEvent('quiz_image_shared', { type: typeKey, method: 'download' });
       }
     } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
       console.error('画像生成失敗:', e);
+      setErrorMsg(msg);
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <button
-      onClick={handleSave}
-      disabled={loading}
-      className="w-full rounded-2xl py-4 font-black flex items-center justify-center gap-2 text-[15px] active:translate-y-[1px] transition-all"
-      style={
-        loading
-          ? { background: '#e0c090', color: '#c8a080', cursor: 'not-allowed' }
-          : { background: 'linear-gradient(90deg, #6c3483, #e84393)', color: '#fff', boxShadow: '0 4px 0 #4a235a' }
-      }
-    >
-      {loading ? '生成中…' : '🖼️ 画像を保存してシェア'}
-    </button>
+    <>
+      {errorMsg && (
+        <p className="text-[11px] text-red-400 mb-2 px-1 break-all">{errorMsg}</p>
+      )}
+      <button
+        onClick={handleSave}
+        disabled={loading}
+        className="w-full rounded-2xl py-4 font-black flex items-center justify-center gap-2 text-[15px] active:translate-y-[1px] transition-all"
+        style={
+          loading
+            ? { background: '#e0c090', color: '#c8a080', cursor: 'not-allowed' }
+            : { background: 'linear-gradient(90deg, #6c3483, #e84393)', color: '#fff', boxShadow: '0 4px 0 #4a235a' }
+        }
+      >
+        {loading ? '生成中…' : '🖼️ 画像を保存してシェア'}
+      </button>
+    </>
   );
 }
 
@@ -243,7 +341,6 @@ function MaleCTAModal({ typeKey, onClose }: { typeKey: QuizTypeKey; onClose: () 
 export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const shareCardRef = useRef<HTMLDivElement>(null);
   const [showCTA, setShowCTA] = useState(false);
   const [qrDataUrl, setQrDataUrl] = useState('');
   const [charDataUrl, setCharDataUrl] = useState('');
@@ -324,11 +421,6 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
   return (
     <div className="min-h-[calc(100vh-56px)] flex flex-col items-center px-4 py-8">
       {showCTA && <MaleCTAModal typeKey={typeKey} onClose={closeCTA} />}
-
-      {/* キャプチャ用シェアカード（画面外非表示） */}
-      <div style={{ position: 'absolute', left: '-9999px', top: 0, overflow: 'hidden', pointerEvents: 'none' }}>
-        <ShareCard typeKey={typeKey} quizType={quizType} axes={axes} qrDataUrl={qrDataUrl} charDataUrl={charDataUrl} cardRef={shareCardRef} />
-      </div>
 
       <p className="text-[11px] font-black tracking-[0.3em] uppercase mb-5" style={{ color: 'rgba(180,150,80,0.5)' }}>✦ 診断結果 ✦</p>
 
@@ -478,7 +570,7 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
 
       {/* シェアボタン */}
       <div className="w-full max-w-sm space-y-3 mb-6">
-        <SaveImageButton cardRef={shareCardRef} typeKey={typeKey} quizType={quizType} charDataUrl={charDataUrl} onCharDataUrlReady={setCharDataUrl} />
+        <SaveImageButton typeKey={typeKey} quizType={quizType} axes={axes} charDataUrl={charDataUrl} qrDataUrl={qrDataUrl} onCharDataUrlReady={setCharDataUrl} />
         <button
           onClick={shareToX}
           className="w-full rounded-2xl py-4 font-black text-white flex items-center justify-center gap-2 text-[15px] active:translate-y-[1px] transition-transform"

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -27,12 +27,12 @@ async function buildShareImage(params: {
 
   // ── テキストエリアの高さを先に計算 ──
   const offCtx = document.createElement('canvas').getContext('2d')!;
-  offCtx.font = `400 18px ${JP_FONT}`;
+  offCtx.font = `400 15px ${JP_FONT}`;
   let textH = 32; // 上パディング
   textH += 58;    // タイトル (52px)
   textH += 8;     // gap
-  textH += 28;    // タグライン
-  textH += 20;    // gap
+  textH += 22;    // タグライン (17px)
+  textH += 16;    // gap
   // 説明文の行数を計算
   let line = '';
   let descLines = 1;
@@ -41,7 +41,7 @@ async function buildShareImage(params: {
     if (offCtx.measureText(test).width > W - tx * 2 && line) { line = ch; descLines++; }
     else line = test;
   }
-  textH += descLines * 28; // 説明文
+  textH += descLines * 22; // 説明文 (15px × 22lineH)
   textH += 24;  // gap + 区切り線
   textH += 20;  // 区切り線後gap
   textH += axes.length * 32; // 軸バー
@@ -103,19 +103,19 @@ async function buildShareImage(params: {
   }
   ctx.textAlign = 'left';
 
-  // QRコード
+  // QRコード + ドメイン（QR左横に並べる）
   if (qrDataUrl) {
     await new Promise<void>((resolve) => {
       const qr = new window.Image();
       qr.onload = () => {
         ctx.fillStyle = 'white';
-        roundRect(ctx, W - 100, charH - 96, 76, 76, 8); ctx.fill();
-        ctx.drawImage(qr, W - 96, charH - 92, 68, 68); resolve();
+        roundRect(ctx, W - 92, charH - 92, 72, 72, 8); ctx.fill();
+        ctx.drawImage(qr, W - 88, charH - 88, 64, 64); resolve();
       };
       qr.onerror = () => resolve(); qr.src = qrDataUrl;
     });
-    ctx.font = `400 16px ${JP_FONT}`; ctx.fillStyle = 'rgba(180,150,80,0.5)';
-    ctx.textAlign = 'right'; ctx.fillText('seihekilab.com', W - 20, charH - 8);
+    ctx.font = `400 15px ${JP_FONT}`; ctx.fillStyle = 'rgba(180,150,80,0.5)';
+    ctx.textAlign = 'right'; ctx.fillText('seihekilab.com', W - 100, charH - 46);
     ctx.textAlign = 'left';
   }
 
@@ -125,11 +125,11 @@ async function buildShareImage(params: {
   ctx.font = `900 52px ${JP_FONT}`; ctx.fillStyle = '#f0e6d3';
   ctx.fillText(quizType.name, tx, ty + 52); ty += 58 + 8;
 
-  ctx.font = `700 22px ${JP_FONT}`; ctx.fillStyle = quizType.color;
-  ctx.fillText(quizType.tagline, tx, ty + 22); ty += 28 + 20;
+  ctx.font = `700 17px ${JP_FONT}`; ctx.fillStyle = quizType.color;
+  ctx.fillText(quizType.tagline, tx, ty + 17); ty += 22 + 16;
 
-  ctx.font = `400 18px ${JP_FONT}`; ctx.fillStyle = 'rgba(200,180,140,0.65)';
-  ty = wrapText(ctx, quizType.description, tx, ty, W - tx * 2, 28) + 24;
+  ctx.font = `400 15px ${JP_FONT}`; ctx.fillStyle = 'rgba(200,180,140,0.65)';
+  ty = wrapText(ctx, quizType.description, tx, ty, W - tx * 2, 22) + 24;
 
   // 区切り線
   ctx.strokeStyle = 'rgba(180,150,80,0.2)'; ctx.lineWidth = 1;
@@ -141,12 +141,16 @@ async function buildShareImage(params: {
     const meta = AXIS_META[axis];
     const isHigh = pct >= 50;
     const color = isHigh ? meta.colorHigh : meta.colorLow;
-    const label = isHigh ? meta.labelHigh : meta.labelLow;
-    const labelW = 56, barX = tx + labelW + 8, barW = W - tx * 2 - labelW * 2 - 16;
+    const labelW = 60, barX = tx + labelW + 8, barW = W - tx * 2 - labelW * 2 - 16;
 
-    ctx.font = `700 17px ${JP_FONT}`; ctx.fillStyle = 'rgba(200,180,140,0.5)';
-    ctx.textAlign = 'right'; ctx.fillText(meta.labelHigh, tx + labelW, ty + 9);
-    ctx.textAlign = 'left'; ctx.fillText(meta.labelLow, barX + barW + 8, ty + 9);
+    ctx.font = `700 15px ${JP_FONT}`;
+    ctx.textAlign = 'right';
+    ctx.fillStyle = isHigh ? color : 'rgba(200,180,140,0.35)';
+    ctx.fillText(meta.labelHigh, tx + labelW, ty + 9);
+
+    ctx.textAlign = 'left';
+    ctx.fillStyle = !isHigh ? color : 'rgba(200,180,140,0.35)';
+    ctx.fillText(meta.labelLow, barX + barW + 8, ty + 9);
 
     ctx.fillStyle = 'rgba(180,150,80,0.1)';
     roundRect(ctx, barX, ty, barW, 10, 5); ctx.fill();
@@ -156,8 +160,6 @@ async function buildShareImage(params: {
     ctx.fillStyle = color;
     roundRect(ctx, isHigh ? barX + barW / 2 - fillW : barX + barW / 2, ty, fillW, 10, 5); ctx.fill();
 
-    ctx.font = `900 17px ${JP_FONT}`; ctx.fillStyle = color;
-    ctx.textAlign = 'right'; ctx.fillText(label, W - tx, ty + 9);
     ctx.textAlign = 'left'; ty += 32;
   }
 

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -44,7 +44,7 @@ async function buildShareImage(params: {
   textH += descLines * 22; // 説明文 (15px × 22lineH)
   textH += 24;  // gap + 区切り線
   textH += 20;  // 区切り線後gap
-  textH += axes.length * 32; // 軸バー
+  textH += axes.length * 36; // 軸バー
   textH += 36;  // フッター + 下パディング
   const H = textH + 600; // 残り全部がキャラエリア（最低600px）
   const charH = H - textH;
@@ -141,16 +141,21 @@ async function buildShareImage(params: {
     const meta = AXIS_META[axis];
     const isHigh = pct >= 50;
     const color = isHigh ? meta.colorHigh : meta.colorLow;
-    const labelW = 60, barX = tx + labelW + 8, barW = W - tx * 2 - labelW * 2 - 16;
+    let degreeLabel: string;
+    if (pct >= 80)      degreeLabel = meta.degreesHigh[0];
+    else if (pct >= 60) degreeLabel = meta.degreesHigh[1];
+    else if (pct >= 40) degreeLabel = 'ニュートラル';
+    else if (pct >= 20) degreeLabel = meta.degreesLow[1];
+    else                degreeLabel = meta.degreesLow[0];
 
-    ctx.font = `700 15px ${JP_FONT}`;
+    // 左: 軸ラベル(高側)  中: バー  右: 度合いバッジ
+    const axisLabelW = 52, degreeW = 110;
+    const barX = tx + axisLabelW + 8, barW = W - tx * 2 - axisLabelW - degreeW - 16;
+
+    ctx.font = `700 14px ${JP_FONT}`;
     ctx.textAlign = 'right';
-    ctx.fillStyle = isHigh ? color : 'rgba(200,180,140,0.35)';
-    ctx.fillText(meta.labelHigh, tx + labelW, ty + 9);
-
-    ctx.textAlign = 'left';
-    ctx.fillStyle = !isHigh ? color : 'rgba(200,180,140,0.35)';
-    ctx.fillText(meta.labelLow, barX + barW + 8, ty + 9);
+    ctx.fillStyle = 'rgba(200,180,140,0.4)';
+    ctx.fillText(meta.labelHigh, tx + axisLabelW, ty + 9);
 
     ctx.fillStyle = 'rgba(180,150,80,0.1)';
     roundRect(ctx, barX, ty, barW, 10, 5); ctx.fill();
@@ -160,7 +165,18 @@ async function buildShareImage(params: {
     ctx.fillStyle = color;
     roundRect(ctx, isHigh ? barX + barW / 2 - fillW : barX + barW / 2, ty, fillW, 10, 5); ctx.fill();
 
-    ctx.textAlign = 'left'; ty += 32;
+    // 度合いバッジ（バー右）
+    const badgeX = barX + barW + 8;
+    const badgeH = 20, badgeY = ty - 5;
+    ctx.font = `700 12px ${JP_FONT}`;
+    ctx.fillStyle = color + '28';
+    roundRect(ctx, badgeX, badgeY, degreeW - 8, badgeH, 10); ctx.fill();
+    ctx.strokeStyle = color + '66'; ctx.lineWidth = 1;
+    roundRect(ctx, badgeX, badgeY, degreeW - 8, badgeH, 10); ctx.stroke();
+    ctx.fillStyle = color;
+    ctx.textAlign = 'center'; ctx.fillText(degreeLabel, badgeX + (degreeW - 8) / 2, badgeY + 13);
+
+    ctx.textAlign = 'left'; ty += 36;
   }
 
   // フッター


### PR DESCRIPTION
## 変更内容

### fix: シェア画像のキャラ空白問題を根本修正
従来の「事前fetchしてimgのsrcにセット → DOMロード待ち」では、DOMへの反映タイミングが保証できずモバイルで依然空白になっていた。

`html-to-image` の `onclone` コールバックを使い、**キャプチャ用クローン生成直後・描画前** に `img.src` をデータURLで直接書き換えることで、ネットワーク遅延やDOM反映タイミングに依存しない確実な方法に変更。

### fix: シェア時のテキスト削除
`navigator.share` から `title` と `text` を削除し、画像ファイルのみをシェアするよう変更。

## 対象ファイル
- `frontend/src/app/quiz/result/[type]/ResultContent.tsx`