### PR TITLE
fix: video埋め込み次元ミスマッチを修正

### DIFF
--- a/scripts/gen_video_embeddings/gen_video_embeddings.py
+++ b/scripts/gen_video_embeddings/gen_video_embeddings.py
@@ -59,6 +59,12 @@ def parse_args() -> argparse.Namespace:
         default=Path("ml/artifacts/latest/item_features.parquet"),
         help="Training-time item_features parquet used to rebuild vocabularies.",
     )
+    parser.add_argument(
+        "--reference-user-features",
+        type=Path,
+        default=Path("ml/artifacts/latest/user_features.parquet"),
+        help="Training-time user_features parquet used to include preferred_tag_ids in tag vocab.",
+    )
     parser.add_argument("--output-dir", type=Path, default=Path("ml/artifacts/live/video_embeddings"), help="Directory to write embeddings.")
     parser.add_argument("--output-name", type=str, default="video_embeddings.parquet", help="Output parquet filename.")
     parser.add_argument("--limit", type=int, default=None, help="Optional maximum number of videos to encode (for debugging).")
@@ -333,6 +339,7 @@ def build_item_feature_space(
     use_price_feature: bool,
     max_tag_features: Optional[int],
     max_performer_features: Optional[int],
+    user_df: Optional[pd.DataFrame] = None,
 ) -> ItemFeatureBundle:
     cat_vocabs = {
         "source": reference_df.get("source", []).astype(str),
@@ -344,6 +351,10 @@ def build_item_feature_space(
     tag_counter: Counter[str] = Counter()
     for values in reference_df.get("tag_ids", []):
         tag_counter.update(_normalize_array(values))
+    # 訓練時と同様にユーザーの preferred_tag_ids もタグ語彙に含める
+    if user_df is not None:
+        for values in user_df.get("preferred_tag_ids", []):
+            tag_counter.update(_normalize_array(values))
     if max_tag_features is not None and max_tag_features > 0:
         tag_vocab = [tag for tag, _ in tag_counter.most_common(max_tag_features)]
     else:
@@ -447,11 +458,15 @@ def main() -> None:
     max_performer_features = meta.get("max_performer_features")
 
     reference_df = load_reference_item_features(args.reference_item_features)
+    user_ref_df: Optional[pd.DataFrame] = None
+    if args.reference_user_features and args.reference_user_features.exists():
+        user_ref_df = pd.read_parquet(args.reference_user_features)
     bundle = build_item_feature_space(
         reference_df,
         use_price_feature=use_price_feature,
         max_tag_features=max_tag_features,
         max_performer_features=max_performer_features,
+        user_df=user_ref_df,
     )
 
     print(

--- a/scripts/publish_two_tower/publish.py
+++ b/scripts/publish_two_tower/publish.py
@@ -171,7 +171,17 @@ def build_upload_plan(
                 item_features_path,
                 f"{prefix}/{run_id}/item_features.parquet",
                 "application/octet-stream",
-                True,  # Compress parquet file
+                True,
+            )
+        )
+    user_features_path = artifacts_dir / "user_features.parquet"
+    if user_features_path.exists():
+        plan.append(
+            (
+                user_features_path,
+                f"{prefix}/{run_id}/user_features.parquet",
+                "application/octet-stream",
+                True,
             )
         )
     if summary_path:
@@ -291,6 +301,12 @@ def cmd_activate(args: argparse.Namespace) -> None:
     if item_features_path:
         current_entry["item_features_path"] = item_features_path
 
+    user_features_path = None
+    if (artifacts_dir / "user_features.parquet").exists():
+        user_features_path = f"{artifacts_prefix}/{run_id}/user_features.parquet.gz"
+    if user_features_path:
+        current_entry["user_features_path"] = user_features_path
+
     manifest["model_name"] = args.model_name
     manifest["current"] = current_entry
     manifest["previous"] = previous_entries
@@ -354,6 +370,8 @@ def cmd_fetch(args: argparse.Namespace) -> None:
         downloads.append(("summary_path", "summary.md", False))
     if entry.get("item_features_path"):
         downloads.append(("item_features_path", "item_features.parquet", True))
+    if entry.get("user_features_path"):
+        downloads.append(("user_features_path", "user_features.parquet", True))
 
     written: List[Dict[str, str]] = []
     for key, filename, decompress in downloads:

--- a/supabase/migrations/20260518400000_fanza_rankings_table.sql
+++ b/supabase/migrations/20260518400000_fanza_rankings_table.sql
@@ -15,7 +15,13 @@ CREATE INDEX IF NOT EXISTS idx_fanza_rankings_video_id ON public.fanza_rankings 
 
 -- anon/authenticated から読み取り可能にする（get_popular_videos は security definer なので不要だが念のため）
 ALTER TABLE public.fanza_rankings ENABLE ROW LEVEL SECURITY;
-CREATE POLICY "fanza_rankings_readable" ON public.fanza_rankings FOR SELECT USING (true);
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'fanza_rankings' AND policyname = 'fanza_rankings_readable'
+  ) THEN
+    CREATE POLICY "fanza_rankings_readable" ON public.fanza_rankings FOR SELECT USING (true);
+  END IF;
+END $$;
 GRANT SELECT ON public.fanza_rankings TO anon, authenticated;
 GRANT INSERT, UPDATE, DELETE ON public.fanza_rankings TO service_role;
 


### PR DESCRIPTION
## Summary
- 訓練時のタグ語彙は `item_df["tag_ids"]` と `user_df["preferred_tag_ids"]` の両方から構築されるが、推論時は `item_features.parquet` のみ使用していたため1次元ずれが発生していた
- `gen_video_embeddings.py` に `--reference-user-features` 引数を追加し、`user_features.parquet` の `preferred_tag_ids` もタグ語彙に含めるよう修正
- `publish_two_tower/publish.py` で `user_features.parquet` のアップロード・マニフェスト登録・ダウンロードに対応

## Root Cause
`train_two_tower.py` では tag_counter をユーザーの preferred_tag_ids も含めて構築するが、`gen_video_embeddings.py` ではアイテム側の tag_ids のみ使っていた。ユーザーのみが持つタグが1件あると 19170 vs 19171 の次元ミスマッチになる。

## Test plan
- [ ] `ml-train-model` を実行し `user_features.parquet` が Storage にアップロードされることを確認
- [ ] `ml-release-embeddings` で fetch 後 `user_features.parquet` が `ml/artifacts/latest/` に存在することを確認
- [ ] `Sync video embeddings` が次元エラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)