### PR TITLE
fix: ml-refresh-fanza-ranking env生成・ranking-only修正

### DIFF
--- a/.github/workflows/ml-refresh-fanza-ranking.yml
+++ b/.github/workflows/ml-refresh-fanza-ranking.yml
@@ -22,17 +22,17 @@ jobs:
       - name: Prepare env file
         run: |
           mkdir -p docker/env
-          cat <<EOF > docker/env/prd.ci.env
-          NEXT_PUBLIC_SUPABASE_URL=${SUPABASE_URL}
-          SUPABASE_URL=${SUPABASE_URL}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
-          SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
-          SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
-          FANZA_API_ID=${FANZA_API_ID}
-          FANZA_API_AFFILIATE_ID=${FANZA_API_AFFILIATE_ID:-}
-          FANZA_LINK_AFFILIATE_ID=${FANZA_LINK_AFFILIATE_ID:-}
-          RANKING_ONLY=true
-          EOF
+          {
+            echo "NEXT_PUBLIC_SUPABASE_URL=${SUPABASE_URL}"
+            echo "SUPABASE_URL=${SUPABASE_URL}"
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}"
+            echo "SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}"
+            echo "SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}"
+            echo "FANZA_API_ID=${FANZA_API_ID}"
+            echo "FANZA_API_AFFILIATE_ID=${FANZA_API_AFFILIATE_ID:-}"
+            echo "FANZA_LINK_AFFILIATE_ID=${FANZA_LINK_AFFILIATE_ID:-}"
+            echo "RANKING_ONLY=true"
+          } > docker/env/prd.ci.env
 
       - name: Run ranking update
         run: INGEST_FANZA_ENV_FILE=docker/env/prd.ci.env bash scripts/ingest_fanza/run.sh

--- a/scripts/gen_video_embeddings/gen_video_embeddings.py
+++ b/scripts/gen_video_embeddings/gen_video_embeddings.py
@@ -266,29 +266,30 @@ def fetch_target_videos(
 ) -> pd.DataFrame:
     sql = """
         SELECT
-          b.id,
-          b.source,
-          b.publisher AS maker,
-          b.label,
-          b.series,
-          b.price,
-          b.product_released_at,
-          array_remove(array_agg(DISTINCT bt.tag_id) FILTER (WHERE bt.tag_id IS NOT NULL AND coalesce(tg.use_for_training, true)), NULL) AS tag_ids,
-          ARRAY[b.author_id] FILTER (WHERE b.author_id IS NOT NULL) AS performer_ids,
-          max(be.model_version) AS current_model_version
-        FROM public.books b
-        LEFT JOIN public.book_tags bt ON bt.book_id = b.id
-        LEFT JOIN public.tags t ON t.id = bt.tag_id
+          v.id,
+          v.source,
+          v.maker,
+          v.label,
+          v.series,
+          v.price,
+          v.product_released_at,
+          array_remove(array_agg(DISTINCT vt.tag_id) FILTER (WHERE vt.tag_id IS NOT NULL AND coalesce(tg.use_for_training, true)), NULL) AS tag_ids,
+          array_remove(array_agg(DISTINCT vp.performer_id) FILTER (WHERE vp.performer_id IS NOT NULL), NULL) AS performer_ids,
+          max(ve.model_version) AS current_model_version
+        FROM public.videos v
+        LEFT JOIN public.video_tags vt ON vt.video_id = v.id
+        LEFT JOIN public.tags t ON t.id = vt.tag_id
         LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
-        LEFT JOIN public.book_embeddings be ON be.book_id = b.id
+        LEFT JOIN public.video_performers vp ON vp.video_id = v.id
+        LEFT JOIN public.video_embeddings ve ON ve.video_id = v.id
         WHERE (
             %(include_existing)s
-            OR be.book_id IS NULL
-            OR be.model_version IS NULL
-            OR be.model_version <> %(model_version)s
+            OR ve.video_id IS NULL
+            OR ve.model_version IS NULL
+            OR ve.model_version <> %(model_version)s
         )
-        GROUP BY b.id, b.source, b.publisher, b.label, b.series, b.price, b.product_released_at, b.author_id
-        ORDER BY b.product_released_at DESC NULLS LAST, b.id DESC
+        GROUP BY v.id, v.source, v.maker, v.label, v.series, v.price, v.product_released_at
+        ORDER BY v.product_released_at DESC NULLS LAST, v.id DESC
     """
     params = {
         "include_existing": include_existing,


### PR DESCRIPTION
## Summary
- heredoc インデントにより env ファイルの変数名に先頭スペースが入り「Supabase URL or Anon Key is not set.」が出ていた → `echo` 並列方式に変更
- `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_ANON_KEY` を env ファイルに追加
- `RANKING_ONLY` を Docker コンテナに渡すよう `run.sh` を修正
- `gen_video_embeddings.py` の SQL を `books` → `videos`/`video_performers`/`video_embeddings` テーブルに修正
- `FeatureSpace` vocab 生成で float 混在時の `TypeError` を修正（exploitation 復活）

🤖 Generated with [Claude Code](https://claude.com/claude-code)