### PR TITLE
[codex] Version quiz share URLs for X cache busting

### DIFF
--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -356,6 +356,7 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
   const [showCTA, setShowCTA] = useState(false);
   const [qrDataUrl, setQrDataUrl] = useState('');
   const [charDataUrl, setCharDataUrl] = useState('');
+  const shareVersion = '2';
 
   useEffect(() => {
     QRCode.toDataURL('https://www.seihekilab.com/quiz', { width: 128, margin: 1, color: { dark: '#000000', light: '#ffffff' } })
@@ -386,9 +387,10 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
 
   const quizType = QUIZ_TYPES[typeKey] ?? QUIZ_TYPES['senc'];
   const scoresParam = searchParams.get('scores') ?? '';
+  const versionParam = searchParams.get('v') ?? shareVersion;
   const shareUrl = scoresParam
-    ? `https://www.seihekilab.com/quiz/result/${typeKey}?scores=${encodeURIComponent(scoresParam)}`
-    : `https://www.seihekilab.com/quiz/result/${typeKey}`;
+    ? `https://www.seihekilab.com/quiz/result/${typeKey}?scores=${encodeURIComponent(scoresParam)}&v=${encodeURIComponent(versionParam)}`
+    : `https://www.seihekilab.com/quiz/result/${typeKey}?v=${encodeURIComponent(versionParam)}`;
   const shareText = `私の偏愛タイプは ${typeKey.toUpperCase()}「${quizType.name}」でした。\n#偏愛16 #性癖ラボ\n\n${shareUrl}`;
 
   const axes: { axis: Axis; pct: number }[] = AXES.map((axis) => ({

--- a/frontend/src/app/quiz/result/[type]/page.tsx
+++ b/frontend/src/app/quiz/result/[type]/page.tsx
@@ -4,10 +4,11 @@ import { ResultContent } from './ResultContent';
 import { QUIZ_TYPES, QuizTypeKey } from '../../data';
 
 const BASE_URL = 'https://www.seihekilab.com';
+const QUIZ_SHARE_VERSION = '2';
 
 export async function generateMetadata({ params, searchParams }: {
   params: Promise<{ type: string }>;
-  searchParams: Promise<{ scores?: string; gender?: string }>;
+  searchParams: Promise<{ scores?: string; gender?: string; v?: string }>;
 }): Promise<Metadata> {
   const { type } = await params;
   const sp = await searchParams;
@@ -16,11 +17,13 @@ export async function generateMetadata({ params, searchParams }: {
 
   const title = `私の偏愛16診断タイプは「${quizType.name}」でした！`;
   const description = `${quizType.tagline} — ${quizType.description.slice(0, 60)}…`;
+  const shareVersion = sp.v || QUIZ_SHARE_VERSION;
 
-  const ogImageUrl = `${BASE_URL}/quiz/og/henai16-${type}-${type.toUpperCase()}.png`;
+  const ogImageUrl = `${BASE_URL}/quiz/og/henai16-${type}-${type.toUpperCase()}.png?v=${shareVersion}`;
   const resultParams = new URLSearchParams();
   if (sp.scores) resultParams.set('scores', sp.scores);
   if (sp.gender) resultParams.set('gender', sp.gender);
+  resultParams.set('v', shareVersion);
   const resultUrl = resultParams.toString()
     ? `${BASE_URL}/quiz/result/${type}?${resultParams.toString()}`
     : `${BASE_URL}/quiz/result/${type}`;


### PR DESCRIPTION
## What changed
- appended `v=2` to quiz result share URLs
- threaded the same `v` parameter into quiz result metadata so `og:url` and `og:image` both change together

## Why
- this is a one-shot fix to force X to treat quiz result shares as a fresh card instead of serving the existing cached preview
- changing only the image URL may not be enough when the page URL itself is already cached by X

## Impact
- shared quiz result URLs now look like `/quiz/result/<type>?...&v=2`
- the quiz OGP image URL also carries `?v=2`
- this keeps the implementation minimal while making the card URL effectively new to the crawler

## Validation
- verified only the result-page metadata and share URL generation files changed
- no automated tests were run for this cache-busting change