### PR TITLE
fix: トップページのリダイレクト先を /grid に変更

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function IndexPage() {
-  redirect("/swipe");
+  redirect("/grid");
 }


### PR DESCRIPTION
## Summary
- `/` へのアクセスが `/swipe` にリダイレクトされていたのを `/grid` に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)