### PR TITLE
fix: sitemapのid型をstringに修正（空サイトマップのバグ修正）

### DIFF
--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -15,6 +15,11 @@ export default function robots(): MetadataRoute.Robots {
         ],
       },
     ],
-    sitemap: `${SITE_URL}/sitemap.xml`,
+    sitemap: [
+      `${SITE_URL}/sitemap/0.xml`,
+      `${SITE_URL}/sitemap/1.xml`,
+      `${SITE_URL}/sitemap/2.xml`,
+      `${SITE_URL}/sitemap/3.xml`,
+    ],
   };
 }

--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -13,12 +13,12 @@ const PAGE_SIZE = 1000;
 // /sitemap/2 = タグページ
 // /sitemap/3 = 女優ページ
 export function generateSitemaps() {
-  return [{ id: 0 }, { id: 1 }, { id: 2 }, { id: 3 }];
+  return [{ id: '0' }, { id: '1' }, { id: '2' }, { id: '3' }];
 }
 
-export default async function sitemap({ id }: { id: number }): Promise<MetadataRoute.Sitemap> {
+export default async function sitemap({ id }: { id: string }): Promise<MetadataRoute.Sitemap> {
   // 静的ページ
-  if (id === 0) {
+  if (id === '0') {
     return [
       { url: `${SITE_URL}/grid`, lastModified: new Date(), changeFrequency: 'daily', priority: 1.0 },
       { url: `${SITE_URL}/swipe`, lastModified: new Date(), changeFrequency: 'daily', priority: 0.9 },
@@ -31,7 +31,7 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
   }
 
   // 動画ページ
-  if (id === 1) {
+  if (id === '1') {
     const entries: MetadataRoute.Sitemap = [];
     let page = 0;
     while (true) {
@@ -57,7 +57,7 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
   }
 
   // タグページ
-  if (id === 2) {
+  if (id === '2') {
     const entries: MetadataRoute.Sitemap = [];
     let page = 0;
     while (true) {
@@ -82,7 +82,7 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
   }
 
   // 女優ページ
-  if (id === 3) {
+  if (id === '3') {
     const entries: MetadataRoute.Sitemap = [];
     let page = 0;
     while (true) {


### PR DESCRIPTION
## 原因

`generateSitemaps` で `{ id: 0 }` と数値を返していたが、Next.js はルートパラメータを**文字列**として渡すため `id === 0` が全て `false` となり、全サイトマップが空で返っていた。

## 変更内容

- `sitemap.ts`: `id` を `number` → `string` に変更（`'0'`〜`'3'`）
- `robots.ts`: `/sitemap.xml`（404）への依存をやめ、`/sitemap/0.xml`〜`/sitemap/3.xml` を直接列挙

## 確認事項

- [ ] デプロイ後、`/sitemap/0.xml` に `/grid` 等の URL が含まれることを確認
- [ ] `/sitemap/1.xml` に動画 URL が含まれることを確認
- [ ] GSC でサイトマップ（`/sitemap/0.xml` など）を再送信

🤖 Generated with [Claude Code](https://claude.com/claude-code)