### PR TITLE
fix: gen_video_embeddings FeatureSpace でfloat混在時のTypeError修正

### DIFF
--- a/.github/workflows/ml-refresh-fanza-ranking.yml
+++ b/.github/workflows/ml-refresh-fanza-ranking.yml
@@ -9,17 +9,29 @@ jobs:
   refresh-rankings:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      FANZA_API_ID: ${{ secrets.FANZA_API_ID }}
+      FANZA_API_AFFILIATE_ID: ${{ secrets.FANZA_API_AFFILIATE_ID }}
+      FANZA_LINK_AFFILIATE_ID: ${{ secrets.FANZA_LINK_AFFILIATE_ID }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
     steps:
       - uses: actions/checkout@v4
 
+      - name: Prepare env file
+        run: |
+          mkdir -p docker/env
+          cat <<EOF > docker/env/prd.ci.env
+          SUPABASE_URL=${SUPABASE_URL}
+          SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
+          FANZA_API_ID=${FANZA_API_ID}
+          FANZA_API_AFFILIATE_ID=${FANZA_API_AFFILIATE_ID:-}
+          FANZA_LINK_AFFILIATE_ID=${FANZA_LINK_AFFILIATE_ID:-}
+          RANKING_ONLY=true
+          EOF
+
       - name: Run ranking update
-        run: bash scripts/ingest_fanza/run.sh
-        env:
-          RANKING_ONLY: 'true'
-          FANZA_API_ID: ${{ secrets.FANZA_API_ID }}
-          FANZA_AFFILIATE_ID: ${{ secrets.FANZA_AFFILIATE_ID }}
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: INGEST_FANZA_ENV_FILE=docker/env/prd.ci.env bash scripts/ingest_fanza/run.sh
 
       - name: Notify Discord
         if: always()

--- a/scripts/gen_video_embeddings/gen_video_embeddings.py
+++ b/scripts/gen_video_embeddings/gen_video_embeddings.py
@@ -135,13 +135,13 @@ class FeatureSpace:
         offset = 0
 
         for field, values in categorical_fields.items():
-            vocab = sorted({v for v in values if v})
+            vocab = sorted({v for v in values if v and isinstance(v, str)})
             self.cat_vocab[field] = {v: i for i, v in enumerate(vocab)}
             self.offsets[field] = (offset, offset + len(vocab))
             offset += len(vocab)
 
         for field, values in multi_fields.items():
-            vocab = sorted({v for v in values if v})
+            vocab = sorted({v for v in values if v and isinstance(v, str)})
             self.multi_vocab[field] = {v: i for i, v in enumerate(vocab)}
             self.multi_offsets[field] = (offset, offset + len(vocab))
             offset += len(vocab)

--- a/scripts/ingest_fanza/run.sh
+++ b/scripts/ingest_fanza/run.sh
@@ -30,6 +30,9 @@ fi
 if [[ "${INGEST_FANZA_DEBUG:-}" != "" ]]; then
   DOCKER_ENV_ARGS+=(--env "INGEST_FANZA_DEBUG=${INGEST_FANZA_DEBUG}")
 fi
+if [[ "${RANKING_ONLY:-}" != "" ]]; then
+  DOCKER_ENV_ARGS+=(--env "RANKING_ONLY=${RANKING_ONLY}")
+fi
 
 exec docker run "${DOCKER_FLAGS[@]}" \
   --env-file "$ENV_FILE" \


### PR DESCRIPTION
## Summary
- `FeatureSpace.__init__` の vocab 生成時、`maker` や `series` フィールドに NaN (float) が混在すると `sorted()` が `TypeError: '<' not supported between instances of 'float' and 'str'` で落ちていた
- `isinstance(v, str)` チェックを追加して float/NaN を除外
- これにより `ml-sync-video-embeddings` が4月13日から毎日失敗していた問題が修正される → `video_embeddings` が再び更新され、exploitation (レコメンド) が復活する予定

## Test plan
- [ ] PR マージ後、`ml-sync-video-embeddings` を手動 dispatch して成功することを確認
- [ ] `video_embeddings` テーブルに新しいエントリが追加されることを確認
- [ ] swipe ページで exploitation スコアが 0 以上になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)