### PR TITLE
fix: sitemapを4分割してGoogleのタイムアウトを解消

### DIFF
--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -5,87 +5,106 @@ import { supabase } from '@/lib/supabase';
 export const revalidate = 86400;
 
 const SITE_URL = 'https://www.seihekilab.com';
-
 const PAGE_SIZE = 1000;
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const entries: MetadataRoute.Sitemap = [
-    { url: `${SITE_URL}/grid`, lastModified: new Date(), changeFrequency: 'daily', priority: 1.0 },
-    { url: `${SITE_URL}/swipe`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
-    { url: `${SITE_URL}/about`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${SITE_URL}/quiz`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.7 },
-    { url: `${SITE_URL}/quiz/characters`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.6 },
-    { url: `${SITE_URL}/tags`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.8 },
-  ];
+// サイトマップを4分割してタイムアウトを防ぐ
+// /sitemap/0 = 静的ページ
+// /sitemap/1 = 動画ページ
+// /sitemap/2 = タグページ
+// /sitemap/3 = 女優ページ
+export function generateSitemaps() {
+  return [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }];
+}
 
-  // 作品LPを全件追加
-  let page = 0;
-  while (true) {
-    const from = page * PAGE_SIZE;
-    const to = from + PAGE_SIZE - 1;
-
-    const { data, error } = await supabase
-      .from('videos')
-      .select('id, created_at')
-      .order('created_at', { ascending: false })
-      .range(from, to);
-
-    if (error || !data || data.length === 0) break;
-
-    for (const v of data) {
-      entries.push({
-        url: `${SITE_URL}/videos/${v.id}`,
-        lastModified: v.created_at ? new Date(v.created_at) : new Date(),
-        changeFrequency: 'monthly',
-        priority: 0.7,
-      });
-    }
-
-    if (data.length < PAGE_SIZE) break;
-    page++;
+export default async function sitemap({ id }: { id: number }): Promise<MetadataRoute.Sitemap> {
+  // 静的ページ
+  if (id === 0) {
+    return [
+      { url: `${SITE_URL}/grid`, lastModified: new Date(), changeFrequency: 'daily', priority: 1.0 },
+      { url: `${SITE_URL}/swipe`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
+      { url: `${SITE_URL}/about`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.8 },
+      { url: `${SITE_URL}/quiz`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.7 },
+      { url: `${SITE_URL}/quiz/characters`, lastModified: new Date(), changeFrequency: 'monthly', priority: 0.6 },
+      { url: `${SITE_URL}/tags`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.8 },
+      { url: `${SITE_URL}/performers`, lastModified: new Date(), changeFrequency: 'weekly', priority: 0.8 },
+    ];
   }
 
-  // タグLPを全件追加（ページネーション）
-  let tagPage = 0;
-  while (true) {
-    const from = tagPage * PAGE_SIZE;
-    const { data: tags, error } = await supabase
-      .from('tags')
-      .select('id')
-      .range(from, from + PAGE_SIZE - 1);
-    if (error || !tags || tags.length === 0) break;
-    for (const t of tags) {
-      entries.push({
-        url: `${SITE_URL}/tags/${t.id}`,
-        lastModified: new Date(),
-        changeFrequency: 'weekly',
-        priority: 0.8,
-      });
+  // 動画ページ
+  if (id === 1) {
+    const entries: MetadataRoute.Sitemap = [];
+    let page = 0;
+    while (true) {
+      const from = page * PAGE_SIZE;
+      const { data, error } = await supabase
+        .from('videos')
+        .select('id, created_at')
+        .order('created_at', { ascending: false })
+        .range(from, from + PAGE_SIZE - 1);
+      if (error || !data || data.length === 0) break;
+      for (const v of data) {
+        entries.push({
+          url: `${SITE_URL}/videos/${v.id}`,
+          lastModified: v.created_at ? new Date(v.created_at) : new Date(),
+          changeFrequency: 'monthly',
+          priority: 0.7,
+        });
+      }
+      if (data.length < PAGE_SIZE) break;
+      page++;
     }
-    if (tags.length < PAGE_SIZE) break;
-    tagPage++;
+    return entries;
   }
 
-  // 女優LPを全件追加（ページネーション）
-  let performerPage = 0;
-  while (true) {
-    const from = performerPage * PAGE_SIZE;
-    const { data: performers, error } = await supabase
-      .from('performers')
-      .select('id')
-      .range(from, from + PAGE_SIZE - 1);
-    if (error || !performers || performers.length === 0) break;
-    for (const p of performers) {
-      entries.push({
-        url: `${SITE_URL}/performers/${p.id}`,
-        lastModified: new Date(),
-        changeFrequency: 'weekly',
-        priority: 0.7,
-      });
+  // タグページ
+  if (id === 2) {
+    const entries: MetadataRoute.Sitemap = [];
+    let page = 0;
+    while (true) {
+      const from = page * PAGE_SIZE;
+      const { data, error } = await supabase
+        .from('tags')
+        .select('id')
+        .range(from, from + PAGE_SIZE - 1);
+      if (error || !data || data.length === 0) break;
+      for (const t of data) {
+        entries.push({
+          url: `${SITE_URL}/tags/${t.id}`,
+          lastModified: new Date(),
+          changeFrequency: 'weekly',
+          priority: 0.8,
+        });
+      }
+      if (data.length < PAGE_SIZE) break;
+      page++;
     }
-    if (performers.length < PAGE_SIZE) break;
-    performerPage++;
+    return entries;
   }
 
-  return entries;
+  // 女優ページ
+  if (id === 3) {
+    const entries: MetadataRoute.Sitemap = [];
+    let page = 0;
+    while (true) {
+      const from = page * PAGE_SIZE;
+      const { data, error } = await supabase
+        .from('performers')
+        .select('id')
+        .range(from, from + PAGE_SIZE - 1);
+      if (error || !data || data.length === 0) break;
+      for (const p of data) {
+        entries.push({
+          url: `${SITE_URL}/performers/${p.id}`,
+          lastModified: new Date(),
+          changeFrequency: 'weekly',
+          priority: 0.7,
+        });
+      }
+      if (data.length < PAGE_SIZE) break;
+      page++;
+    }
+    return entries;
+  }
+
+  return [];
 }


### PR DESCRIPTION
## 概要

GSC で「サイトマップを読み込めませんでした」が発生していた問題を修正します。

## 原因

`sitemap.ts` が1リクエストで動画・タグ・女優すべてのデータを Supabase から逐次取得していたため、レスポンスに数十秒かかり Google のクローラーがタイムアウトしていた。

## 変更内容

`generateSitemaps` を使ってサイトマップを4分割。`/sitemap.xml` がインデックスとなり、各サイトマップが独立して取得される。

| URL | 内容 |
|---|---|
| `/sitemap.xml` | インデックス |
| `/sitemap/0.xml` | 静的ページ（grid・about・quiz等）|
| `/sitemap/1.xml` | 動画ページ（約900件）|
| `/sitemap/2.xml` | タグページ（600件以上）|
| `/sitemap/3.xml` | 女優ページ（7000件以上）|

## 確認事項

- [ ] デプロイ後、`/sitemap.xml` がインデックス形式で返ることを確認
- [ ] GSC でサイトマップを再送信し「読み込めませんでした」が解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)