### PR TITLE
[codex] Add quiz OGP assets and default result URLs to v3

### DIFF
--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -356,7 +356,7 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
   const [showCTA, setShowCTA] = useState(false);
   const [qrDataUrl, setQrDataUrl] = useState('');
   const [charDataUrl, setCharDataUrl] = useState('');
-  const shareVersion = '2';
+  const shareVersion = '3';
 
   useEffect(() => {
     QRCode.toDataURL('https://www.seihekilab.com/quiz', { width: 128, margin: 1, color: { dark: '#000000', light: '#ffffff' } })
@@ -379,6 +379,13 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
 
   const gender = searchParams.get('gender') ?? 'other';
   const isMale = gender === 'male';
+
+  useEffect(() => {
+    if (searchParams.get('v')) return;
+    const nextParams = new URLSearchParams(searchParams.toString());
+    nextParams.set('v', shareVersion);
+    router.replace(`/quiz/result/${typeKey}?${nextParams.toString()}`);
+  }, [router, searchParams, shareVersion, typeKey]);
 
   const rawScores = (() => {
     try { return JSON.parse(decodeURIComponent(searchParams.get('scores') ?? '{}')); }

--- a/frontend/src/app/quiz/result/[type]/ResultContent.tsx
+++ b/frontend/src/app/quiz/result/[type]/ResultContent.tsx
@@ -356,6 +356,7 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
   const [showCTA, setShowCTA] = useState(false);
   const [qrDataUrl, setQrDataUrl] = useState('');
   const [charDataUrl, setCharDataUrl] = useState('');
+  const shareVersion = '2';
 
   useEffect(() => {
     QRCode.toDataURL('https://www.seihekilab.com/quiz', { width: 128, margin: 1, color: { dark: '#000000', light: '#ffffff' } })
@@ -386,9 +387,10 @@ export function ResultContent({ typeKey }: { typeKey: QuizTypeKey }) {
 
   const quizType = QUIZ_TYPES[typeKey] ?? QUIZ_TYPES['senc'];
   const scoresParam = searchParams.get('scores') ?? '';
+  const versionParam = searchParams.get('v') ?? shareVersion;
   const shareUrl = scoresParam
-    ? `https://www.seihekilab.com/quiz/result/${typeKey}?scores=${encodeURIComponent(scoresParam)}`
-    : `https://www.seihekilab.com/quiz/result/${typeKey}`;
+    ? `https://www.seihekilab.com/quiz/result/${typeKey}?scores=${encodeURIComponent(scoresParam)}&v=${encodeURIComponent(versionParam)}`
+    : `https://www.seihekilab.com/quiz/result/${typeKey}?v=${encodeURIComponent(versionParam)}`;
   const shareText = `私の偏愛タイプは ${typeKey.toUpperCase()}「${quizType.name}」でした。\n#偏愛16 #性癖ラボ\n\n${shareUrl}`;
 
   const axes: { axis: Axis; pct: number }[] = AXES.map((axis) => ({

--- a/frontend/src/app/quiz/result/[type]/page.tsx
+++ b/frontend/src/app/quiz/result/[type]/page.tsx
@@ -4,10 +4,11 @@ import { ResultContent } from './ResultContent';
 import { QUIZ_TYPES, QuizTypeKey } from '../../data';
 
 const BASE_URL = 'https://www.seihekilab.com';
+const QUIZ_SHARE_VERSION = '2';
 
 export async function generateMetadata({ params, searchParams }: {
   params: Promise<{ type: string }>;
-  searchParams: Promise<{ scores?: string; gender?: string }>;
+  searchParams: Promise<{ scores?: string; gender?: string; v?: string }>;
 }): Promise<Metadata> {
   const { type } = await params;
   const sp = await searchParams;
@@ -16,11 +17,13 @@ export async function generateMetadata({ params, searchParams }: {
 
   const title = `私の偏愛16診断タイプは「${quizType.name}」でした！`;
   const description = `${quizType.tagline} — ${quizType.description.slice(0, 60)}…`;
+  const shareVersion = sp.v || QUIZ_SHARE_VERSION;
 
-  const ogImageUrl = `${BASE_URL}/quiz/og/henai16-${type}-${type.toUpperCase()}.png`;
+  const ogImageUrl = `${BASE_URL}/quiz/og/henai16-${type}-${type.toUpperCase()}.png?v=${shareVersion}`;
   const resultParams = new URLSearchParams();
   if (sp.scores) resultParams.set('scores', sp.scores);
   if (sp.gender) resultParams.set('gender', sp.gender);
+  resultParams.set('v', shareVersion);
   const resultUrl = resultParams.toString()
     ? `${BASE_URL}/quiz/result/${type}?${resultParams.toString()}`
     : `${BASE_URL}/quiz/result/${type}`;

--- a/frontend/src/app/quiz/result/[type]/page.tsx
+++ b/frontend/src/app/quiz/result/[type]/page.tsx
@@ -4,7 +4,7 @@ import { ResultContent } from './ResultContent';
 import { QUIZ_TYPES, QuizTypeKey } from '../../data';
 
 const BASE_URL = 'https://www.seihekilab.com';
-const QUIZ_SHARE_VERSION = '2';
+const QUIZ_SHARE_VERSION = '3';
 
 export async function generateMetadata({ params, searchParams }: {
   params: Promise<{ type: string }>;


### PR DESCRIPTION
## What changed
- switched quiz result metadata to use dedicated static OGP images under `public/quiz/og`
- added 16 quiz result OGP PNG assets for each personality type
- appended a version parameter to quiz result share URLs for X cache busting
- threaded the same version through quiz result metadata so `og:url` and `og:image` change together
- bumped the default version to `v=3`
- when a quiz result page is opened without a `v` query parameter, it now rewrites the URL to include `?v=3`

## Why
- X share previews were intermittently failing to show for quiz result pages
- the original result-page sharing setup relied on less suitable assets and cache-unfriendly URLs
- changing only the image URL may not be enough when the page URL itself is already cached by X
- making the result page settle on `?v=3` prevents the shared URL from missing the cache-busting parameter

## Impact
- each quiz result page now points `og:image` and `twitter:image` to `/quiz/og/henai16-<type>-<TYPE>.png?v=3`
- result detail pages now resolve to `/quiz/result/<type>?v=3` when opened without a version
- shared quiz result URLs carry `v=3`
- X shares should use purpose-built wide images instead of the base character art

## Validation
- verified locally that `/quiz/result/spnw` returns metadata with `og:url` ending in `?v=3`
- verified locally that `og:image` resolves to the dedicated `public/quiz/og` asset with `?v=3`
- no automated tests were run for this asset and metadata change