### PR TITLE
fix: swipe_like の型比較エラーを修正

### DIFF
--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -513,7 +513,7 @@ export default function Home() {
       }
     }
 
-    if (decisionType === 'like') {
+    if (decisionType === 'swipe_like') {
       window.dispatchEvent(new Event('like-added'));
     }
     emitDecisionEvents(card, decisionType);


### PR DESCRIPTION
swipe/page.tsx の decisionType 比較が 'like' のままだったのを 'swipe_like' に修正