### PR TITLE
feat: FANZAアニメ動画をingest対象に追加

### DIFF
--- a/scripts/ingest_fanza/index.ts
+++ b/scripts/ingest_fanza/index.ts
@@ -558,6 +558,7 @@ async function main() {
 
   const sources = [
     { service: 'digital', floor: 'videoa', source: 'FANZA' },
+    { service: 'digital', floor: 'anime',  source: 'FANZA_ANIME' },
   ];
 
   let totalSuccess = 0;


### PR DESCRIPTION
## Summary
- `scripts/ingest_fanza/index.ts` の sources に `digital/anime` (FANZA_ANIME) を追加

## Test plan
- [ ] GHA ingest_fanza 実行後、`videos` テーブルに `source = 'FANZA_ANIME'` のレコードが追加されることを確認