### PR TITLE
fix: ingest対象からFANZA同人を除外

### DIFF
--- a/scripts/ingest_fanza/index.ts
+++ b/scripts/ingest_fanza/index.ts
@@ -557,8 +557,7 @@ async function main() {
   console.log(`Fetching videos released between ${gteReleaseDate} and ${lteReleaseDate}...`);
 
   const sources = [
-    { service: 'digital', floor: 'videoa',         source: 'FANZA' },
-    { service: 'doujin',  floor: 'digital_doujin', source: 'FANZA_DOUJIN' },
+    { service: 'digital', floor: 'videoa', source: 'FANZA' },
   ];
 
   let totalSuccess = 0;


### PR DESCRIPTION
FANZA_DOUJIN (doujin/digital_doujin) を ingest 対象から削除。videoa のみを対象とする。