### PR TITLE
feat: ゲストユーザーのログイン促進ファネル計測

### DIFF
--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
 import { X, Play, Heart, Eye, ChevronDown, ChevronUp, Brain, Hand, Bot, Target, LockOpen, ExternalLink, type LucideIcon } from 'lucide-react';
+import { trackEvent } from '@/lib/analytics';
 
 type VideoItem = {
   id: string;
@@ -61,6 +62,7 @@ function GridPage() {
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
   const [showLoginNudge, setShowLoginNudge] = useState(false);
   const guestLikeCountRef = useRef(0);
+  const guestLikeCountTotalRef = useRef(0);
   const overlayHideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const loaderRef = useRef<HTMLDivElement>(null);
   const OVERLAY_HIDE_DELAY_MS = 700;
@@ -169,8 +171,11 @@ function GridPage() {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) {
       guestLikeCountRef.current += 1;
+      guestLikeCountTotalRef.current += 1;
+      trackEvent('guest_swipe', { swipe_count: guestLikeCountTotalRef.current, decision_type: 'grid_like' });
       if (guestLikeCountRef.current === 3 || guestLikeCountRef.current % 10 === 0) {
         setShowLoginNudge(true);
+        trackEvent('login_nudge_shown', { like_count: guestLikeCountRef.current });
       }
       return;
     }
@@ -210,13 +215,13 @@ function GridPage() {
             </div>
             <div className="flex flex-col gap-1 flex-shrink-0">
               <button
-                onClick={() => { setShowLoginNudge(false); window.dispatchEvent(new Event('open-auth-modal')); }}
+                onClick={() => { setShowLoginNudge(false); trackEvent('login_nudge_clicked', { like_count: guestLikeCountRef.current }); window.dispatchEvent(new Event('open-auth-modal')); }}
                 className="px-3 py-1 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-[11px] font-bold transition-colors"
               >
                 登録
               </button>
               <button
-                onClick={() => setShowLoginNudge(false)}
+                onClick={() => { setShowLoginNudge(false); trackEvent('login_nudge_dismissed', { like_count: guestLikeCountRef.current }); }}
                 className="px-3 py-1 rounded-lg text-[#8b949e] hover:text-white text-[11px] transition-colors text-center"
               >
                 後で
@@ -236,13 +241,13 @@ function GridPage() {
             </div>
             <div className="flex items-center gap-3 flex-shrink-0">
               <button
-                onClick={() => setShowLoginNudge(false)}
+                onClick={() => { setShowLoginNudge(false); trackEvent('login_nudge_dismissed', { like_count: guestLikeCountRef.current }); }}
                 className="px-4 py-2 rounded-lg text-[#8b949e] hover:text-white text-sm transition-colors"
               >
                 後で
               </button>
               <button
-                onClick={() => { setShowLoginNudge(false); window.dispatchEvent(new Event('open-auth-modal')); }}
+                onClick={() => { setShowLoginNudge(false); trackEvent('login_nudge_clicked', { like_count: guestLikeCountRef.current }); window.dispatchEvent(new Event('open-auth-modal')); }}
                 className="px-6 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-sm font-bold transition-colors shadow-lg shadow-violet-900/50"
               >
                 無料で登録

--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -66,6 +66,7 @@ function SwipePage() {
   const [authReady, setAuthReady] = useState<boolean>(false);
   const [showLoginNudge, setShowLoginNudge] = useState(false);
   const guestLikeCountRef = useRef(0);
+  const guestSwipeCountRef = useRef(0);
   const mainRef = useRef<HTMLDivElement | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const sessionStartRef = useRef<number | null>(null);
@@ -426,10 +427,13 @@ function SwipePage() {
         recommendation_params: card.recommendationParams ?? null,
       });
       setGuestDecisions(current);
+      guestSwipeCountRef.current += 1;
+      trackEvent('guest_swipe', { swipe_count: guestSwipeCountRef.current, decision_type: decisionType });
       if (decisionType === 'swipe_like') {
         guestLikeCountRef.current += 1;
         if (guestLikeCountRef.current === 3 || guestLikeCountRef.current % 10 === 0) {
           setShowLoginNudge(true);
+          trackEvent('login_nudge_shown', { swipe_count: guestSwipeCountRef.current, like_count: guestLikeCountRef.current });
         }
       }
     }
@@ -564,13 +568,13 @@ function SwipePage() {
           </div>
           <div className="flex flex-col gap-1 flex-shrink-0">
             <button
-              onClick={() => { setShowLoginNudge(false); window.dispatchEvent(new Event('open-auth-modal')); }}
+              onClick={() => { setShowLoginNudge(false); trackEvent('login_nudge_clicked', { swipe_count: guestSwipeCountRef.current }); window.dispatchEvent(new Event('open-auth-modal')); }}
               className="px-3 py-1 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-[11px] font-bold transition-colors"
             >
               登録
             </button>
             <button
-              onClick={() => setShowLoginNudge(false)}
+              onClick={() => { setShowLoginNudge(false); trackEvent('login_nudge_dismissed', { swipe_count: guestSwipeCountRef.current }); }}
               className="px-3 py-1 rounded-lg text-[#8b949e] hover:text-white text-[11px] transition-colors text-center"
             >
               後で

--- a/frontend/src/components/GlobalModals.tsx
+++ b/frontend/src/components/GlobalModals.tsx
@@ -18,11 +18,13 @@ export default function GlobalModals() {
       setAuthInitialTab('login');
       setShowRegisterNotice(false);
       setIsAuthOpen(true);
+      trackEvent('auth_modal_open', { tab: 'login' });
     };
     const registerHandler = () => {
       setAuthInitialTab('register');
       setShowRegisterNotice(true);
       setIsAuthOpen(true);
+      trackEvent('auth_modal_open', { tab: 'register' });
       trackEvent('signup_modal_shown');
     };
     const likedHandler = () => setIsLikedOpen(true);


### PR DESCRIPTION
## Summary
- ゲストユーザーのスワイプ・いいね操作を `guest_swipe` イベントで計測
- ログイン促進Nudgeの表示・クリック・却下を `login_nudge_shown` / `login_nudge_clicked` / `login_nudge_dismissed` で計測
- 認証モーダルのオープンを `auth_modal_open` (`tab: login|register`) で計測
- swipe・gridページ両方に対応

## 計測ファネル
```
guest_swipe → login_nudge_shown → login_nudge_clicked → auth_modal_open → login (既存)
                                 → login_nudge_dismissed
```

## Test plan
- [ ] ゲストとしてswipeページでスワイプし、GA4 DebugViewで `guest_swipe` が発火することを確認
- [ ] 3回いいねで `login_nudge_shown` が発火することを確認
- [ ] Nudge「登録」クリックで `login_nudge_clicked` + `auth_modal_open` が発火することを確認
- [ ] 「後で」クリックで `login_nudge_dismissed` が発火することを確認
- [ ] gridページでも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)