### PR TITLE
fix: migration repair リストに 20260518300000 を追加

### DIFF
--- a/.github/workflows/apprelease-release.yml
+++ b/.github/workflows/apprelease-release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Repair failed migrations
         working-directory: supabase
         run: |
-          for v in 20260517020453 20260517020512 20260517020530 20260517111741 20260518200000; do
+          for v in 20260517020453 20260517020512 20260517020530 20260517111741 20260518200000 20260518300000; do
             supabase migration repair --status reverted "$v" || true
           done
 


### PR DESCRIPTION
## Summary
- `20260518300000_add_fanza_rank.sql` が repair リストに漏れており、`20260518400000_fanza_rankings_table.sql` が適用されていなかった
- repair リストに追加することで次回 push 時に両マイグレーションが適用される

🤖 Generated with [Claude Code](https://claude.com/claude-code)