### PR TITLE
feat: fanza_rankings テーブルを新設しランキング管理を別テーブルへ切り出し

### DIFF
--- a/scripts/ingest_fanza/index.ts
+++ b/scripts/ingest_fanza/index.ts
@@ -536,14 +536,18 @@ async function ingestSource(
 async function updateRankings() {
   console.log('[ingest_fanza] === Starting ranking update ===');
   const rankingSources = [
-    { service: 'digital', floor: 'videoa' },
-    { service: 'digital', floor: 'anime' },
+    { service: 'digital', floor: 'videoa', source: 'fanza_videoa' },
+    { service: 'digital', floor: 'anime',  source: 'fanza_anime'  },
   ];
   const hits = 100;
   const maxRank = 500;
+  const updatedAt = new Date().toISOString();
 
-  for (const { service, floor } of rankingSources) {
+  for (const { service, floor, source } of rankingSources) {
     console.log(`\n[ingest_fanza] Fetching rankings: ${service}/${floor}`);
+
+    // 今回取得したランキングデータを収集
+    const rows: { source: string; rank: number; external_id: string; video_id: string | null; updated_at: string }[] = [];
     let rank = 1;
 
     for (let offset = 1; offset <= maxRank; offset += hits) {
@@ -552,17 +556,43 @@ async function updateRankings() {
 
       for (const item of result.items) {
         if (!item.content_id) { rank++; continue; }
-        const { error } = await supabase
+
+        // video_id を external_id から解決
+        const { data: video } = await supabase
           .from('videos')
-          .update({ fanza_rank: rank, fanza_rank_updated_at: new Date().toISOString() })
-          .eq('external_id', item.content_id);
-        if (error) {
-          console.warn(`[rank] update failed external_id=${item.content_id}: ${error.message}`);
-        }
+          .select('id')
+          .eq('external_id', item.content_id)
+          .maybeSingle();
+
+        rows.push({
+          source,
+          rank,
+          external_id: item.content_id,
+          video_id: video?.id ?? null,
+          updated_at: updatedAt,
+        });
         rank++;
       }
     }
-    console.log(`[ingest_fanza] Rankings updated for ${service}/${floor} (${rank - 1} items)`);
+
+    // 対象ソースを全削除してから挿入（圏外落ちを自動的に除去）
+    const { error: delError } = await supabase
+      .from('fanza_rankings')
+      .delete()
+      .eq('source', source);
+    if (delError) {
+      console.warn(`[rank] delete failed for source=${source}: ${delError.message}`);
+      continue;
+    }
+
+    if (rows.length > 0) {
+      const { error: insError } = await supabase.from('fanza_rankings').insert(rows);
+      if (insError) {
+        console.warn(`[rank] insert failed for source=${source}: ${insError.message}`);
+      }
+    }
+
+    console.log(`[ingest_fanza] Rankings refreshed for ${source}: ${rows.length} items`);
   }
   console.log('[ingest_fanza] === Ranking update complete ===');
 }

--- a/supabase/migrations/20260518400000_fanza_rankings_table.sql
+++ b/supabase/migrations/20260518400000_fanza_rankings_table.sql
@@ -1,0 +1,98 @@
+-- fanza_rank を videos テーブルから切り出し、fanza_rankings テーブルへ移行
+
+-- 1. 新テーブル作成
+CREATE TABLE IF NOT EXISTS public.fanza_rankings (
+  source      text        NOT NULL,
+  rank        int         NOT NULL,
+  video_id    uuid        REFERENCES public.videos(id) ON DELETE SET NULL,
+  external_id text        NOT NULL,
+  updated_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (source, rank)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fanza_rankings_video_id ON public.fanza_rankings (video_id)
+  WHERE video_id IS NOT NULL;
+
+-- anon/authenticated から読み取り可能にする（get_popular_videos は security definer なので不要だが念のため）
+ALTER TABLE public.fanza_rankings ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "fanza_rankings_readable" ON public.fanza_rankings FOR SELECT USING (true);
+GRANT SELECT ON public.fanza_rankings TO anon, authenticated;
+GRANT INSERT, UPDATE, DELETE ON public.fanza_rankings TO service_role;
+
+-- 2. videos テーブルから fanza_rank カラムを削除
+DROP INDEX IF EXISTS idx_videos_fanza_rank;
+ALTER TABLE public.videos DROP COLUMN IF EXISTS fanza_rank;
+ALTER TABLE public.videos DROP COLUMN IF EXISTS fanza_rank_updated_at;
+
+-- 3. get_popular_videos: fanza_rankings テーブルを JOIN
+CREATE OR REPLACE FUNCTION public.get_popular_videos(
+  user_uuid uuid DEFAULT NULL,
+  limit_count int DEFAULT 20,
+  lookback_days int DEFAULT 7
+)
+RETURNS TABLE (
+  id uuid, title text, description text, external_id text,
+  thumbnail_url text, thumbnail_vertical_url text,
+  sample_video_url text, product_url text,
+  product_released_at timestamptz,
+  performers jsonb, tags jsonb,
+  score double precision
+)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH user_likes AS (
+    SELECT vpd.video_id, SUM(vpd.likes)::double precision AS total_likes
+    FROM public.video_popularity_daily vpd
+    WHERE vpd.d >= (NOW() - make_interval(days => lookback_days))
+    GROUP BY vpd.video_id
+  ),
+  best_rank AS (
+    SELECT fr.video_id, MIN(fr.rank) AS rank
+    FROM public.fanza_rankings fr
+    WHERE fr.video_id IS NOT NULL
+    GROUP BY fr.video_id
+  ),
+  ranked AS (
+    SELECT
+      v.id,
+      COALESCE(ul.total_likes, 0) AS like_score,
+      CASE WHEN br.rank IS NOT NULL
+        THEN (501 - LEAST(br.rank, 500))::double precision / 500.0
+        ELSE 0
+      END AS rank_score
+    FROM public.videos v
+    LEFT JOIN user_likes ul ON ul.video_id = v.id
+    LEFT JOIN best_rank br ON br.video_id = v.id
+    WHERE v.sample_video_url IS NOT NULL
+      AND (user_uuid IS NULL OR NOT EXISTS (
+        SELECT 1 FROM public.user_video_decisions uvd
+        WHERE uvd.user_id = user_uuid AND uvd.video_id = v.id
+      ))
+  )
+  SELECT
+    v.id, v.title, v.description, v.external_id,
+    v.thumbnail_url, v.thumbnail_vertical_url, v.sample_video_url,
+    COALESCE(v.affiliate_url, v.product_url) AS product_url,
+    v.product_released_at,
+    COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('id', p.id, 'name', p.name) ORDER BY p.name)
+      FROM public.video_performers vp JOIN public.performers p ON p.id = vp.performer_id
+      WHERE vp.video_id = v.id
+    ), '[]'::jsonb) AS performers,
+    COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('id', t.id, 'name', t.name) ORDER BY t.name)
+      FROM public.video_tags vt JOIN public.tags t ON t.id = vt.tag_id
+      LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
+      WHERE vt.video_id = v.id AND COALESCE(tg.show_in_ui, TRUE)
+    ), '[]'::jsonb) AS tags,
+    CASE WHEN r.like_score > 0 THEN r.like_score ELSE r.rank_score END AS score
+  FROM ranked r
+  JOIN public.videos v ON v.id = r.id
+  ORDER BY score DESC NULLS LAST, v.product_released_at DESC
+  LIMIT limit_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_popular_videos(uuid, int, int) TO anon, authenticated;


### PR DESCRIPTION
## Summary
- `videos.fanza_rank` カラムを廃止し `fanza_rankings (source, rank, video_id, external_id, updated_at)` テーブルを新設
- ランキング更新時に対象ソースを全 DELETE → INSERT するため、圏外落ちが自動反映される
- `get_popular_videos` を `fanza_rankings` JOIN に書き換え
- `ingest_fanza/index.ts` の `updateRankings()` を新テーブル向けに更新

## Note
PR #192 マージ時にこのコミットが漏れていたため cherry-pick で追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)