### PR TITLE
[codex] Version quiz result URLs and default them to v3

### DIFF
--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -356,7 +356,7 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
   const [showCTA, setShowCTA] = useState(false);
   const [qrDataUrl, setQrDataUrl] = useState('');
   const [charDataUrl, setCharDataUrl] = useState('');
-  const shareVersion = '2';
+  const shareVersion = '3';
 
   useEffect(() => {
     QRCode.toDataURL('https://www.seihekilab.com/quiz', { width: 128, margin: 1, color: { dark: '#000000', light: '#ffffff' } })
@@ -379,6 +379,13 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
 
   const gender = searchParams.get('gender') ?? 'other';
   const isMale = gender === 'male';
+
+  useEffect(() => {
+    if (searchParams.get('v')) return;
+    const nextParams = new URLSearchParams(searchParams.toString());
+    nextParams.set('v', shareVersion);
+    router.replace(`/quiz/result/${typeKey}?${nextParams.toString()}`);
+  }, [router, searchParams, shareVersion, typeKey]);
 
   const rawScores = (() => {
     try { return JSON.parse(decodeURIComponent(searchParams.get('scores') ?? '{}')); }

--- a/frontend/src/app/quiz/result/[type]/page.tsx
+++ b/frontend/src/app/quiz/result/[type]/page.tsx
@@ -4,7 +4,7 @@ import { ResultContent } from './ResultContent';
 import { QUIZ_TYPES, QuizTypeKey } from '../../data';
 
 const BASE_URL = 'https://www.seihekilab.com';
-const QUIZ_SHARE_VERSION = '2';
+const QUIZ_SHARE_VERSION = '3';
 
 export async function generateMetadata({ params, searchParams }: {
   params: Promise<{ type: string }>;


### PR DESCRIPTION
## What changed
- appended a version parameter to quiz result share URLs for X cache busting
- threaded the same version through quiz result metadata so `og:url` and `og:image` change together
- bumped the default version to `v=3`
- when a quiz result page is opened without a `v` query parameter, it now rewrites the URL to include `?v=3`

## Why
- this is a one-shot fix to force X to treat quiz result shares as fresh cards instead of serving the existing cached previews
- changing only the image URL may not be enough when the page URL itself is already cached by X
- making the result page settle on `?v=3` prevents the shared URL from missing the cache-busting parameter

## Impact
- result detail pages now resolve to `/quiz/result/<type>?v=3` when opened without a version
- shared quiz result URLs carry `v=3`
- the quiz OGP image URL also carries the same version parameter

## Validation
- verified only the result-page metadata and result-page client logic changed relative to the OGP asset branch
- no automated tests were run for this cache-busting update