### PR TITLE
feat: swipeデバッグオーバーレイを画面左上・右上の固定カードに追加

### DIFF
--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -598,6 +598,7 @@ function SwipePage() {
                 skipButtonRef={skipButtonRef}
                 likeButtonRef={likeButtonRef}
                 likedListButtonRef={likedListButtonRef}
+                isDebug={isDebug}
               />
             ) : (
               <SwipeCard
@@ -610,6 +611,7 @@ function SwipePage() {
                 cardWidth={cardWidth}
                 canSwipe={true}
                 onSamplePlay={(card) => handleSamplePlay(card, 'desktop')}
+                isDebug={isDebug}
               />
             )
           ) : (

--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -510,54 +510,56 @@ function SwipePage() {
       style={{ background: currentGradient }}
       transition={{ duration: 0.3 }}
     >
-      {/* デバッグパネル */}
+      {/* デバッグ: 左上オーバーレイ（セッション集計） */}
       {isDebug && cards.length > 0 && (() => {
         const relevant = cards.slice(activeIndex);
         const all = cards;
-        const countFor = (arr: CardData[]) => {
-          const counts: Record<string, number> = {};
-          const scores: Record<string, number[]> = {};
-          for (const c of arr) {
-            const src = c.recommendationSource ?? 'unknown';
-            counts[src] = (counts[src] ?? 0) + 1;
-            if (c.recommendationScore != null) {
-              if (!scores[src]) scores[src] = [];
-              scores[src].push(c.recommendationScore);
-            }
+        const counts: Record<string, number> = {};
+        const scores: Record<string, number[]> = {};
+        for (const c of all) {
+          const src = c.recommendationSource ?? 'unknown';
+          counts[src] = (counts[src] ?? 0) + 1;
+          if (c.recommendationScore != null) {
+            if (!scores[src]) scores[src] = [];
+            scores[src].push(c.recommendationScore);
           }
-          return { counts, scores };
-        };
-        const { counts, scores } = countFor(all);
+        }
         const total = all.length;
         const COLORS: Record<string, string> = {
-          exploitation: 'bg-violet-600 text-white',
-          popularity: 'bg-blue-600 text-white',
-          exploration: 'bg-green-700 text-white',
+          exploitation: 'text-violet-400',
+          popularity: 'text-blue-400',
+          exploration: 'text-green-400',
         };
         return (
-          <div className="fixed top-[52px] left-0 right-0 z-50 bg-[#0d1117]/95 border-b border-[#30363d] px-3 py-2 text-[11px] font-mono">
-            <div className="flex flex-wrap gap-x-4 gap-y-1 items-center">
-              <span className="text-[#8b949e]">loaded:{total} remaining:{relevant.length}</span>
-              {Object.entries(counts).sort((a, b) => b[1] - a[1]).map(([src, cnt]) => {
-                const avg = scores[src]?.length
-                  ? (scores[src].reduce((a, b) => a + b, 0) / scores[src].length).toFixed(3)
-                  : '–';
-                const max = scores[src]?.length
-                  ? Math.max(...scores[src]).toFixed(3)
-                  : '–';
-                return (
-                  <span key={src} className="flex items-center gap-1.5">
-                    <span className={`px-1.5 py-0.5 rounded text-[10px] font-bold ${COLORS[src] ?? 'bg-gray-600 text-white'}`}>{src}</span>
-                    <span className="text-[#e6edf3]">{cnt} ({((cnt / total) * 100).toFixed(0)}%)</span>
-                    <span className="text-yellow-300">avg:{avg}</span>
-                    <span className="text-yellow-500">max:{max}</span>
-                  </span>
-                );
-              })}
-            </div>
+          <div className="fixed top-[60px] left-2 z-50 bg-black/80 backdrop-blur-sm border border-white/10 rounded-xl px-3 py-2 text-[10px] font-mono flex flex-col gap-1 min-w-[160px]">
+            <span className="text-[#8b949e]">loaded:{total} rem:{relevant.length}</span>
+            {Object.entries(counts).sort((a, b) => b[1] - a[1]).map(([src, cnt]) => {
+              const avg = scores[src]?.length
+                ? (scores[src].reduce((a, b) => a + b, 0) / scores[src].length).toFixed(3)
+                : '–';
+              const max = scores[src]?.length ? Math.max(...scores[src]).toFixed(3) : '–';
+              return (
+                <div key={src} className="flex flex-col gap-0">
+                  <span className={`font-bold ${COLORS[src] ?? 'text-white'}`}>{src} {cnt} ({((cnt / total) * 100).toFixed(0)}%)</span>
+                  <span className="text-yellow-300 pl-1">avg:{avg} max:{max}</span>
+                </div>
+              );
+            })}
           </div>
         );
       })()}
+      {/* デバッグ: 右上オーバーレイ（現在のカード情報） */}
+      {isDebug && activeCard && (
+        <div className="fixed top-[60px] right-2 z-50 bg-black/80 backdrop-blur-sm border border-white/10 rounded-xl px-3 py-2 text-[10px] font-mono flex flex-col gap-0.5 min-w-[140px] items-end">
+          <span className="text-white font-bold">{activeCard.recommendationSource ?? 'unknown'}</span>
+          {typeof activeCard.recommendationScore === 'number' && (
+            <span className="text-yellow-300">score: {activeCard.recommendationScore.toFixed(4)}</span>
+          )}
+          {activeCard.recommendationModelVersion && (
+            <span className="text-cyan-300">{activeCard.recommendationModelVersion}</span>
+          )}
+        </div>
+      )}
       {/* ゲスト向けログイン nudge トースト */}
       {showLoginNudge && !isLoggedIn && (
         <div className="fixed bottom-24 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-[#1c1f26] border border-violet-500/50 rounded-2xl px-4 py-3 shadow-2xl shadow-violet-900/30 max-w-[320px] w-[90vw]">
@@ -598,7 +600,6 @@ function SwipePage() {
                 skipButtonRef={skipButtonRef}
                 likeButtonRef={likeButtonRef}
                 likedListButtonRef={likedListButtonRef}
-                isDebug={isDebug}
               />
             ) : (
               <SwipeCard
@@ -611,7 +612,6 @@ function SwipePage() {
                 cardWidth={cardWidth}
                 canSwipe={true}
                 onSamplePlay={(card) => handleSamplePlay(card, 'desktop')}
-                isDebug={isDebug}
               />
             )
           ) : (

--- a/frontend/src/components/MobileVideoLayout.tsx
+++ b/frontend/src/components/MobileVideoLayout.tsx
@@ -12,9 +12,10 @@ interface MobileVideoLayoutProps {
   skipButtonRef?: RefObject<HTMLButtonElement | null>;
   likeButtonRef?: RefObject<HTMLButtonElement | null>;
   likedListButtonRef?: RefObject<HTMLButtonElement | null>;
+  isDebug?: boolean;
 }
 
-const MobileVideoLayout: React.FC<MobileVideoLayoutProps> = ({ cardData, onSkip, onLike, onSamplePlay, skipButtonRef, likeButtonRef, likedListButtonRef }) => {
+const MobileVideoLayout: React.FC<MobileVideoLayoutProps> = ({ cardData, onSkip, onLike, onSamplePlay, skipButtonRef, likeButtonRef, likedListButtonRef, isDebug }) => {
   const [showVideo, setShowVideo] = useState(false);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [showOverlay, setShowOverlay] = useState(true);
@@ -71,6 +72,23 @@ const MobileVideoLayout: React.FC<MobileVideoLayoutProps> = ({ cardData, onSkip,
 
         {/* メインカード（白背景・角丸・影） */}
         <div className="relative z-10 bg-white rounded-2xl overflow-hidden shadow-xl">
+          {isDebug && (
+            <div className="absolute top-2 right-2 z-50 flex flex-col items-end gap-0.5 pointer-events-none">
+              <span className="bg-black/70 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
+                {cardData.recommendationSource ?? 'unknown'}
+              </span>
+              {typeof cardData.recommendationScore === 'number' && (
+                <span className="bg-black/70 text-yellow-300 text-[10px] font-mono px-1.5 py-0.5 rounded">
+                  {cardData.recommendationScore.toFixed(4)}
+                </span>
+              )}
+              {cardData.recommendationModelVersion && (
+                <span className="bg-black/70 text-cyan-300 text-[10px] font-mono px-1.5 py-0.5 rounded">
+                  {cardData.recommendationModelVersion}
+                </span>
+              )}
+            </div>
+          )}
           {/* 動画表示エリア（4:3） */}
           <div className="w-full p-3">
             <div className="w-full overflow-hidden relative aspect-[4/3] bg-black flex items-center justify-center rounded-xl">

--- a/frontend/src/components/MobileVideoLayout.tsx
+++ b/frontend/src/components/MobileVideoLayout.tsx
@@ -12,10 +12,9 @@ interface MobileVideoLayoutProps {
   skipButtonRef?: RefObject<HTMLButtonElement | null>;
   likeButtonRef?: RefObject<HTMLButtonElement | null>;
   likedListButtonRef?: RefObject<HTMLButtonElement | null>;
-  isDebug?: boolean;
 }
 
-const MobileVideoLayout: React.FC<MobileVideoLayoutProps> = ({ cardData, onSkip, onLike, onSamplePlay, skipButtonRef, likeButtonRef, likedListButtonRef, isDebug }) => {
+const MobileVideoLayout: React.FC<MobileVideoLayoutProps> = ({ cardData, onSkip, onLike, onSamplePlay, skipButtonRef, likeButtonRef, likedListButtonRef }) => {
   const [showVideo, setShowVideo] = useState(false);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [showOverlay, setShowOverlay] = useState(true);
@@ -72,23 +71,6 @@ const MobileVideoLayout: React.FC<MobileVideoLayoutProps> = ({ cardData, onSkip,
 
         {/* メインカード（白背景・角丸・影） */}
         <div className="relative z-10 bg-white rounded-2xl overflow-hidden shadow-xl">
-          {isDebug && (
-            <div className="absolute top-2 right-2 z-50 flex flex-col items-end gap-0.5 pointer-events-none">
-              <span className="bg-black/70 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
-                {cardData.recommendationSource ?? 'unknown'}
-              </span>
-              {typeof cardData.recommendationScore === 'number' && (
-                <span className="bg-black/70 text-yellow-300 text-[10px] font-mono px-1.5 py-0.5 rounded">
-                  {cardData.recommendationScore.toFixed(4)}
-                </span>
-              )}
-              {cardData.recommendationModelVersion && (
-                <span className="bg-black/70 text-cyan-300 text-[10px] font-mono px-1.5 py-0.5 rounded">
-                  {cardData.recommendationModelVersion}
-                </span>
-              )}
-            </div>
-          )}
           {/* 動画表示エリア（4:3） */}
           <div className="w-full p-3">
             <div className="w-full overflow-hidden relative aspect-[4/3] bg-black flex items-center justify-center rounded-xl">

--- a/frontend/src/components/SwipeCard.tsx
+++ b/frontend/src/components/SwipeCard.tsx
@@ -36,10 +36,9 @@ interface SwipeCardProps {
   cardWidth: number | undefined;
   canSwipe?: boolean;
   onSamplePlay?: (card: CardData) => void;
-  isDebug?: boolean;
 }
 
-const SwipeCard = forwardRef<SwipeCardHandle, SwipeCardProps>(({ cardData, onSwipe, onDrag, onDragEnd, cardWidth, canSwipe = true, onSamplePlay, isDebug }, ref) => {
+const SwipeCard = forwardRef<SwipeCardHandle, SwipeCardProps>(({ cardData, onSwipe, onDrag, onDragEnd, cardWidth, canSwipe = true, onSamplePlay }, ref) => {
   const controls = useAnimation();
   
   const [showVideo, setShowVideo] = useState(false);
@@ -144,23 +143,6 @@ const SwipeCard = forwardRef<SwipeCardHandle, SwipeCardProps>(({ cardData, onSwi
       >
       {/* 上部: 動画エリア（PC版は4:3のアスペクト比） */}
       <div className="relative w-full aspect-[4/3] bg-black/90 flex items-center justify-center rounded-xl overflow-hidden">
-        {isDebug && (
-          <div className="absolute top-2 right-2 z-50 flex flex-col items-end gap-0.5 pointer-events-none">
-            <span className="bg-black/70 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
-              {cardData.recommendationSource ?? 'unknown'}
-            </span>
-            {typeof cardData.recommendationScore === 'number' && (
-              <span className="bg-black/70 text-yellow-300 text-[10px] font-mono px-1.5 py-0.5 rounded">
-                {cardData.recommendationScore.toFixed(4)}
-              </span>
-            )}
-            {cardData.recommendationModelVersion && (
-              <span className="bg-black/70 text-cyan-300 text-[10px] font-mono px-1.5 py-0.5 rounded">
-                {cardData.recommendationModelVersion}
-              </span>
-            )}
-          </div>
-        )}
         {showOverlay && (
           <div
             className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10"

--- a/frontend/src/components/SwipeCard.tsx
+++ b/frontend/src/components/SwipeCard.tsx
@@ -33,12 +33,13 @@ interface SwipeCardProps {
   onSwipe: (direction: 'left' | 'right') => void;
   onDrag?: (event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => void;
   onDragEnd?: (event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => void;
-  cardWidth: number | undefined; // cardWidth propを追加
-  canSwipe?: boolean; // 追加: ゲスト制限時にスワイプを抑制
+  cardWidth: number | undefined;
+  canSwipe?: boolean;
   onSamplePlay?: (card: CardData) => void;
+  isDebug?: boolean;
 }
 
-const SwipeCard = forwardRef<SwipeCardHandle, SwipeCardProps>(({ cardData, onSwipe, onDrag, onDragEnd, cardWidth, canSwipe = true, onSamplePlay }, ref) => {
+const SwipeCard = forwardRef<SwipeCardHandle, SwipeCardProps>(({ cardData, onSwipe, onDrag, onDragEnd, cardWidth, canSwipe = true, onSamplePlay, isDebug }, ref) => {
   const controls = useAnimation();
   
   const [showVideo, setShowVideo] = useState(false);
@@ -143,6 +144,23 @@ const SwipeCard = forwardRef<SwipeCardHandle, SwipeCardProps>(({ cardData, onSwi
       >
       {/* 上部: 動画エリア（PC版は4:3のアスペクト比） */}
       <div className="relative w-full aspect-[4/3] bg-black/90 flex items-center justify-center rounded-xl overflow-hidden">
+        {isDebug && (
+          <div className="absolute top-2 right-2 z-50 flex flex-col items-end gap-0.5 pointer-events-none">
+            <span className="bg-black/70 text-white text-[10px] font-mono px-1.5 py-0.5 rounded">
+              {cardData.recommendationSource ?? 'unknown'}
+            </span>
+            {typeof cardData.recommendationScore === 'number' && (
+              <span className="bg-black/70 text-yellow-300 text-[10px] font-mono px-1.5 py-0.5 rounded">
+                {cardData.recommendationScore.toFixed(4)}
+              </span>
+            )}
+            {cardData.recommendationModelVersion && (
+              <span className="bg-black/70 text-cyan-300 text-[10px] font-mono px-1.5 py-0.5 rounded">
+                {cardData.recommendationModelVersion}
+              </span>
+            )}
+          </div>
+        )}
         {showOverlay && (
           <div
             className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10"


### PR DESCRIPTION
## Summary
- `/swipe?debug=1` アクセス時に2つのデバッグオーバーレイカードを表示
  - **左上**: セッション全体の集計（loaded/remaining、source別件数・割合・avg/maxスコア）
  - **右上**: 現在表示中のカードのsource・score・model_version

## Test plan
- [ ] `/swipe?debug=1` でアクセスし、左上・右上にオーバーレイカードが表示されることを確認
- [ ] スワイプするたびに右上カードの情報が切り替わることを確認
- [ ] `?debug=1` なしでは表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)