### PR TITLE
fix: リモート専用マイグレーションのスタブファイルを追加

### DIFF
--- a/supabase/migrations/20260517020453_remote_only_stub.sql
+++ b/supabase/migrations/20260517020453_remote_only_stub.sql
@@ -1,0 +1,2 @@
+-- This migration was applied directly to the remote database via Supabase dashboard.
+-- Its effects are reverted by 20260517200000_revert_books_to_videos.sql.

--- a/supabase/migrations/20260517020512_remote_only_stub.sql
+++ b/supabase/migrations/20260517020512_remote_only_stub.sql
@@ -1,0 +1,2 @@
+-- This migration was applied directly to the remote database via Supabase dashboard.
+-- Its effects are reverted by 20260517200000_revert_books_to_videos.sql.

--- a/supabase/migrations/20260517020530_remote_only_stub.sql
+++ b/supabase/migrations/20260517020530_remote_only_stub.sql
@@ -1,0 +1,2 @@
+-- This migration was applied directly to the remote database via Supabase dashboard.
+-- Its effects are reverted by 20260517200000_revert_books_to_videos.sql.

--- a/supabase/migrations/20260517111741_remote_only_stub.sql
+++ b/supabase/migrations/20260517111741_remote_only_stub.sql
@@ -1,0 +1,2 @@
+-- This migration was applied directly to the remote database via Supabase dashboard.
+-- Its effects are reverted by 20260517200000_revert_books_to_videos.sql.


### PR DESCRIPTION
## Summary
- `20260517020453`, `20260517020512`, `20260517020530`, `20260517111741` の4つのマイグレーションがリモートDBに直接適用されておりローカルに存在しない
- `supabase db push` が "Remote migration versions not found in local migrations directory" エラーを出し続ける
- 各IDに対してコメントのみのスタブSQLファイルを追加して解消する
- スタブはリモートに既に適用済みなので再実行されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)