### PR TITLE
feat/fix: 診断結果シェア画像改善（Canvas化・縦長レイアウト・度合いバッジ・QR）

### DIFF
--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -103,17 +103,20 @@ async function buildShareImage(params: {
   }
   ctx.textAlign = 'left';
 
-  // QRコード + ドメイン（QR左横に並べる）
+  // QRコード + ドメイン（右下に大きめに配置）
   if (qrDataUrl) {
     await new Promise<void>((resolve) => {
       const qr = new window.Image();
       qr.onload = () => {
         ctx.fillStyle = 'white';
-        roundRect(ctx, W - 92, charH - 92, 72, 72, 8); ctx.fill();
-        ctx.drawImage(qr, W - 88, charH - 88, 64, 64); resolve();
+        roundRect(ctx, W - 116, charH - 122, 100, 100, 10); ctx.fill();
+        ctx.drawImage(qr, W - 111, charH - 117, 90, 90); resolve();
       };
       qr.onerror = () => resolve(); qr.src = qrDataUrl;
     });
+    ctx.font = `600 14px ${JP_FONT}`; ctx.fillStyle = 'rgba(180,150,80,0.55)';
+    ctx.textAlign = 'right'; ctx.fillText('seihekilab.com', W - 20, charH - 8);
+    ctx.textAlign = 'left';
   }
 
   // ── テキストエリア（下詰め）──

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -114,9 +114,6 @@ async function buildShareImage(params: {
       };
       qr.onerror = () => resolve(); qr.src = qrDataUrl;
     });
-    ctx.font = `600 14px ${JP_FONT}`; ctx.fillStyle = 'rgba(180,150,80,0.55)';
-    ctx.textAlign = 'right'; ctx.fillText('seihekilab.com', W - 20, charH - 8);
-    ctx.textAlign = 'left';
   }
 
   // ── テキストエリア（下詰め）──


### PR DESCRIPTION
## Summary

- `html-to-image` を廃止し Canvas API 直描画でシェア画像生成をリプレース（モバイルでのキャラ空白問題を根本解消）
- シェア画像を縦長3:4に変更・日本語フォント適用・下余白を除去してキャラエリアを可変高さに
- 軸バーに度合いバッジ（「支配強」「やや奉仕」「ニュートラル」など）を追加
- QRコードを大きくして読み取りやすく改善
- クイズのA/Bエリアをテキスト表示＋中央区切り線に変更し、ドットサイズ付きボタンを明示的なUIに刷新
- 診断結果ページに「相性の良いタイプ」セクションを追加（シェアボタンの上）

## Test plan

- [ ] スマホで診断を完了し結果ページを確認（相性タイプ3件表示）
- [ ] 「画像を保存してシェア」でキャラ画像付き縦長画像が生成される
- [ ] 軸バーに左右ラベル＋度合いバッジが正しく表示される
- [ ] QRコードが読み取れるサイズで表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)