### PR TITLE
fix: ml-release-embeddings approvedをboolean型に変更しスキップ問題を修正

### DIFF
--- a/.github/workflows/ml-release-embeddings.yml
+++ b/.github/workflows/ml-release-embeddings.yml
@@ -4,13 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       approved:
-        description: "評価済みか。'yes' で埋め込み反映を実行"
+        description: "評価済みか。true で埋め込み反映を実行"
         required: true
-        default: no
-        type: choice
-        options:
-          - yes
-          - no
+        default: 'false'
+        type: boolean
       run_id:
         description: "任意の識別子（省略時は UTC timestamp）"
         required: false
@@ -27,7 +24,7 @@ jobs:
   release:
     name: Sync Embeddings & Publish
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.approved == 'yes' }}
+    if: ${{ github.event.inputs.approved == 'true' }}
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}


### PR DESCRIPTION
## Summary
- `approved` の input type が `choice (yes/no)` だったが UI では `true/false` (boolean) として表示されていた
- `if: approved == 'yes'` が永遠に満たされず job がスキップされていた
- `type: boolean` に変更し、条件を `approved == 'true'` に修正

## Test plan
- [ ] `approved: true` にチェックして Run workflow → job がスキップされず実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)