### PR TITLE
feat: FANZAランキングを週次取得してpopularityフォールバックに使用

### DIFF
--- a/.github/workflows/apprelease-release.yml
+++ b/.github/workflows/apprelease-release.yml
@@ -33,6 +33,13 @@ jobs:
         run: |
           supabase link --project-ref "$SUPABASE_PROJECT_ID" --password "$SUPABASE_DB_PASSWORD"
 
+      - name: Repair failed migrations
+        working-directory: supabase
+        run: |
+          for v in 20260517020453 20260517020512 20260517020530 20260517111741 20260518200000; do
+            supabase migration repair --status reverted "$v" || true
+          done
+
       - name: Push migrations
         working-directory: supabase
         run: supabase db push --include-all

--- a/.github/workflows/ml-refresh-fanza-ranking.yml
+++ b/.github/workflows/ml-refresh-fanza-ranking.yml
@@ -1,0 +1,35 @@
+name: "[ML] Refresh FANZA Rankings"
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'  # 毎週月曜 2:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  refresh-rankings:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ranking update
+        run: bash scripts/ingest_fanza/run.sh
+        env:
+          RANKING_ONLY: 'true'
+          FANZA_API_ID: ${{ secrets.FANZA_API_ID }}
+          FANZA_AFFILIATE_ID: ${{ secrets.FANZA_AFFILIATE_ID }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+      - name: Notify Discord
+        if: always()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -z "$DISCORD_WEBHOOK_URL" ] && exit 0
+          if [ "$JOB_STATUS" = "success" ]; then ICON="✅"; else ICON="❌"; fi
+          curl -fsSL -X POST -H "Content-Type: application/json" \
+            -d "{\"content\":\"${ICON} FANZA Rankings refresh: ${JOB_STATUS} <${RUN_URL}>\"}" \
+            "$DISCORD_WEBHOOK_URL"

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -298,7 +298,7 @@ function GridPage() {
             }}
           >
             {/* サムネイル */}
-            <div className="w-full bg-black relative">
+            <div className="w-full bg-black relative group">
               <img
                 src={(video.thumbnail_vertical_url?.replace('ps.jpg', 'pl.jpg')) || video.thumbnail_url || ''}
                 alt={video.title ?? ''}
@@ -306,12 +306,6 @@ function GridPage() {
                 loading="lazy"
                 onLoad={() => setLoadedIds((prev) => new Set([...prev, video.id]))}
               />
-              {/* 再生アイコン */}
-              <div className="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-100 transition-opacity bg-black/30">
-                <div className="w-10 h-10 rounded-full bg-white/20 backdrop-blur-sm flex items-center justify-center border border-white/40">
-                  <Play size={18} className="text-white ml-0.5" fill="white" />
-                </div>
-              </div>
               {/* 既読オーバーレイ（いいね済みでない場合のみ） */}
               {viewedIds.has(video.id) && !likedIds.has(video.id) && (
                 <div className="absolute inset-0 bg-black/60 pointer-events-none" />
@@ -320,16 +314,30 @@ function GridPage() {
               {likedIds.has(video.id) && (
                 <div className="absolute inset-0 bg-pink-500/40 pointer-events-none" />
               )}
-              {/* いいね済みバッジ */}
-              {likedIds.has(video.id) && (
-                <div className="absolute top-1.5 right-1.5 w-6 h-6 rounded-full bg-pink-500 flex items-center justify-center shadow-lg">
-                  <Heart size={12} className="text-white" fill="white" />
+              {/* 常時表示: 下部グラデーション + アクションヒント */}
+              <div className="absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-black/70 to-transparent pointer-events-none" />
+              {/* 再生ボタン（常時・薄め） */}
+              <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                <div className="w-9 h-9 rounded-full bg-black/25 flex items-center justify-center group-hover:bg-black/50 transition-colors">
+                  <Play size={16} className="text-white/50 group-hover:text-white/90 ml-0.5 transition-colors" fill="currentColor" />
                 </div>
-              )}
-              {/* 既読バッジ（いいね済みでない場合のみ） */}
+              </div>
+              {/* いいねボタン（常時・右下） */}
+              <button
+                className={`absolute bottom-1.5 right-1.5 w-7 h-7 rounded-full flex items-center justify-center transition-colors shadow-md ${
+                  likedIds.has(video.id)
+                    ? 'bg-pink-500'
+                    : 'bg-black/40 hover:bg-pink-500/80'
+                }`}
+                onClick={(e) => { e.stopPropagation(); handleLike(video); }}
+                aria-label="いいね"
+              >
+                <Heart size={13} className="text-white" fill={likedIds.has(video.id) ? 'white' : 'none'} strokeWidth={2} />
+              </button>
+              {/* 既読バッジ（いいね済みでない場合のみ・左上） */}
               {viewedIds.has(video.id) && !likedIds.has(video.id) && (
-                <div className="absolute top-1.5 right-1.5 w-6 h-6 rounded-full bg-black/60 border border-white/20 flex items-center justify-center">
-                  <Eye size={11} className="text-white/70" />
+                <div className="absolute top-1.5 left-1.5 w-5 h-5 rounded-full bg-black/60 border border-white/20 flex items-center justify-center pointer-events-none">
+                  <Eye size={10} className="text-white/70" />
                 </div>
               )}
               {/* デバッグバッジ */}

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -22,6 +22,7 @@ type VideoItem = {
 };
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 const FANZA_AFFILIATE_ID = process.env.NEXT_PUBLIC_FANZA_AFFILIATE_ID ?? 'yotadata2-001';
 const EMBED_USER_INTERVAL = 10; // N回いいねするたびにembed-userを呼ぶ
 
@@ -71,10 +72,13 @@ function GridPage() {
     setLoading(true);
     try {
       const { data: { session } } = await supabase.auth.getSession();
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (session?.access_token) {
-        headers['Authorization'] = `Bearer ${session.access_token}`;
-      }
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'apikey': SUPABASE_ANON_KEY,
+        'Authorization': session?.access_token
+          ? `Bearer ${session.access_token}`
+          : `Bearer ${SUPABASE_ANON_KEY}`,
+      };
       const res = await fetch(`${SUPABASE_URL}/functions/v1/videos-grid`, {
         method: 'POST',
         headers,

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -316,10 +316,10 @@ function GridPage() {
               )}
               {/* 常時表示: 下部グラデーション + アクションヒント */}
               <div className="absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-black/70 to-transparent pointer-events-none" />
-              {/* 再生ボタン（常時・薄め） */}
+              {/* 再生ボタン（モバイル: 常時表示、PC: hover時のみ） */}
               <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                <div className="w-9 h-9 rounded-full bg-black/25 flex items-center justify-center group-hover:bg-black/50 transition-colors">
-                  <Play size={16} className="text-white/50 group-hover:text-white/90 ml-0.5 transition-colors" fill="currentColor" />
+                <div className="w-9 h-9 rounded-full bg-black/30 flex items-center justify-center sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                  <Play size={16} className="text-white/80 ml-0.5" fill="currentColor" />
                 </div>
               </div>
               {/* いいねボタン（常時・右下） */}

--- a/frontend/src/components/BrowseTabBar.tsx
+++ b/frontend/src/components/BrowseTabBar.tsx
@@ -185,7 +185,7 @@ function BrowseTabBarInner() {
             {lv && (
               <div
                 className="flex items-center gap-1 px-2 py-0.5 rounded-full border bg-[#0d1117]/80"
-                style={{ borderColor: lv.borderColor, boxShadow: `0 0 8px 1px ${lv.borderColor}` }}
+                style={{ borderColor: lv.borderColor }}
               >
                 <lv.Icon size={12} className={lv.iconColor} strokeWidth={2} />
                 <span className={`text-[10px] font-extrabold bg-gradient-to-r ${lv.color} bg-clip-text text-transparent whitespace-nowrap`}>

--- a/frontend/src/components/auth/AuthModal.tsx
+++ b/frontend/src/components/auth/AuthModal.tsx
@@ -17,23 +17,23 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialTab = 'lo
   return (
     <Dialog as="div" className="relative z-50" open={isOpen} onClose={onClose}>
       {/* Backdrop */}
-      <div className="fixed inset-0 bg-black/50 backdrop-blur-sm" aria-hidden="true" />
+      <div className="fixed inset-0 bg-black/70 backdrop-blur-sm" aria-hidden="true" />
 
       {/* Modal Content */}
       <div className="fixed inset-0 flex items-center justify-center p-4">
-                  <Dialog.Panel className="w-full max-w-md rounded-2xl bg-white p-8 shadow-2xl">
-            <button onClick={onClose} className='absolute top-4 right-4 text-gray-600 hover:text-gray-900 transition-colors'>
+                  <Dialog.Panel className="w-full max-w-md rounded-2xl bg-[#0d1117] border border-[#30363d] p-8 shadow-2xl">
+            <button onClick={onClose} className='absolute top-4 right-4 text-[#8b949e] hover:text-[#e6edf3] transition-colors'>
               <X size={24} />
             </button>
             <Tab.Group defaultIndex={initialTab === 'register' ? 1 : 0}>
-              <Tab.List className="flex space-x-1 rounded-xl bg-gray-100 p-1 mb-6">
+              <Tab.List className="flex space-x-1 rounded-xl bg-[#161b22] p-1 mb-6">
                 {['ログイン', '新規登録'].map((tab) => (
                   <Tab as={Fragment} key={tab}>
                     {({ selected }) => (
                       <button
                         className={`w-full rounded-lg py-2.5 text-sm font-bold leading-5 transition-all duration-300 focus:outline-none ${selected
-                            ? 'bg-white shadow-md text-gray-900'
-                            : 'text-gray-600 hover:bg-gray-200'
+                            ? 'bg-violet-600 text-white'
+                            : 'text-[#8b949e] hover:bg-[#30363d]'
                           }`}
                       >
                         {tab}
@@ -48,7 +48,7 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialTab = 'lo
                 </Tab.Panel>
                 <Tab.Panel className="focus:outline-none">
                   {registerNotice ? (
-                    <div className="mb-4 p-3 rounded-lg bg-amber-50 text-amber-700 text-xs leading-relaxed">
+                    <div className="mb-4 p-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-300 text-xs leading-relaxed">
                       {registerNotice}
                     </div>
                   ) : null}

--- a/frontend/src/components/auth/Input.tsx
+++ b/frontend/src/components/auth/Input.tsx
@@ -9,14 +9,14 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
 const Input = forwardRef<HTMLInputElement, InputProps>(({ label, id, ...props }, ref) => {
   return (
     <div>
-      <label htmlFor={id} className="block text-sm font-medium text-gray-700 mb-1">
+      <label htmlFor={id} className="block text-sm font-medium text-[#8b949e] mb-1">
         {label}
       </label>
       <input
         id={id}
         ref={ref}
         {...props}
-        className="w-full px-4 py-2.5 bg-gray-100 rounded-lg border border-gray-300 text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-300"
+        className="w-full px-4 py-2.5 bg-[#161b22] rounded-lg border border-[#30363d] text-[#e6edf3] placeholder-[#484f58] focus:outline-none focus:ring-0 focus:border-violet-500 transition-all duration-300"
       />
     </div>
   );

--- a/frontend/src/components/auth/LoginForm.tsx
+++ b/frontend/src/components/auth/LoginForm.tsx
@@ -74,7 +74,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onClose }) => {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       {message && (
-        <div className={'p-3 rounded-lg text-sm bg-red-100 text-red-800'}>
+        <div className={'p-3 rounded-lg text-sm bg-red-500/10 border border-red-500/30 text-red-400'}>
           {message.text}
         </div>
       )}
@@ -87,7 +87,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onClose }) => {
           required: 'ユーザーIDは必須です',
         })}
       />
-      {errors.username && <p className="text-red-500 text-xs mt-1">{errors.username.message}</p>}
+      {errors.username && <p className="text-red-400 text-xs mt-1">{errors.username.message}</p>}
 
       <Input
         id="password"
@@ -98,19 +98,15 @@ const LoginForm: React.FC<LoginFormProps> = ({ onClose }) => {
           required: 'パスワードは必須です',
         })}
       />
-      {errors.password && <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>}
+      {errors.password && <p className="text-red-400 text-xs mt-1">{errors.password.message}</p>}
 
-      <div className={`rounded-full bg-gradient-to-r ${CTA_GRADIENT_CLASS} p-[2px]`}>
-        <button
-          type="submit"
-          className="w-full py-3 px-4 font-bold rounded-full transition-all duration-300 shadow-sm hover:shadow-md disabled:opacity-60 disabled:cursor-not-allowed bg-white hover:bg-gradient-to-r hover:from-[#ADB4E3]/15 hover:via-[#F7BECE]/15 hover:to-[#F9B1C4]/15"
-          disabled={isLoading}
-        >
-          <span className={`bg-gradient-to-r ${CTA_GRADIENT_CLASS} bg-clip-text text-transparent`}>
-            {isLoading ? 'ログイン中...' : 'ログイン'}
-          </span>
-        </button>
-      </div>
+      <button
+        type="submit"
+        className="w-full py-3 px-4 font-bold rounded-lg transition-colors bg-violet-600 hover:bg-violet-500 text-white disabled:opacity-60 disabled:cursor-not-allowed"
+        disabled={isLoading}
+      >
+        {isLoading ? 'ログイン中...' : 'ログイン'}
+      </button>
     </form>
   );
 };

--- a/frontend/src/components/auth/RegisterForm.tsx
+++ b/frontend/src/components/auth/RegisterForm.tsx
@@ -81,7 +81,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onClose }) => {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       {message && (
-        <div className={'p-3 rounded-lg text-sm bg-red-100 text-red-800'}>
+        <div className={'p-3 rounded-lg text-sm bg-red-500/10 border border-red-500/30 text-red-400'}>
           {message.text}
         </div>
       )}
@@ -100,8 +100,8 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onClose }) => {
             },
           })}
         />
-        {errors.username && <p className="text-red-500 text-xs">{errors.username.message}</p>}
-        <p className="text-[11px] text-gray-500">※3文字以上、英数字とアンダーバーのみ／小文字に置き換えて管理します</p>
+        {errors.username && <p className="text-red-400 text-xs">{errors.username.message}</p>}
+        <p className="text-[11px] text-[#8b949e]">※3文字以上、英数字とアンダーバーのみ／小文字に置き換えて管理します</p>
       </div>
 
       <Input
@@ -114,7 +114,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onClose }) => {
           maxLength: { value: 30, message: '30文字以内で入力してください' },
         })}
       />
-      {errors.displayName && <p className="text-red-500 text-xs mt-1">{errors.displayName.message}</p>}
+      {errors.displayName && <p className="text-red-400 text-xs mt-1">{errors.displayName.message}</p>}
 
       <div className="space-y-2">
         <Input
@@ -127,7 +127,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onClose }) => {
             minLength: { value: 8, message: 'パスワードは8文字以上です' },
           })}
         />
-        {errors.password && <p className="text-red-500 text-xs mt-1">{errors.password.message}</p>}
+        {errors.password && <p className="text-red-400 text-xs mt-1">{errors.password.message}</p>}
 
         <Input
           id="confirmPassword"
@@ -139,39 +139,35 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onClose }) => {
             validate: (value) => value === password || 'パスワードが一致しません',
           })}
         />
-        {errors.confirmPassword && <p className="text-red-500 text-xs mt-1">{errors.confirmPassword.message}</p>}
+        {errors.confirmPassword && <p className="text-red-400 text-xs mt-1">{errors.confirmPassword.message}</p>}
       </div>
 
-      <div className="space-y-2 text-sm text-gray-700">
+      <div className="space-y-2 text-sm text-[#e6edf3]">
         <label className="flex items-start gap-2">
           <input
             type="checkbox"
-            className="mt-1 h-4 w-4 rounded border-gray-300 text-rose-500 focus:ring-rose-400"
+            className="mt-1 h-4 w-4 rounded border-[#30363d] bg-[#161b22] accent-violet-600 focus:ring-violet-500"
             {...register('isAdult', { required: '18歳以上のみ登録できます' })}
           />
           <span>私は18歳以上です。</span>
         </label>
-        {errors.isAdult && <p className="text-red-500 text-xs">{errors.isAdult.message}</p>}
-        <p className="text-xs text-gray-500">
+        {errors.isAdult && <p className="text-red-400 text-xs">{errors.isAdult.message}</p>}
+        <p className="text-xs text-[#8b949e]">
           利用規約は{' '}
-          <button type="button" onClick={() => setIsTermsOpen(true)} className="text-rose-500 underline">
+          <button type="button" onClick={() => setIsTermsOpen(true)} className="text-violet-400 underline">
             こちら
           </button>
           {' '}から確認できます。
         </p>
       </div>
 
-      <div className={`rounded-full bg-gradient-to-r ${CTA_GRADIENT_CLASS} p-[2px]`}>
-        <button
-          type="submit"
-          className="w-full py-3 px-4 font-bold rounded-full transition-all duration-300 shadow-sm hover:shadow-md disabled:opacity-60 disabled:cursor-not-allowed bg-white hover:bg-gradient-to-r hover:from-[#ADB4E3]/15 hover:via-[#F7BECE]/15 hover:to-[#F9B1C4]/15"
-          disabled={isLoading}
-        >
-          <span className={`bg-gradient-to-r ${CTA_GRADIENT_CLASS} bg-clip-text text-transparent`}>
-            {isLoading ? '登録中...' : '利用規約に同意して登録'}
-          </span>
-        </button>
-      </div>
+      <button
+        type="submit"
+        className="w-full py-3 px-4 font-bold rounded-lg transition-colors bg-violet-600 hover:bg-violet-500 text-white disabled:opacity-60 disabled:cursor-not-allowed"
+        disabled={isLoading}
+      >
+        {isLoading ? '登録中...' : '利用規約に同意して登録'}
+      </button>
 
       <TermsModal open={isTermsOpen} onClose={() => setIsTermsOpen(false)} />
     </form>

--- a/scripts/ingest_fanza/index.ts
+++ b/scripts/ingest_fanza/index.ts
@@ -533,6 +533,40 @@ async function ingestSource(
   return { success: successCount, failure: failureCount, fetched: fetchedCount };
 }
 
+async function updateRankings() {
+  console.log('[ingest_fanza] === Starting ranking update ===');
+  const rankingSources = [
+    { service: 'digital', floor: 'videoa' },
+    { service: 'digital', floor: 'anime' },
+  ];
+  const hits = 100;
+  const maxRank = 500;
+
+  for (const { service, floor } of rankingSources) {
+    console.log(`\n[ingest_fanza] Fetching rankings: ${service}/${floor}`);
+    let rank = 1;
+
+    for (let offset = 1; offset <= maxRank; offset += hits) {
+      const result = await fetchFanzaApiItems({ hits, offset, sort: 'rank' }, service, floor);
+      if (!result?.items?.length) break;
+
+      for (const item of result.items) {
+        if (!item.content_id) { rank++; continue; }
+        const { error } = await supabase
+          .from('videos')
+          .update({ fanza_rank: rank, fanza_rank_updated_at: new Date().toISOString() })
+          .eq('external_id', item.content_id);
+        if (error) {
+          console.warn(`[rank] update failed external_id=${item.content_id}: ${error.message}`);
+        }
+        rank++;
+      }
+    }
+    console.log(`[ingest_fanza] Rankings updated for ${service}/${floor} (${rank - 1} items)`);
+  }
+  console.log('[ingest_fanza] === Ranking update complete ===');
+}
+
 async function main() {
   const today = new Date();
   const formatDate = (date: Date) => date.toISOString().split('T')[0];
@@ -555,6 +589,13 @@ async function main() {
   }
 
   console.log(`Fetching videos released between ${gteReleaseDate} and ${lteReleaseDate}...`);
+
+  // ランキング更新モード
+  const rankingOnly = process.env.RANKING_ONLY === 'true';
+  if (rankingOnly) {
+    await updateRankings();
+    return;
+  }
 
   const sources = [
     { service: 'digital', floor: 'videoa', source: 'FANZA' },

--- a/supabase/migrations/20260518200000_decision_type_surface.sql
+++ b/supabase/migrations/20260518200000_decision_type_surface.sql
@@ -1,13 +1,15 @@
 -- decision_type に surface を含める
 -- like/nope → swipe_like/grid_like/swipe_nope
 
--- 1. 既存データを更新（全て swipe 由来とみなす）
+-- 1. CHECK 制約を先に外す（UPDATE が通るように）
+alter table public.user_video_decisions
+  drop constraint if exists user_video_decisions_decision_type_check;
+
+-- 2. 既存データを更新（全て swipe 由来とみなす）
 update public.user_video_decisions set decision_type = 'swipe_like' where decision_type = 'like';
 update public.user_video_decisions set decision_type = 'swipe_nope' where decision_type = 'nope';
 
--- 2. CHECK 制約を更新
-alter table public.user_video_decisions
-  drop constraint if exists user_video_decisions_decision_type_check;
+-- 3. 新しい CHECK 制約を追加
 alter table public.user_video_decisions
   add constraint user_video_decisions_decision_type_check
   check (decision_type in ('swipe_like', 'swipe_nope', 'grid_like'));

--- a/supabase/migrations/20260518300000_add_fanza_rank.sql
+++ b/supabase/migrations/20260518300000_add_fanza_rank.sql
@@ -1,0 +1,75 @@
+-- FANZA公式ランキング順位を保持するカラム
+ALTER TABLE public.videos
+  ADD COLUMN IF NOT EXISTS fanza_rank int,
+  ADD COLUMN IF NOT EXISTS fanza_rank_updated_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_videos_fanza_rank ON public.videos (fanza_rank ASC NULLS LAST)
+  WHERE fanza_rank IS NOT NULL;
+
+-- get_popular_videos: fanza_rank をフォールバックとして使用
+CREATE OR REPLACE FUNCTION public.get_popular_videos(
+  user_uuid uuid DEFAULT NULL,
+  limit_count int DEFAULT 20,
+  lookback_days int DEFAULT 7
+)
+RETURNS TABLE (
+  id uuid, title text, description text, external_id text,
+  thumbnail_url text, thumbnail_vertical_url text,
+  sample_video_url text, product_url text,
+  product_released_at timestamptz,
+  performers jsonb, tags jsonb,
+  score double precision
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH user_likes AS (
+    SELECT vpd.video_id, SUM(vpd.likes)::double precision AS total_likes
+    FROM public.video_popularity_daily vpd
+    WHERE vpd.d >= (NOW() - make_interval(days => lookback_days))
+    GROUP BY vpd.video_id
+  ),
+  ranked AS (
+    SELECT
+      v.id,
+      COALESCE(ul.total_likes, 0) AS like_score,
+      -- fanza_rank は小さいほど良い → スコアに変換（上位500位以内を対象）
+      CASE WHEN v.fanza_rank IS NOT NULL AND v.fanza_rank <= 500
+        THEN (501 - v.fanza_rank)::double precision / 500.0
+        ELSE 0
+      END AS rank_score
+    FROM public.videos v
+    LEFT JOIN user_likes ul ON ul.video_id = v.id
+    WHERE v.sample_video_url IS NOT NULL
+      AND (user_uuid IS NULL OR NOT EXISTS (
+        SELECT 1 FROM public.user_video_decisions uvd
+        WHERE uvd.user_id = user_uuid AND uvd.video_id = v.id
+      ))
+  )
+  SELECT
+    v.id, v.title, v.description, v.external_id,
+    v.thumbnail_url, v.thumbnail_vertical_url, v.sample_video_url,
+    COALESCE(v.affiliate_url, v.product_url) AS product_url,
+    v.product_released_at,
+    COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('id', p.id, 'name', p.name) ORDER BY p.name)
+      FROM public.video_performers vp JOIN public.performers p ON p.id = vp.performer_id
+      WHERE vp.video_id = v.id
+    ), '[]'::jsonb) AS performers,
+    COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('id', t.id, 'name', t.name) ORDER BY t.name)
+      FROM public.video_tags vt JOIN public.tags t ON t.id = vt.tag_id
+      LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
+      WHERE vt.video_id = v.id AND COALESCE(tg.show_in_ui, TRUE)
+    ), '[]'::jsonb) AS tags,
+    -- like_score がなければ rank_score で代替
+    CASE WHEN r.like_score > 0 THEN r.like_score ELSE r.rank_score END AS score
+  FROM ranked r
+  JOIN public.videos v ON v.id = r.id
+  ORDER BY score DESC NULLS LAST, v.product_released_at DESC
+  LIMIT limit_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_popular_videos(uuid, int, int) TO anon, authenticated;


### PR DESCRIPTION
## Summary
- `videos.fanza_rank` カラムを追加（FANZA公式の人気順位）
- `ingest_fanza` に `RANKING_ONLY=true` モードを追加（sort=rank で上位500件のランクを更新）
- `get_popular_videos` を修正: user_video_decisions によるいいね数がない初期状態では `fanza_rank` をスコアとして使用
- GHA ワークフロー `ml-refresh-fanza-ranking.yml` を追加（毎週月曜 2:00 UTC）

## 動作
- いいね数がある場合: 従来通りいいね数をスコアに使用
- いいね数がない（初期状態）: fanza_rank を 0〜1 に正規化してスコアとして代用