### PR TITLE
feat: いいねリストの公開共有機能（/list/[token]）

### DIFF
--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -398,13 +398,13 @@ function GridPage() {
       </div>
       </div>{/* /max-w-4xl */}
 
-      {/* Pinterest グリッド */}
-      <div className="px-3 py-4">
-      <div className="columns-1 sm:columns-2 md:columns-3 lg:columns-4 xl:columns-5 gap-2 space-y-2">
+      {/* グリッド: モバイル2カラム・縦長サムネイル */}
+      <div className="px-2 py-4">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
         {videos.map((video) => (
           <div
             key={video.id}
-            className={`break-inside-avoid rounded-2xl overflow-hidden cursor-pointer bg-[#161b22] border transition-all shadow-md ${
+            className={`rounded-xl overflow-hidden cursor-pointer bg-[#161b22] border transition-all shadow-md ${
               loadedIds.has(video.id) ? 'opacity-100' : 'opacity-0'
             } ${
               likedIds.has(video.id)
@@ -420,13 +420,13 @@ function GridPage() {
               setViewedIds((prev) => new Set([...prev, video.id]));
             }}
           >
-            {/* サムネイル */}
-            <div className="w-full bg-black relative group">
+            {/* サムネイル: 縦長固定比率 */}
+            <div className="w-full bg-black relative group aspect-[2/3]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={(video.thumbnail_vertical_url?.replace('ps.jpg', 'pl.jpg')) || video.thumbnail_url || ''}
                 alt={video.title ?? ''}
-                className="w-full object-cover"
+                className="w-full h-full object-cover"
                 loading="lazy"
                 onLoad={() => setLoadedIds((prev) => new Set([...prev, video.id]))}
               />
@@ -452,20 +452,20 @@ function GridPage() {
               </div>
               {/* いいね/興味なしボタン（常時・右下） */}
               {nopedIds.has(video.id) ? (
-                <div className="absolute bottom-1.5 right-1.5 w-7 h-7 rounded-full bg-white/20 flex items-center justify-center shadow-md pointer-events-none">
-                  <X size={13} className="text-white/80" strokeWidth={2.5} />
+                <div className="absolute bottom-2 right-2 w-8 h-8 rounded-full bg-white/20 flex items-center justify-center shadow-md pointer-events-none">
+                  <X size={14} className="text-white/80" strokeWidth={2.5} />
                 </div>
               ) : (
                 <button
-                  className={`absolute bottom-1.5 right-1.5 w-7 h-7 rounded-full flex items-center justify-center transition-colors shadow-md ${
+                  className={`absolute bottom-2 right-2 w-8 h-8 rounded-full flex items-center justify-center transition-colors shadow-lg ${
                     likedIds.has(video.id)
                       ? 'bg-pink-500'
-                      : 'bg-black/40 hover:bg-pink-500/80'
+                      : 'bg-black/50 hover:bg-pink-500/80'
                   }`}
                   onClick={(e) => { e.stopPropagation(); handleLike(video); }}
                   aria-label="いいね"
                 >
-                  <Heart size={13} className="text-white" fill={likedIds.has(video.id) ? 'white' : 'none'} strokeWidth={2} />
+                  <Heart size={15} className="text-white" fill={likedIds.has(video.id) ? 'white' : 'none'} strokeWidth={2} />
                 </button>
               )}
               {/* 既読バッジ（いいね済みでない場合のみ・左上） */}

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -421,13 +421,13 @@ function GridPage() {
               setViewedIds((prev) => new Set([...prev, video.id]));
             }}
           >
-            <div className="w-full bg-black relative group aspect-[2/3]">
+            <div className="w-full bg-black relative group aspect-[3/4]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               {/* 横長画像の右半分をトリミングして縦長表示 */}
               <img
                 src={video.thumbnail_url ?? ''}
                 alt={video.title ?? ''}
-                className="w-full h-full object-cover object-[80%_50%]"
+                className="w-full h-full object-cover object-right"
                 loading="lazy"
                 onLoad={() => setLoadedIds((prev) => new Set([...prev, video.id]))}
               />

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -35,12 +35,14 @@ function toFanzaEmbedUrl(externalId: string | null): string {
 
 const SOURCE_BADGE_COLORS: Record<string, string> = {
   exploitation: 'bg-violet-600 text-white',
+  exploitation_tag: 'bg-orange-500 text-white',
   popularity: 'bg-blue-600 text-white',
   exploration: 'bg-green-700 text-white',
 };
 
 const SOURCE_BORDER_COLORS: Record<string, string> = {
   exploitation: 'border-violet-500',
+  exploitation_tag: 'border-orange-400',
   popularity: 'border-blue-500',
   exploration: 'border-green-600',
 };

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -98,6 +98,7 @@ function GridPage() {
       });
       if (!res.ok) return;
       const data = await res.json();
+      if (isDebug && data._debug) console.log('[grid debug]', JSON.stringify(data._debug));
       const newVideos: VideoItem[] = (data.videos ?? []).filter(
         (v: VideoItem) => !loadedVideoIds.current.has(v.id)
       );
@@ -131,11 +132,6 @@ function GridPage() {
     const done = localStorage.getItem('onboarding_done');
     if (!done) {
       setShowOnboarding(true);
-    } else {
-      const saved = localStorage.getItem('onboarding_tags');
-      if (saved) {
-        try { preferredTagIds.current = JSON.parse(saved); } catch { /* ignore */ }
-      }
     }
   }, []);
 
@@ -158,6 +154,11 @@ function GridPage() {
   // 初回ロード（オンボーディング未完了の場合はスキップ、完了後に手動で呼ぶ）
   useEffect(() => {
     if (localStorage.getItem('onboarding_done')) {
+      // preferredTagIds を fetchVideos より先に読み込む
+      const saved = localStorage.getItem('onboarding_tags');
+      if (saved) {
+        try { preferredTagIds.current = JSON.parse(saved); } catch { /* ignore */ }
+      }
       fetchVideos();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -427,7 +427,7 @@ function GridPage() {
               <img
                 src={video.thumbnail_url ?? ''}
                 alt={video.title ?? ''}
-                className="w-full h-full object-cover object-right"
+                className="w-full h-full object-cover object-[80%_50%]"
                 loading="lazy"
                 onLoad={() => setLoadedIds((prev) => new Set([...prev, video.id]))}
               />

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -423,8 +423,9 @@ function GridPage() {
           >
             <div className="w-full bg-black relative group aspect-[2/3]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
+              {/* 縦長サムネイル（全件保持済み）*/}
               <img
-                src={(video.thumbnail_vertical_url?.replace('ps.jpg', 'pl.jpg')) || video.thumbnail_url || ''}
+                src={video.thumbnail_vertical_url?.replace('ps.jpg', 'pl.jpg') ?? ''}
                 alt={video.title ?? ''}
                 className="w-full h-full object-cover"
                 loading="lazy"

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -400,12 +400,12 @@ function GridPage() {
 
       {/* グリッド: モバイル=2カラム縦長、PC=Pinterestスタイル */}
       <div className="px-2 sm:px-3 py-4">
-      {/* モバイル: 2カラムグリッド */}
-      <div className="grid grid-cols-2 gap-2 sm:hidden">
+      {/* モバイル: 2カラム masonry（columns） */}
+      <div className="columns-2 gap-2 space-y-2 sm:hidden">
         {videos.map((video) => (
           <div
             key={video.id}
-            className={`rounded-xl overflow-hidden cursor-pointer bg-[#161b22] border transition-all shadow-md ${
+            className={`break-inside-avoid rounded-xl overflow-hidden cursor-pointer bg-[#161b22] border transition-all shadow-md ${
               loadedIds.has(video.id) ? 'opacity-100' : 'opacity-0'
             } ${
               likedIds.has(video.id)
@@ -463,7 +463,7 @@ function GridPage() {
             </div>
             {/* タイトル・タグ */}
             <div className="px-2 pt-1.5 pb-2">
-              <p className="text-[11px] font-semibold text-[#e6edf3] line-clamp-2 leading-snug mb-1">
+              <p className="text-[11px] font-semibold text-[#e6edf3] leading-snug mb-1">
                 {video.title}
               </p>
               {(video.tags as { id: string; name: string }[])?.length > 0 && (

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -421,7 +421,7 @@ function GridPage() {
               setViewedIds((prev) => new Set([...prev, video.id]));
             }}
           >
-            <div className="w-full bg-black relative group aspect-[5/7]">
+            <div className="w-full bg-black relative group aspect-[7/10]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               {/* 横長画像の右半分をトリミングして縦長表示 */}
               <img

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -398,9 +398,10 @@ function GridPage() {
       </div>
       </div>{/* /max-w-4xl */}
 
-      {/* グリッド: モバイル2カラム・縦長サムネイル */}
-      <div className="px-2 py-4">
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
+      {/* グリッド: モバイル=2カラム縦長、PC=Pinterestスタイル */}
+      <div className="px-2 sm:px-3 py-4">
+      {/* モバイル: 2カラムグリッド */}
+      <div className="grid grid-cols-2 gap-2 sm:hidden">
         {videos.map((video) => (
           <div
             key={video.id}
@@ -420,13 +421,74 @@ function GridPage() {
               setViewedIds((prev) => new Set([...prev, video.id]));
             }}
           >
-            {/* サムネイル: 縦長固定比率 */}
             <div className="w-full bg-black relative group aspect-[2/3]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={(video.thumbnail_vertical_url?.replace('ps.jpg', 'pl.jpg')) || video.thumbnail_url || ''}
                 alt={video.title ?? ''}
                 className="w-full h-full object-cover"
+                loading="lazy"
+                onLoad={() => setLoadedIds((prev) => new Set([...prev, video.id]))}
+              />
+              {viewedIds.has(video.id) && !likedIds.has(video.id) && <div className="absolute inset-0 bg-black/60 pointer-events-none" />}
+              {likedIds.has(video.id) && <div className="absolute inset-0 bg-pink-500/40 pointer-events-none" />}
+              {nopedIds.has(video.id) && <div className="absolute inset-0 bg-black/70 pointer-events-none" />}
+              <div className="absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-black/70 to-transparent pointer-events-none" />
+              {nopedIds.has(video.id) ? (
+                <div className="absolute bottom-2 right-2 w-8 h-8 rounded-full bg-white/20 flex items-center justify-center shadow-md pointer-events-none">
+                  <X size={14} className="text-white/80" strokeWidth={2.5} />
+                </div>
+              ) : (
+                <button
+                  className={`absolute bottom-2 right-2 w-8 h-8 rounded-full flex items-center justify-center transition-colors shadow-lg ${likedIds.has(video.id) ? 'bg-pink-500' : 'bg-black/50 hover:bg-pink-500/80'}`}
+                  onClick={(e) => { e.stopPropagation(); handleLike(video); }}
+                  aria-label="いいね"
+                >
+                  <Heart size={15} className="text-white" fill={likedIds.has(video.id) ? 'white' : 'none'} strokeWidth={2} />
+                </button>
+              )}
+              {viewedIds.has(video.id) && !likedIds.has(video.id) && (
+                <div className="absolute top-1.5 left-1.5 w-5 h-5 rounded-full bg-black/60 border border-white/20 flex items-center justify-center pointer-events-none">
+                  <Eye size={10} className="text-white/70" />
+                </div>
+              )}
+              {isDebug && (
+                <div className="absolute bottom-1 left-1">
+                  <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded ${SOURCE_BADGE_COLORS[video.source] ?? 'bg-gray-600 text-white'}`}>{video.source}</span>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      {/* PC: Pinterestスタイル */}
+      <div className="hidden sm:block columns-2 md:columns-3 lg:columns-4 xl:columns-5 gap-2 space-y-2">
+        {videos.map((video) => (
+          <div
+            key={video.id}
+            className={`break-inside-avoid rounded-2xl overflow-hidden cursor-pointer bg-[#161b22] border transition-all shadow-md ${
+              loadedIds.has(video.id) ? 'opacity-100' : 'opacity-0'
+            } ${
+              likedIds.has(video.id)
+                ? 'border-pink-500/60'
+                : isDebug
+                  ? (SOURCE_BORDER_COLORS[video.source] ?? 'border-[#30363d]')
+                  : 'border-[#30363d] hover:border-violet-500/60'
+            }`}
+            onClick={() => {
+              if (overlayHideTimer.current) clearTimeout(overlayHideTimer.current);
+              setShowVideo(false);
+              setSelected(video);
+              setViewedIds((prev) => new Set([...prev, video.id]));
+            }}
+          >
+            {/* サムネイル */}
+            <div className="w-full bg-black relative group">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={(video.thumbnail_vertical_url?.replace('ps.jpg', 'pl.jpg')) || video.thumbnail_url || ''}
+                alt={video.title ?? ''}
+                className="w-full object-cover"
                 loading="lazy"
                 onLoad={() => setLoadedIds((prev) => new Set([...prev, video.id]))}
               />
@@ -509,8 +571,7 @@ function GridPage() {
           </div>
         ))}
       </div>
-
-      </div>{/* columns */}
+      </div>{/* PC columns / モバイルgrid wrapper */}
 
       {/* ローダー */}
       <div ref={loaderRef} className="h-16 flex items-center justify-center">

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -423,11 +423,11 @@ function GridPage() {
           >
             <div className="w-full bg-black relative group aspect-[2/3]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              {/* 縦長サムネイル: pl.jpg → pt.jpg でパッケージ表紙（縦長）を使用 */}
+              {/* 横長画像の右半分をトリミングして縦長表示 */}
               <img
-                src={video.thumbnail_url?.replace('pl.jpg', 'pt.jpg') ?? ''}
+                src={video.thumbnail_url ?? ''}
                 alt={video.title ?? ''}
-                className="w-full h-full object-cover"
+                className="w-full h-full object-cover object-right"
                 loading="lazy"
                 onLoad={() => setLoadedIds((prev) => new Set([...prev, video.id]))}
               />

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -423,9 +423,9 @@ function GridPage() {
           >
             <div className="w-full bg-black relative group aspect-[2/3]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              {/* 縦長サムネイル（全件保持済み）*/}
+              {/* 縦長サムネイル: pl.jpg → pt.jpg でパッケージ表紙（縦長）を使用 */}
               <img
-                src={video.thumbnail_vertical_url?.replace('ps.jpg', 'pl.jpg') ?? ''}
+                src={video.thumbnail_url?.replace('pl.jpg', 'pt.jpg') ?? ''}
                 alt={video.title ?? ''}
                 className="w-full h-full object-cover"
                 loading="lazy"

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -704,7 +704,7 @@ function GridPage() {
                     className="flex items-center gap-1.5 justify-center w-full py-2 rounded-lg bg-[#f0f0f0] hover:bg-[#e0e0e0] text-gray-500 text-xs font-medium transition-colors"
                   >
                     <ExternalLink size={12} />
-                    FANZAで購入・詳細を見る
+                    本編を見る
                   </a>
                 )}
               </div>

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -421,9 +421,9 @@ function GridPage() {
               setViewedIds((prev) => new Set([...prev, video.id]));
             }}
           >
-            <div className="w-full bg-black relative group aspect-[7/10]">
+            {/* サムネイル */}
+            <div className="w-full bg-black relative aspect-[7/10]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              {/* 横長画像の右半分をトリミングして縦長表示 */}
               <img
                 src={video.thumbnail_url ?? ''}
                 alt={video.title ?? ''}
@@ -432,9 +432,16 @@ function GridPage() {
                 onLoad={() => setLoadedIds((prev) => new Set([...prev, video.id]))}
               />
               {viewedIds.has(video.id) && !likedIds.has(video.id) && <div className="absolute inset-0 bg-black/60 pointer-events-none" />}
-              {likedIds.has(video.id) && <div className="absolute inset-0 bg-pink-500/40 pointer-events-none" />}
+              {likedIds.has(video.id) && <div className="absolute inset-0 bg-pink-500/30 pointer-events-none" />}
               {nopedIds.has(video.id) && <div className="absolute inset-0 bg-black/70 pointer-events-none" />}
-              <div className="absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-black/70 to-transparent pointer-events-none" />
+              <div className="absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-black/80 to-transparent pointer-events-none" />
+              {/* 再生ボタン（中央・常時表示） */}
+              <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                <div className="w-10 h-10 rounded-full bg-black/50 border border-white/30 flex items-center justify-center">
+                  <Play size={18} className="text-white ml-0.5" fill="currentColor" />
+                </div>
+              </div>
+              {/* ハートボタン（右下） */}
               {nopedIds.has(video.id) ? (
                 <div className="absolute bottom-2 right-2 w-8 h-8 rounded-full bg-white/20 flex items-center justify-center shadow-md pointer-events-none">
                   <X size={14} className="text-white/80" strokeWidth={2.5} />
@@ -448,14 +455,24 @@ function GridPage() {
                   <Heart size={15} className="text-white" fill={likedIds.has(video.id) ? 'white' : 'none'} strokeWidth={2} />
                 </button>
               )}
-              {viewedIds.has(video.id) && !likedIds.has(video.id) && (
-                <div className="absolute top-1.5 left-1.5 w-5 h-5 rounded-full bg-black/60 border border-white/20 flex items-center justify-center pointer-events-none">
-                  <Eye size={10} className="text-white/70" />
-                </div>
-              )}
               {isDebug && (
                 <div className="absolute bottom-1 left-1">
                   <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded ${SOURCE_BADGE_COLORS[video.source] ?? 'bg-gray-600 text-white'}`}>{video.source}</span>
+                </div>
+              )}
+            </div>
+            {/* タイトル・タグ */}
+            <div className="px-2 pt-1.5 pb-2">
+              <p className="text-[11px] font-semibold text-[#e6edf3] line-clamp-2 leading-snug mb-1">
+                {video.title}
+              </p>
+              {(video.tags as { id: string; name: string }[])?.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {(video.tags as { id: string; name: string }[]).slice(0, 2).map((t) => (
+                    <span key={t.id} className="text-[9px] bg-violet-900/40 border border-violet-700/40 text-violet-300 rounded-full px-1.5 py-0.5">
+                      {t.name}
+                    </span>
+                  ))}
                 </div>
               )}
             </div>

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -421,7 +421,7 @@ function GridPage() {
               setViewedIds((prev) => new Set([...prev, video.id]));
             }}
           >
-            <div className="w-full bg-black relative group aspect-[3/4]">
+            <div className="w-full bg-black relative group aspect-[5/7]">
               {/* eslint-disable-next-line @next/next/no-img-element */}
               {/* 横長画像の右半分をトリミングして縦長表示 */}
               <img

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -167,7 +167,11 @@ function GridPage() {
   // 無限スクロール
   useEffect(() => {
     const observer = new IntersectionObserver(
-      (entries) => { if (entries[0].isIntersecting) fetchVideos(); },
+      (entries) => {
+        // オンボーディング未完了の場合はスキップ
+        if (!localStorage.getItem('onboarding_done')) return;
+        if (entries[0].isIntersecting) fetchVideos();
+      },
       { threshold: 0.1 }
     );
     if (loaderRef.current) observer.observe(loaderRef.current);

--- a/frontend/src/app/list/[token]/CopyLinkButton.tsx
+++ b/frontend/src/app/list/[token]/CopyLinkButton.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState } from 'react';
+import { Link2, Check } from 'lucide-react';
+
+export default function CopyLinkButton({ url }: { url: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium border border-[#30363d] text-[#8b949e] hover:border-violet-500/50 hover:text-[#e6edf3] transition-all"
+    >
+      {copied ? (
+        <><Check size={14} className="text-green-400" />コピーしました</>
+      ) : (
+        <><Link2 size={14} />リンクをコピー</>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -1,0 +1,170 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { supabase } from '@/lib/supabase';
+import CopyLinkButton from './CopyLinkButton';
+
+const SITE_URL = 'https://www.seihekilab.com';
+const AF_ID = process.env.NEXT_PUBLIC_FANZA_AFFILIATE_ID ?? 'yotadata2-001';
+
+type Video = {
+  id: string;
+  title: string | null;
+  external_id: string | null;
+  thumbnail_url: string | null;
+  thumbnail_vertical_url: string | null;
+  product_url: string | null;
+  liked_at: string;
+};
+
+type TagStat = { tag_name: string; cnt: number };
+
+type ListData = {
+  title: string | null;
+  videos: Video[];
+  tags: TagStat[];
+};
+
+function toAffiliateUrl(raw?: string | null): string {
+  if (!raw) return '';
+  if (raw.startsWith('https://al.fanza.co.jp/')) {
+    try {
+      const u = new URL(raw);
+      u.searchParams.set('af_id', AF_ID);
+      return u.toString();
+    } catch { /* ignore */ }
+  }
+  return `https://al.fanza.co.jp/?lurl=${encodeURIComponent(raw)}&af_id=${encodeURIComponent(AF_ID)}&ch=link_tool&ch_id=link`;
+}
+
+async function fetchListData(token: string): Promise<ListData | null> {
+  const { data, error } = await supabase.rpc('get_public_list_data', { p_token: token });
+  if (error || !data || data.error === 'not_found') return null;
+  return data as ListData;
+}
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ token: string }> }
+): Promise<Metadata> {
+  const { token } = await params;
+  const data = await fetchListData(token);
+  if (!data) return { title: 'リストが見つかりません | 性癖ラボ' };
+
+  const title = data.title ?? '私のお気に入りリスト';
+  const topTags = data.tags.slice(0, 3).map((t) => t.tag_name).join('・');
+  const description = topTags
+    ? `好きなジャンル: ${topTags}。${data.videos.length}作品のいいねリスト。`
+    : `${data.videos.length}作品のいいねリスト。`;
+
+  return {
+    title: `${title} | 性癖ラボ`,
+    description,
+    openGraph: {
+      title: `${title} | 性癖ラボ`,
+      description,
+      url: `${SITE_URL}/list/${token}`,
+      siteName: '性癖ラボ',
+      type: 'website',
+    },
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function PublicListPage(
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+  const data = await fetchListData(token);
+  if (!data) notFound();
+
+  const title = data.title ?? 'お気に入りリスト';
+  const pageUrl = `${SITE_URL}/list/${token}`;
+
+  return (
+    <div className="min-h-screen bg-[#0d1117] text-[#e6edf3]">
+      <div className="max-w-4xl mx-auto px-4 py-10">
+
+        {/* ヘッダー */}
+        <div className="mb-8">
+          <Link href="/" className="text-xs text-[#656d76] hover:text-[#8b949e] transition-colors mb-4 inline-block">
+            ← 性癖ラボ
+          </Link>
+          <h1 className="text-2xl font-black text-[#e6edf3] mb-2">{title}</h1>
+          <p className="text-sm text-[#8b949e]">{data.videos.length}作品のいいねリスト</p>
+          <div className="mt-3">
+            <CopyLinkButton url={pageUrl} />
+          </div>
+        </div>
+
+        {/* タグまとめ */}
+        {data.tags.length > 0 && (
+          <div className="mb-8 p-4 rounded-xl border border-[#21262d] bg-[#161b22]">
+            <p className="text-xs font-semibold text-[#656d76] uppercase tracking-wider mb-3">好きなジャンル</p>
+            <div className="flex flex-wrap gap-2">
+              {data.tags.map((t) => (
+                <span
+                  key={t.tag_name}
+                  className="px-3 py-1 rounded-full text-sm bg-violet-900/40 text-violet-300 border border-violet-500/30"
+                >
+                  {t.tag_name}
+                  <span className="ml-1.5 text-xs text-violet-400/60">{t.cnt}</span>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 作品グリッド */}
+        {data.videos.length === 0 ? (
+          <p className="text-center text-[#656d76] py-20">まだいいねした作品がありません。</p>
+        ) : (
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            {data.videos.map((video) => {
+              const affiliateUrl = toAffiliateUrl(video.product_url);
+              const thumb = video.thumbnail_vertical_url ?? video.thumbnail_url;
+              return (
+                <a
+                  key={video.id}
+                  href={affiliateUrl || '#'}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22]"
+                >
+                  {thumb ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={thumb}
+                      alt={video.title ?? ''}
+                      className="w-full aspect-[3/4] object-cover group-hover:opacity-90 transition-opacity"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="w-full aspect-[3/4] bg-[#21262d] flex items-center justify-center">
+                      <span className="text-[#484f58] text-xs">No Image</span>
+                    </div>
+                  )}
+                  <div className="p-2">
+                    <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
+                      {video.title ?? ''}
+                    </p>
+                  </div>
+                </a>
+              );
+            })}
+          </div>
+        )}
+
+        {/* フッター */}
+        <div className="mt-12 pt-6 border-t border-[#21262d] text-center">
+          <p className="text-sm text-[#656d76] mb-3">このリストは性癖ラボで作成されました</p>
+          <Link
+            href="/grid"
+            className="inline-block px-6 py-2.5 rounded-full bg-violet-600 hover:bg-violet-500 text-white text-sm font-bold transition-colors"
+          >
+            自分のリストを作る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { supabase } from '@/lib/supabase';
 import CopyLinkButton from './CopyLinkButton';
 
-const SITE_URL = 'https://www.seihekilab.com';
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.seihekilab.com';
 const AF_ID = process.env.NEXT_PUBLIC_FANZA_AFFILIATE_ID ?? 'yotadata2-001';
 
 type Video = {

--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -207,7 +207,12 @@ function SwipePage() {
       if (session?.access_token) headers.Authorization = `Bearer ${session.access_token}`;
       const timeoutMs = 12000;
       const timeoutPromise = new Promise<never>((_, reject) => setTimeout(() => reject(new Error('videos-feed timeout')), timeoutMs));
-      const invokePromise = supabase.functions.invoke('videos-feed', { headers, body: {} });
+      const savedTags = localStorage.getItem('onboarding_tags');
+      const preferredTagIds = savedTags ? (() => { try { return JSON.parse(savedTags); } catch { return []; } })() : [];
+      const invokePromise = supabase.functions.invoke('videos-feed', {
+        headers,
+        body: preferredTagIds.length > 0 ? { preferred_tag_ids: preferredTagIds } : {},
+      });
       const { data, error } = await Promise.race([invokePromise, timeoutPromise]);
       if (error) {
         console.error('Error from videos-feed invoke:', error);

--- a/frontend/src/components/AccountManagementDrawer.tsx
+++ b/frontend/src/components/AccountManagementDrawer.tsx
@@ -2,7 +2,7 @@
 
 import { Dialog, Transition } from '@headlessui/react';
 import { Fragment, useEffect, useState, useCallback } from 'react';
-import { X, Heart, Tag, Users, TrendingUp } from 'lucide-react';
+import { X, Heart, Tag, Users, TrendingUp, Link2, Check, Loader2 } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 
 interface AccountManagementDrawerProps {
@@ -20,6 +20,9 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
   const [tags, setTags] = useState<TagItem[]>([]);
   const [performers, setPerformers] = useState<PerformerItem[]>([]);
   const [loading, setLoading] = useState(false);
+  const [publicToken, setPublicToken] = useState<string | null>(null);
+  const [tokenLoading, setTokenLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     const checkLoginStatus = async () => {
@@ -56,8 +59,45 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
   }, []);
 
   useEffect(() => {
-    if (isOpen && isLoggedIn) fetchInsights();
+    if (isOpen && isLoggedIn) {
+      fetchInsights();
+      // 既存の公開トークンを取得
+      supabase.from('public_lists').select('token').eq('is_active', true).maybeSingle()
+        .then(({ data }) => { if (data) setPublicToken(data.token); });
+    }
   }, [isOpen, isLoggedIn, fetchInsights]);
+
+  const handleCreatePublicList = async () => {
+    setTokenLoading(true);
+    try {
+      const { data: existing } = await supabase
+        .from('public_lists').select('token').eq('is_active', true).maybeSingle();
+      if (existing) {
+        setPublicToken(existing.token);
+      } else {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (!user) return;
+        const { data } = await supabase
+          .from('public_lists').insert({ user_id: user.id }).select('token').single();
+        if (data) setPublicToken(data.token);
+      }
+    } finally {
+      setTokenLoading(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!publicToken) return;
+    await navigator.clipboard.writeText(`https://www.seihekilab.com/list/${publicToken}`);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDeletePublicList = async () => {
+    if (!publicToken) return;
+    await supabase.from('public_lists').update({ is_active: false }).eq('token', publicToken);
+    setPublicToken(null);
+  };
 
   const handleLogout = async () => {
     try {
@@ -172,6 +212,49 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
                           </section>
 
                           <div className="border-t border-white/10" />
+                        </>
+                      )}
+
+                      {/* 公開リスト */}
+                      {isLoggedIn && (
+                        <>
+                          <div className="border-t border-white/10" />
+                          <section className="space-y-3">
+                            <p className="text-[11px] text-[#8b949e] font-semibold uppercase tracking-wider">公開リスト</p>
+                            <p className="text-xs text-[#656d76]">いいねリストを URL で公開・シェアできます。</p>
+                            {publicToken ? (
+                              <div className="space-y-2">
+                                <div className="flex items-center gap-2 p-2.5 rounded-lg bg-[#161b22] border border-[#30363d] text-xs text-[#8b949e] truncate">
+                                  <Link2 size={12} className="shrink-0" />
+                                  <span className="truncate">seihekilab.com/list/{publicToken}</span>
+                                </div>
+                                <div className="flex gap-2">
+                                  <button
+                                    onClick={handleCopyLink}
+                                    className="flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors"
+                                  >
+                                    {copied ? <><Check size={12} />コピー済み</> : <><Link2 size={12} />リンクをコピー</>}
+                                  </button>
+                                  <button
+                                    onClick={handleDeletePublicList}
+                                    className="px-3 py-2 rounded-lg bg-red-500/20 text-red-400 border border-red-500/30 text-xs font-bold hover:bg-red-500/30 transition-colors"
+                                  >
+                                    削除
+                                  </button>
+                                </div>
+                              </div>
+                            ) : (
+                              <button
+                                onClick={handleCreatePublicList}
+                                disabled={tokenLoading}
+                                className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-[#e6edf3] text-sm font-bold transition-all disabled:opacity-50"
+                              >
+                                {tokenLoading
+                                  ? <><Loader2 size={14} className="animate-spin" />作成中…</>
+                                  : <><Link2 size={14} />公開リンクを作成</>}
+                              </button>
+                            )}
+                          </section>
                         </>
                       )}
 

--- a/frontend/src/components/AccountManagementDrawer.tsx
+++ b/frontend/src/components/AccountManagementDrawer.tsx
@@ -88,7 +88,7 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
 
   const handleCopyLink = async () => {
     if (!publicToken) return;
-    await navigator.clipboard.writeText(`https://www.seihekilab.com/list/${publicToken}`);
+    await navigator.clipboard.writeText(`${window.location.origin}/list/${publicToken}`);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -226,7 +226,7 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
                               <div className="space-y-2">
                                 <div className="flex items-center gap-2 p-2.5 rounded-lg bg-[#161b22] border border-[#30363d] text-xs text-[#8b949e] truncate">
                                   <Link2 size={12} className="shrink-0" />
-                                  <span className="truncate">seihekilab.com/list/{publicToken}</span>
+                                  <span className="truncate">{typeof window !== 'undefined' ? window.location.host : 'seihekilab.com'}/list/{publicToken}</span>
                                 </div>
                                 <div className="flex gap-2">
                                   <button

--- a/frontend/src/components/FanzaLinkButton.tsx
+++ b/frontend/src/components/FanzaLinkButton.tsx
@@ -18,7 +18,7 @@ export default function FanzaLinkButton({ href, videoId, source = 'video_page' }
       onClick={() => trackEvent('fanza_link_click', { video_id: videoId, source })}
       className="block w-full text-center bg-amber-500 hover:bg-amber-400 text-white font-bold rounded-lg py-3 text-sm transition-colors"
     >
-      FANZAで見る
+      本編を見る
     </Link>
   );
 }

--- a/frontend/src/components/VideoDetailModal.tsx
+++ b/frontend/src/components/VideoDetailModal.tsx
@@ -161,14 +161,13 @@ export default function VideoDetailModal({ isOpen, onClose, videoId }: { isOpen:
                       </div>
                       <div>
                         <div className="border rounded-lg p-3">
-                          <div className="text-sm text-gray-700 mb-2">外部サイトで見る</div>
                           <Link
                             href={video.product_url || '#'}
                             target="_blank"
                             onClick={() => trackEvent('fanza_link_click', { video_id: video.id, source: 'modal' })}
                             className="block w-full text-center bg-amber-500 text-white font-bold rounded-lg py-2"
                           >
-                            商品ページへ
+                            本編を見る
                           </Link>
                         </div>
                       </div>

--- a/scripts/ingest_fanza/index.ts
+++ b/scripts/ingest_fanza/index.ts
@@ -537,7 +537,8 @@ async function updateRankings() {
   console.log('[ingest_fanza] === Starting ranking update ===');
   const rankingSources = [
     { service: 'digital', floor: 'videoa', source: 'fanza_videoa' },
-    { service: 'digital', floor: 'anime',  source: 'fanza_anime'  },
+    // アニメはランキングからも除外
+    // { service: 'digital', floor: 'anime',  source: 'fanza_anime'  },
   ];
   const hits = 100;
   const maxRank = 500;
@@ -629,7 +630,8 @@ async function main() {
 
   const sources = [
     { service: 'digital', floor: 'videoa', source: 'FANZA' },
-    { service: 'digital', floor: 'anime',  source: 'FANZA_ANIME' },
+    // アニメは取り込まない（非実写コンテンツ除外）
+    // { service: 'digital', floor: 'anime',  source: 'FANZA_ANIME' },
   ];
 
   let totalSuccess = 0;

--- a/supabase/functions/videos-feed/index.ts
+++ b/supabase/functions/videos-feed/index.ts
@@ -13,7 +13,7 @@ type VideoEntry = {
   tags: unknown
   score: number | null
   model_version: string | null
-  source: 'exploitation' | 'popularity' | 'exploration'
+  source: 'exploitation' | 'exploitation_tag' | 'popularity' | 'exploration'
 }
 
 const corsHeaders = {
@@ -66,6 +66,7 @@ Deno.serve(async (req) => {
     const authHeader = req.headers.get('Authorization') ?? ''
     const requestJson = await req.json().catch(() => ({}))
     const pageLimit = clampLimit(typeof requestJson.limit === 'number' ? requestJson.limit : undefined)
+    const preferredTagIds: string[] = Array.isArray(requestJson.preferred_tag_ids) ? requestJson.preferred_tag_ids : []
     const popularLookbackDays = typeof requestJson.popularity_days === 'number'
       ? Math.max(1, requestJson.popularity_days)
       : DEFAULT_POPULAR_LOOKBACK_DAYS
@@ -119,12 +120,51 @@ Deno.serve(async (req) => {
     const popularityTarget = Math.max(1, Math.floor(adjustedPageLimit * adjustedPopularityRatio))
     const explorationTarget = Math.max(0, adjustedPageLimit - exploitationTarget - popularityTarget)
 
+    // コールドスタート時のタグ推薦: exploitation=50%, popularity=30%, exploration=20%
+    const useTagMode = preferredTagIds.length > 0 && decisionCount === 0
+    const tagExploitationTarget = Math.floor(adjustedPageLimit * 0.5)
+    const tagPopularityTarget   = Math.floor(adjustedPageLimit * 0.3)
+    const tagExplorationTarget  = adjustedPageLimit - tagExploitationTarget - tagPopularityTarget
+    const effectiveExploitationTarget = useTagMode ? tagExploitationTarget : exploitationTarget
+    const effectivePopularityTarget   = useTagMode ? tagPopularityTarget   : popularityTarget
+    const effectiveExplorationTarget  = useTagMode ? tagExplorationTarget  : explorationTarget
+
     const seen = new Set<string>()
     const exploitation: VideoEntry[] = []
     const popularity: VideoEntry[] = []
     const exploration: VideoEntry[] = []
 
-    if (userId && adjustedExploitationRatio > 0) {
+    if (useTagMode) {
+      const { data: tagRecs, error: tagError } = await supabase.rpc('get_videos_by_tags', {
+        tag_ids: preferredTagIds,
+        exclude_ids: [],
+        p_limit: Math.max(tagExploitationTarget * CANDIDATE_MULTIPLIER, 60),
+      })
+      if (tagError) {
+        console.error('get_videos_by_tags error:', tagError.message)
+      } else {
+        for (const item of (tagRecs ?? []) as Record<string, unknown>[]) {
+          const id = String(item.id)
+          if (seen.has(id)) continue
+          exploitation.push({
+            id,
+            title: (item.title ?? null) as string | null,
+            description: null,
+            external_id: (item.external_id ?? null) as string | null,
+            thumbnail_url: (item.thumbnail_url ?? null) as string | null,
+            sample_video_url: (item.sample_video_url ?? null) as string | null,
+            product_released_at: (item.product_released_at ?? null) as string | null,
+            performers: (item.performers ?? []) as unknown,
+            tags: (item.tags ?? []) as unknown,
+            score: null,
+            model_version: null,
+            source: 'exploitation_tag',
+          })
+          seen.add(id)
+          if (exploitation.length >= tagExploitationTarget) break
+        }
+      }
+    } else if (userId && adjustedExploitationRatio > 0) {
       const { data: recs, error: recError } = await supabase.rpc('get_videos_recommendations', {
         user_uuid: userId,
         page_limit: Math.max(adjustedPageLimit * CANDIDATE_MULTIPLIER, 100),
@@ -155,10 +195,10 @@ Deno.serve(async (req) => {
       }
     }
 
-    if (popularityTarget > 0) {
+    if (effectivePopularityTarget > 0) {
       const { data: popData, error: popError } = await supabase.rpc('get_popular_videos', {
         user_uuid: userId,
-        limit_count: popularityTarget * CANDIDATE_MULTIPLIER,
+        limit_count: effectivePopularityTarget * CANDIDATE_MULTIPLIER,
         lookback_days: popularLookbackDays,
       })
       if (popError) {
@@ -184,13 +224,13 @@ Deno.serve(async (req) => {
             source: 'popularity',
           })
           seen.add(id)
-          if (popularity.length >= popularityTarget) break
+          if (popularity.length >= effectivePopularityTarget) break
         }
       }
     }
 
     const explorationNeeded = Math.max(0,
-      explorationTarget + (exploitationTarget - exploitation.length) + (popularityTarget - popularity.length),
+      effectiveExplorationTarget + (effectiveExploitationTarget - exploitation.length) + (effectivePopularityTarget - popularity.length),
     )
 
     if (explorationNeeded > 0) {

--- a/supabase/functions/videos-grid/index.ts
+++ b/supabase/functions/videos-grid/index.ts
@@ -106,11 +106,13 @@ Deno.serve(async (req) => {
     // コールドスタート時（decisionCount=0 + タグ選択済み）は
     // exploitation 枠をタグ一致動画で埋める（推薦モデルの代替）
     if (preferredTagIds.length > 0 && decisionCount === 0) {
+      console.log('[tag] preferredTagIds count:', preferredTagIds.length, 'first:', preferredTagIds[0])
       const { data: tagRecs, error: tagError } = await supabase.rpc('get_videos_by_tags', {
         tag_ids: preferredTagIds,
         exclude_ids: excludeIds.length > 0 ? excludeIds : [],
         p_limit: Math.max(exploitationTarget * CANDIDATE_MULTIPLIER, 60),
       })
+      console.log('[tag] tagRecs count:', (tagRecs ?? []).length, 'error:', tagError?.message)
       if (tagError) {
         console.error('get_videos_by_tags error:', tagError.message)
       } else {
@@ -258,7 +260,17 @@ Deno.serve(async (req) => {
       if (ei >= exploitation.length && pi >= popularity.length && xi >= exploration.length) break
     }
 
-    return new Response(JSON.stringify({ videos: final.slice(0, pageLimit) }), {
+    return new Response(JSON.stringify({
+      videos: final.slice(0, pageLimit),
+      _debug: {
+        preferredTagIds_count: preferredTagIds.length,
+        preferredTagIds_first: preferredTagIds[0] ?? null,
+        decisionCount,
+        exploitation_count: exploitation.length,
+        popularity_count: popularity.length,
+        exploration_count: exploration.length,
+      },
+    }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       status: 200,
     })

--- a/supabase/functions/videos-grid/index.ts
+++ b/supabase/functions/videos-grid/index.ts
@@ -14,7 +14,7 @@ type VideoEntry = {
   tags: unknown
   score: number | null
   model_version: string | null
-  source: 'exploitation' | 'popularity' | 'exploration'
+  source: 'exploitation' | 'exploitation_tag' | 'popularity' | 'exploration'
 }
 
 const corsHeaders = {
@@ -132,7 +132,7 @@ Deno.serve(async (req) => {
             tags: item.tags ?? [],
             score: null,
             model_version: null,
-            source: 'exploitation',
+            source: 'exploitation_tag',
           })
           seen.add(id)
           if (exploitation.length >= exploitationTarget) break

--- a/supabase/functions/videos-grid/index.ts
+++ b/supabase/functions/videos-grid/index.ts
@@ -128,8 +128,9 @@ Deno.serve(async (req) => {
             embed_url: toEmbedUrl((item.external_id ?? null) as string | null),
             product_url: (item.product_url ?? null) as string | null,
             product_released_at: (item.product_released_at ?? null) as string | null,
-            performers: item.performers ?? [],
-            tags: item.tags ?? [],
+            // video_performers(performers(id,name)) の二重ネストをフラット化
+            performers: ((item.performers as {performers: {id:string;name:string}}[]) ?? []).map(p => p.performers).filter(Boolean),
+            tags: ((item.tags as {tags: {id:string;name:string}}[]) ?? []).map(t => t.tags).filter(Boolean),
             score: null,
             model_version: null,
             source: 'exploitation_tag',

--- a/supabase/functions/videos-grid/index.ts
+++ b/supabase/functions/videos-grid/index.ts
@@ -106,52 +106,35 @@ Deno.serve(async (req) => {
     // コールドスタート時（decisionCount=0 + タグ選択済み）は
     // exploitation 枠をタグ一致動画で埋める（推薦モデルの代替）
     if (preferredTagIds.length > 0 && decisionCount === 0) {
-      // step1: タグに一致するユニークな video_id を取得
-      const { data: tagMatches, error: tagMatchError } = await supabase
-        .from('video_tags')
-        .select('video_id')
-        .in('tag_id', preferredTagIds)
-        .limit(500)
-      if (tagMatchError) {
-        console.error('tag match error:', tagMatchError.message)
+      const { data: tagRecs, error: tagError } = await supabase.rpc('get_videos_by_tags', {
+        tag_ids: preferredTagIds,
+        exclude_ids: excludeIds.length > 0 ? excludeIds : [],
+        p_limit: Math.max(exploitationTarget * CANDIDATE_MULTIPLIER, 60),
+      })
+      if (tagError) {
+        console.error('get_videos_by_tags error:', tagError.message)
       } else {
-        const candidateIds = [...new Set(
-          (tagMatches ?? []).map(r => String(r.video_id))
-        )].filter(id => !seen.has(id)).slice(0, Math.max(exploitationTarget * CANDIDATE_MULTIPLIER, 60))
-
-        if (candidateIds.length > 0) {
-          // step2: video_id リストで動画詳細を取得
-          const { data: tagRecs, error: tagRecsError } = await supabase
-            .from('videos')
-            .select('id, title, external_id, thumbnail_url, thumbnail_vertical_url, sample_video_url, product_url, product_released_at, performers:video_performers(performers(id, name)), tags:video_tags(tags(id, name))')
-            .in('id', candidateIds)
-            .limit(candidateIds.length)
-          if (tagRecsError) {
-            console.error('tag recs error:', tagRecsError.message)
-          } else {
-            for (const item of (tagRecs ?? []) as Record<string, unknown>[]) {
-              const id = String(item.id)
-              if (seen.has(id)) continue
-              exploitation.push({
-                id,
-                title: (item.title ?? null) as string | null,
-                external_id: (item.external_id ?? null) as string | null,
-                thumbnail_url: (item.thumbnail_url ?? null) as string | null,
-                thumbnail_vertical_url: (item.thumbnail_vertical_url ?? null) as string | null,
-                sample_video_url: (item.sample_video_url ?? null) as string | null,
-                embed_url: toEmbedUrl((item.external_id ?? null) as string | null),
-                product_url: (item.product_url ?? null) as string | null,
-                product_released_at: (item.product_released_at ?? null) as string | null,
-                performers: ((item.performers as {performers:{id:string;name:string}}[]) ?? []).map(p => p.performers).filter(Boolean),
-                tags: ((item.tags as {tags:{id:string;name:string}}[]) ?? []).map(t => t.tags).filter(Boolean),
-                score: null,
-                model_version: null,
-                source: 'exploitation_tag',
-              })
-              seen.add(id)
-              if (exploitation.length >= exploitationTarget) break
-            }
-          }
+        for (const item of (tagRecs ?? []) as Record<string, unknown>[]) {
+          const id = String(item.id)
+          if (seen.has(id)) continue
+          exploitation.push({
+            id,
+            title: (item.title ?? null) as string | null,
+            external_id: (item.external_id ?? null) as string | null,
+            thumbnail_url: (item.thumbnail_url ?? null) as string | null,
+            thumbnail_vertical_url: (item.thumbnail_vertical_url ?? null) as string | null,
+            sample_video_url: (item.sample_video_url ?? null) as string | null,
+            embed_url: toEmbedUrl((item.external_id ?? null) as string | null),
+            product_url: (item.product_url ?? null) as string | null,
+            product_released_at: (item.product_released_at ?? null) as string | null,
+            performers: (item.performers ?? []) as unknown,
+            tags: (item.tags ?? []) as unknown,
+            score: null,
+            model_version: null,
+            source: 'exploitation_tag',
+          })
+          seen.add(id)
+          if (exploitation.length >= exploitationTarget) break
         }
       }
     } else if (userId && adjustedExploitationRatio > 0) {

--- a/supabase/functions/videos-grid/index.ts
+++ b/supabase/functions/videos-grid/index.ts
@@ -103,7 +103,43 @@ Deno.serve(async (req) => {
     const popularity: VideoEntry[] = []
     const exploration: VideoEntry[] = []
 
-    if (userId && adjustedExploitationRatio > 0) {
+    // decisionCount=0 かつ preferredTagIds がある場合はタグ一致動画で exploitation を埋める
+    const useTagExploitation = preferredTagIds.length > 0 && decisionCount === 0
+
+    if (useTagExploitation) {
+      const { data: tagRecs, error: tagError } = await supabase
+        .from('videos')
+        .select('id, title, external_id, thumbnail_url, thumbnail_vertical_url, sample_video_url, product_url, product_released_at, performers:video_performers(performers(id, name)), tags:video_tags(tags(id, name)), video_tags!inner(tag_id)')
+        .in('video_tags.tag_id', preferredTagIds)
+        .not('id', 'in', `(${excludeIds.length > 0 ? excludeIds.join(',') : '00000000-0000-0000-0000-000000000000'})`)
+        .limit(Math.max(exploitationTarget * CANDIDATE_MULTIPLIER, 60))
+      if (tagError) {
+        console.error('tag exploitation error:', tagError.message)
+      } else {
+        for (const item of (tagRecs ?? []) as Record<string, unknown>[]) {
+          const id = String(item.id)
+          if (seen.has(id)) continue
+          exploitation.push({
+            id,
+            title: (item.title ?? null) as string | null,
+            external_id: (item.external_id ?? null) as string | null,
+            thumbnail_url: (item.thumbnail_url ?? null) as string | null,
+            thumbnail_vertical_url: (item.thumbnail_vertical_url ?? null) as string | null,
+            sample_video_url: (item.sample_video_url ?? null) as string | null,
+            embed_url: toEmbedUrl((item.external_id ?? null) as string | null),
+            product_url: (item.product_url ?? null) as string | null,
+            product_released_at: (item.product_released_at ?? null) as string | null,
+            performers: item.performers ?? [],
+            tags: item.tags ?? [],
+            score: null,
+            model_version: null,
+            source: 'exploitation',
+          })
+          seen.add(id)
+          if (exploitation.length >= exploitationTarget) break
+        }
+      }
+    } else if (userId && adjustedExploitationRatio > 0) {
       const { data: recs, error: recError } = await supabase.rpc('get_videos_recommendations', {
         user_uuid: userId,
         page_limit: Math.max(pageLimit * CANDIDATE_MULTIPLIER, 100),
@@ -176,35 +212,14 @@ Deno.serve(async (req) => {
     )
 
     if (explorationNeeded > 0) {
-      // preferredTagIds がある場合（オンボーディング直後）はタグ一致動画を優先取得
       let randomData: Record<string, unknown>[] | null = null
       let randomError: { message: string } | null = null
 
-      if (preferredTagIds.length > 0 && decisionCount === 0) {
-        const { data, error } = await supabase
-          .from('videos')
-          .select(`
-            id, title, external_id, thumbnail_url, thumbnail_vertical_url,
-            sample_video_url, product_url, product_released_at,
-            performers:video_performers(performers(id, name)),
-            tags:video_tags(tags(id, name)),
-            video_tags!inner(tag_id)
-          `)
-          .in('video_tags.tag_id', preferredTagIds)
-          .not('id', 'in', `(${excludeIds.length > 0 ? excludeIds.join(',') : 'null'})`)
-          .limit(Math.max(explorationNeeded * CANDIDATE_MULTIPLIER, DEFAULT_LIMIT))
-        randomData = (data as unknown as Record<string, unknown>[] | null)
-        randomError = error
-      }
-
-      // フォールバック: タグ指定なし or 取得失敗時はランダム取得
-      if (!randomData || randomData.length === 0) {
-        const { data, error } = await supabase.rpc('get_videos_feed', {
-          page_limit: Math.max(explorationNeeded * CANDIDATE_MULTIPLIER, DEFAULT_LIMIT),
-        })
-        randomData = data
-        randomError = error
-      }
+      const { data, error } = await supabase.rpc('get_videos_feed', {
+        page_limit: Math.max(explorationNeeded * CANDIDATE_MULTIPLIER, DEFAULT_LIMIT),
+      })
+      randomData = data
+      randomError = error
       if (randomError) {
         console.error('get_videos_feed error:', randomError.message)
       } else {

--- a/supabase/functions/videos-grid/index.ts
+++ b/supabase/functions/videos-grid/index.ts
@@ -106,37 +106,52 @@ Deno.serve(async (req) => {
     // コールドスタート時（decisionCount=0 + タグ選択済み）は
     // exploitation 枠をタグ一致動画で埋める（推薦モデルの代替）
     if (preferredTagIds.length > 0 && decisionCount === 0) {
-      const { data: tagRecs, error: tagError } = await supabase
-        .from('videos')
-        .select('id, title, external_id, thumbnail_url, thumbnail_vertical_url, sample_video_url, product_url, product_released_at, performers:video_performers(performers(id, name)), tags:video_tags(tags(id, name)), video_tags!inner(tag_id)')
-        .in('video_tags.tag_id', preferredTagIds)
-        .not('id', 'in', `(${excludeIds.length > 0 ? excludeIds.join(',') : '00000000-0000-0000-0000-000000000000'})`)
-        .limit(Math.max(exploitationTarget * CANDIDATE_MULTIPLIER, 60))
-      if (tagError) {
-        console.error('tag exploitation error:', tagError.message)
+      // step1: タグに一致するユニークな video_id を取得
+      const { data: tagMatches, error: tagMatchError } = await supabase
+        .from('video_tags')
+        .select('video_id')
+        .in('tag_id', preferredTagIds)
+        .limit(500)
+      if (tagMatchError) {
+        console.error('tag match error:', tagMatchError.message)
       } else {
-        for (const item of (tagRecs ?? []) as Record<string, unknown>[]) {
-          const id = String(item.id)
-          if (seen.has(id)) continue
-          exploitation.push({
-            id,
-            title: (item.title ?? null) as string | null,
-            external_id: (item.external_id ?? null) as string | null,
-            thumbnail_url: (item.thumbnail_url ?? null) as string | null,
-            thumbnail_vertical_url: (item.thumbnail_vertical_url ?? null) as string | null,
-            sample_video_url: (item.sample_video_url ?? null) as string | null,
-            embed_url: toEmbedUrl((item.external_id ?? null) as string | null),
-            product_url: (item.product_url ?? null) as string | null,
-            product_released_at: (item.product_released_at ?? null) as string | null,
-            // video_performers(performers(id,name)) の二重ネストをフラット化
-            performers: ((item.performers as {performers: {id:string;name:string}}[]) ?? []).map(p => p.performers).filter(Boolean),
-            tags: ((item.tags as {tags: {id:string;name:string}}[]) ?? []).map(t => t.tags).filter(Boolean),
-            score: null,
-            model_version: null,
-            source: 'exploitation_tag',
-          })
-          seen.add(id)
-          if (exploitation.length >= exploitationTarget) break
+        const candidateIds = [...new Set(
+          (tagMatches ?? []).map(r => String(r.video_id))
+        )].filter(id => !seen.has(id)).slice(0, Math.max(exploitationTarget * CANDIDATE_MULTIPLIER, 60))
+
+        if (candidateIds.length > 0) {
+          // step2: video_id リストで動画詳細を取得
+          const { data: tagRecs, error: tagRecsError } = await supabase
+            .from('videos')
+            .select('id, title, external_id, thumbnail_url, thumbnail_vertical_url, sample_video_url, product_url, product_released_at, performers:video_performers(performers(id, name)), tags:video_tags(tags(id, name))')
+            .in('id', candidateIds)
+            .limit(candidateIds.length)
+          if (tagRecsError) {
+            console.error('tag recs error:', tagRecsError.message)
+          } else {
+            for (const item of (tagRecs ?? []) as Record<string, unknown>[]) {
+              const id = String(item.id)
+              if (seen.has(id)) continue
+              exploitation.push({
+                id,
+                title: (item.title ?? null) as string | null,
+                external_id: (item.external_id ?? null) as string | null,
+                thumbnail_url: (item.thumbnail_url ?? null) as string | null,
+                thumbnail_vertical_url: (item.thumbnail_vertical_url ?? null) as string | null,
+                sample_video_url: (item.sample_video_url ?? null) as string | null,
+                embed_url: toEmbedUrl((item.external_id ?? null) as string | null),
+                product_url: (item.product_url ?? null) as string | null,
+                product_released_at: (item.product_released_at ?? null) as string | null,
+                performers: ((item.performers as {performers:{id:string;name:string}}[]) ?? []).map(p => p.performers).filter(Boolean),
+                tags: ((item.tags as {tags:{id:string;name:string}}[]) ?? []).map(t => t.tags).filter(Boolean),
+                score: null,
+                model_version: null,
+                source: 'exploitation_tag',
+              })
+              seen.add(id)
+              if (exploitation.length >= exploitationTarget) break
+            }
+          }
         }
       }
     } else if (userId && adjustedExploitationRatio > 0) {

--- a/supabase/functions/videos-grid/index.ts
+++ b/supabase/functions/videos-grid/index.ts
@@ -103,10 +103,9 @@ Deno.serve(async (req) => {
     const popularity: VideoEntry[] = []
     const exploration: VideoEntry[] = []
 
-    // decisionCount=0 かつ preferredTagIds がある場合はタグ一致動画で exploitation を埋める
-    const useTagExploitation = preferredTagIds.length > 0 && decisionCount === 0
-
-    if (useTagExploitation) {
+    // コールドスタート時（decisionCount=0 + タグ選択済み）は
+    // exploitation 枠をタグ一致動画で埋める（推薦モデルの代替）
+    if (preferredTagIds.length > 0 && decisionCount === 0) {
       const { data: tagRecs, error: tagError } = await supabase
         .from('videos')
         .select('id, title, external_id, thumbnail_url, thumbnail_vertical_url, sample_video_url, product_url, product_released_at, performers:video_performers(performers(id, name)), tags:video_tags(tags(id, name)), video_tags!inner(tag_id)')

--- a/supabase/functions/videos-grid/index.ts
+++ b/supabase/functions/videos-grid/index.ts
@@ -97,6 +97,8 @@ Deno.serve(async (req) => {
     const exploitationTarget = Math.max(1, Math.floor(pageLimit * adjustedExploitationRatio))
     const popularityTarget = Math.max(1, Math.floor(pageLimit * adjustedPopularityRatio))
     const explorationTarget = Math.max(0, pageLimit - exploitationTarget - popularityTarget)
+    // コールドスタート時のタグ推薦ターゲット（ゲスト含め50%を確保）
+    const tagExploitationTarget = Math.floor(pageLimit * 0.5)
 
     const seen = new Set<string>(excludeIds)
     const exploitation: VideoEntry[] = []
@@ -105,14 +107,21 @@ Deno.serve(async (req) => {
 
     // コールドスタート時（decisionCount=0 + タグ選択済み）は
     // exploitation 枠をタグ一致動画で埋める（推薦モデルの代替）
+    let tagRecsCount = -1
+    let tagRecsFirstId: string | null = null
     if (preferredTagIds.length > 0 && decisionCount === 0) {
-      console.log('[tag] preferredTagIds count:', preferredTagIds.length, 'first:', preferredTagIds[0])
       const { data: tagRecs, error: tagError } = await supabase.rpc('get_videos_by_tags', {
         tag_ids: preferredTagIds,
         exclude_ids: excludeIds.length > 0 ? excludeIds : [],
-        p_limit: Math.max(exploitationTarget * CANDIDATE_MULTIPLIER, 60),
+        p_limit: Math.max(tagExploitationTarget * CANDIDATE_MULTIPLIER, 60),
       })
-      console.log('[tag] tagRecs count:', (tagRecs ?? []).length, 'error:', tagError?.message)
+      tagRecsCount = (tagRecs ?? []).length
+      tagRecsFirstId = String(((tagRecs ?? []) as Record<string, unknown>[])[0]?.id ?? null)
+      const first = (tagRecs ?? [])[0] as Record<string, unknown> | undefined
+      console.log('[tag] first item keys:', JSON.stringify(first ? Object.keys(first) : []))
+      console.log('[tag] first item id:', first?.id, 'type:', typeof first?.id)
+      const first5ids = (tagRecs ?? [] as Record<string, unknown>[]).slice(0, 5).map((r: Record<string, unknown>) => String(r.id))
+      console.log('[tag] first5 ids:', JSON.stringify(first5ids))
       if (tagError) {
         console.error('get_videos_by_tags error:', tagError.message)
       } else {
@@ -136,7 +145,7 @@ Deno.serve(async (req) => {
             source: 'exploitation_tag',
           })
           seen.add(id)
-          if (exploitation.length >= exploitationTarget) break
+          if (exploitation.length >= tagExploitationTarget) break
         }
       }
     } else if (userId && adjustedExploitationRatio > 0) {
@@ -266,6 +275,9 @@ Deno.serve(async (req) => {
         preferredTagIds_count: preferredTagIds.length,
         preferredTagIds_first: preferredTagIds[0] ?? null,
         decisionCount,
+        tagRecs_count: tagRecsCount,
+        excludeIds_count: excludeIds.length,
+        tagRecs_firstId: tagRecsFirstId,
         exploitation_count: exploitation.length,
         popularity_count: popularity.length,
         exploration_count: exploration.length,

--- a/supabase/functions/videos-grid/index.ts
+++ b/supabase/functions/videos-grid/index.ts
@@ -97,8 +97,11 @@ Deno.serve(async (req) => {
     const exploitationTarget = Math.max(1, Math.floor(pageLimit * adjustedExploitationRatio))
     const popularityTarget = Math.max(1, Math.floor(pageLimit * adjustedPopularityRatio))
     const explorationTarget = Math.max(0, pageLimit - exploitationTarget - popularityTarget)
-    // コールドスタート時のタグ推薦ターゲット（ゲスト含め50%を確保）
-    const tagExploitationTarget = Math.floor(pageLimit * 0.5)
+    // コールドスタート時のタグ推薦: exploitation=50%, popularity=30%, exploration=20% に上書き
+    const useTagMode = preferredTagIds.length > 0 && decisionCount === 0
+    const tagExploitationTarget = Math.floor(pageLimit * 0.5)  // 15
+    const tagPopularityTarget   = Math.floor(pageLimit * 0.3)  // 9
+    const tagExplorationTarget  = pageLimit - tagExploitationTarget - tagPopularityTarget  // 6
 
     const seen = new Set<string>(excludeIds)
     const exploitation: VideoEntry[] = []
@@ -181,10 +184,11 @@ Deno.serve(async (req) => {
       }
     }
 
-    if (popularityTarget > 0) {
+    const effectivePopularityTarget = useTagMode ? tagPopularityTarget : popularityTarget
+    if (effectivePopularityTarget > 0) {
       const { data: popData, error: popError } = await supabase.rpc('get_popular_videos', {
         user_uuid: userId,
-        limit_count: popularityTarget * CANDIDATE_MULTIPLIER,
+        limit_count: effectivePopularityTarget * CANDIDATE_MULTIPLIER,
         lookback_days: popularLookbackDays,
       })
       if (popError) {
@@ -210,14 +214,16 @@ Deno.serve(async (req) => {
             source: 'popularity',
           })
           seen.add(id)
-          if (popularity.length >= popularityTarget) break
+          if (popularity.length >= effectivePopularityTarget) break
         }
       }
     }
 
+    const effectiveExploitationTarget = useTagMode ? tagExploitationTarget : exploitationTarget
+    const effectiveExplorationTarget  = useTagMode ? tagExplorationTarget  : explorationTarget
     const explorationNeeded = Math.max(
       0,
-      explorationTarget + (exploitationTarget - exploitation.length) + (popularityTarget - popularity.length),
+      effectiveExplorationTarget + (effectiveExploitationTarget - exploitation.length) + (effectivePopularityTarget - popularity.length),
     )
 
     if (explorationNeeded > 0) {

--- a/supabase/migrations/20260530000000_add_public_lists.sql
+++ b/supabase/migrations/20260530000000_add_public_lists.sql
@@ -1,22 +1,49 @@
--- いいねリストの公開共有機能
+-- =============================================
+-- いいねリスト公開 & カスタムリスト共有機能
+-- =============================================
+
+-- リスト本体
 CREATE TABLE IF NOT EXISTS public.public_lists (
   id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id     uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   token       text        NOT NULL UNIQUE DEFAULT substring(encode(gen_random_bytes(9), 'base64'), 1, 12),
   title       text,
+  description text,
+  -- 'liked'  : いいねリストを動的に表示
+  -- 'custom' : public_list_videos で明示的に管理
+  list_type   text        NOT NULL DEFAULT 'liked' CHECK (list_type IN ('liked', 'custom')),
   is_active   boolean     NOT NULL DEFAULT true,
   created_at  timestamptz NOT NULL DEFAULT now(),
   updated_at  timestamptz NOT NULL DEFAULT now()
 );
 
-ALTER TABLE public.public_lists ENABLE ROW LEVEL SECURITY;
+-- リストに含める動画（custom リスト用・liked でも将来使用可）
+CREATE TABLE IF NOT EXISTS public.public_list_videos (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  list_id     uuid        NOT NULL REFERENCES public.public_lists(id) ON DELETE CASCADE,
+  video_id    uuid        NOT NULL REFERENCES public.videos(id) ON DELETE CASCADE,
+  sort_order  integer     NOT NULL DEFAULT 0,
+  added_at    timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (list_id, video_id)
+);
 
--- token を知っていれば誰でも読める
+-- インデックス
+CREATE INDEX IF NOT EXISTS idx_public_lists_user_id  ON public.public_lists(user_id);
+CREATE INDEX IF NOT EXISTS idx_public_lists_token     ON public.public_lists(token);
+CREATE INDEX IF NOT EXISTS idx_public_list_videos_list ON public.public_list_videos(list_id, sort_order);
+
+-- =============================================
+-- RLS
+-- =============================================
+
+ALTER TABLE public.public_lists        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.public_list_videos  ENABLE ROW LEVEL SECURITY;
+
+-- public_lists: token を知っていれば誰でも読める
 CREATE POLICY "public_lists_select"
   ON public.public_lists FOR SELECT
   USING (is_active = true);
 
--- 本人のみ作成・更新・削除
 CREATE POLICY "public_lists_insert"
   ON public.public_lists FOR INSERT
   WITH CHECK (auth.uid() = user_id);
@@ -29,21 +56,64 @@ CREATE POLICY "public_lists_delete"
   ON public.public_lists FOR DELETE
   USING (auth.uid() = user_id);
 
--- 公開リストのデータを取得する関数
--- token で検索し、対応ユーザーのいいね動画＋タグ集計を返す
+-- public_list_videos: リストが公開中なら誰でも読める
+CREATE POLICY "public_list_videos_select"
+  ON public.public_list_videos FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.public_lists pl
+      WHERE pl.id = list_id AND pl.is_active = true
+    )
+  );
+
+CREATE POLICY "public_list_videos_insert"
+  ON public.public_list_videos FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.public_lists pl
+      WHERE pl.id = list_id AND pl.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "public_list_videos_update"
+  ON public.public_list_videos FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.public_lists pl
+      WHERE pl.id = list_id AND pl.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "public_list_videos_delete"
+  ON public.public_list_videos FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.public_lists pl
+      WHERE pl.id = list_id AND pl.user_id = auth.uid()
+    )
+  );
+
+-- =============================================
+-- 公開リストデータ取得関数
+-- list_type='liked'  → user_video_decisions から動的取得（常に最新）
+-- list_type='custom' → public_list_videos から取得
+-- =============================================
 CREATE OR REPLACE FUNCTION public.get_public_list_data(p_token text)
 RETURNS json
 LANGUAGE plpgsql
 SECURITY DEFINER
 AS $$
 DECLARE
-  v_user_id uuid;
-  v_title   text;
-  v_videos  json;
-  v_tags    json;
+  v_list_id   uuid;
+  v_user_id   uuid;
+  v_title     text;
+  v_desc      text;
+  v_list_type text;
+  v_videos    json;
+  v_tags      json;
 BEGIN
-  -- token から user_id を取得
-  SELECT user_id, title INTO v_user_id, v_title
+  SELECT id, user_id, title, description, list_type
+  INTO v_list_id, v_user_id, v_title, v_desc, v_list_type
   FROM public.public_lists
   WHERE token = p_token AND is_active = true;
 
@@ -51,46 +121,82 @@ BEGIN
     RETURN json_build_object('error', 'not_found');
   END IF;
 
-  -- いいね動画を最新100件取得（外部IDが必要なものだけ）
-  SELECT json_agg(row_to_json(v)) INTO v_videos
-  FROM (
-    SELECT
-      vi.id,
-      vi.title,
-      vi.external_id,
-      vi.thumbnail_url,
-      vi.thumbnail_vertical_url,
-      vi.product_url,
-      uvd.created_at AS liked_at
-    FROM public.user_video_decisions uvd
-    JOIN public.videos vi ON vi.id = uvd.video_id
-    WHERE uvd.user_id = v_user_id
-      AND uvd.decision_type IN ('swipe_like', 'grid_like')
-      AND vi.external_id IS NOT NULL
-    ORDER BY uvd.created_at DESC
-    LIMIT 100
-  ) v;
+  -- 動画一覧取得
+  IF v_list_type = 'custom' THEN
+    -- カスタムリスト: public_list_videos の順番通りに返す
+    SELECT json_agg(row_to_json(v)) INTO v_videos
+    FROM (
+      SELECT
+        vi.id,
+        vi.title,
+        vi.external_id,
+        vi.thumbnail_url,
+        vi.thumbnail_vertical_url,
+        vi.product_url,
+        plv.added_at AS liked_at
+      FROM public.public_list_videos plv
+      JOIN public.videos vi ON vi.id = plv.video_id
+      WHERE plv.list_id = v_list_id
+        AND vi.external_id IS NOT NULL
+      ORDER BY plv.sort_order, plv.added_at DESC
+      LIMIT 200
+    ) v;
+  ELSE
+    -- いいねリスト: user_video_decisions から動的取得
+    SELECT json_agg(row_to_json(v)) INTO v_videos
+    FROM (
+      SELECT
+        vi.id,
+        vi.title,
+        vi.external_id,
+        vi.thumbnail_url,
+        vi.thumbnail_vertical_url,
+        vi.product_url,
+        uvd.created_at AS liked_at
+      FROM public.user_video_decisions uvd
+      JOIN public.videos vi ON vi.id = uvd.video_id
+      WHERE uvd.user_id = v_user_id
+        AND uvd.decision_type IN ('swipe_like', 'grid_like')
+        AND vi.external_id IS NOT NULL
+      ORDER BY uvd.created_at DESC
+      LIMIT 100
+    ) v;
+  END IF;
 
-  -- タグ集計（上位12件）
-  SELECT json_agg(row_to_json(t)) INTO v_tags
-  FROM (
-    SELECT
-      tg.name AS tag_name,
-      COUNT(*) AS cnt
-    FROM public.user_video_decisions uvd
-    JOIN public.video_tags vt ON vt.video_id = uvd.video_id
-    JOIN public.tags tg ON tg.id = vt.tag_id
-    WHERE uvd.user_id = v_user_id
-      AND uvd.decision_type IN ('swipe_like', 'grid_like')
-    GROUP BY tg.name
-    ORDER BY cnt DESC
-    LIMIT 12
-  ) t;
+  -- タグ集計（liked: いいね全体, custom: リスト内動画）
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(t)) INTO v_tags
+    FROM (
+      SELECT tg.name AS tag_name, COUNT(*) AS cnt
+      FROM public.public_list_videos plv
+      JOIN public.video_tags vt ON vt.video_id = plv.video_id
+      JOIN public.tags tg ON tg.id = vt.tag_id
+      WHERE plv.list_id = v_list_id
+      GROUP BY tg.name
+      ORDER BY cnt DESC
+      LIMIT 12
+    ) t;
+  ELSE
+    SELECT json_agg(row_to_json(t)) INTO v_tags
+    FROM (
+      SELECT tg.name AS tag_name, COUNT(*) AS cnt
+      FROM public.user_video_decisions uvd
+      JOIN public.video_tags vt ON vt.video_id = uvd.video_id
+      JOIN public.tags tg ON tg.id = vt.tag_id
+      WHERE uvd.user_id = v_user_id
+        AND uvd.decision_type IN ('swipe_like', 'grid_like')
+      GROUP BY tg.name
+      ORDER BY cnt DESC
+      LIMIT 12
+    ) t;
+  END IF;
 
   RETURN json_build_object(
-    'title',  v_title,
-    'videos', COALESCE(v_videos, '[]'::json),
-    'tags',   COALESCE(v_tags, '[]'::json)
+    'title',     v_title,
+    'description', v_desc,
+    'list_type', v_list_type,
+    'videos',    COALESCE(v_videos, '[]'::json),
+    'tags',      COALESCE(v_tags,   '[]'::json)
   );
 END;
 $$;

--- a/supabase/migrations/20260530000000_add_public_lists.sql
+++ b/supabase/migrations/20260530000000_add_public_lists.sql
@@ -200,3 +200,32 @@ BEGIN
   );
 END;
 $$;
+
+-- タグ指定動画取得 RPC（コールドスタート用）
+CREATE OR REPLACE FUNCTION public.get_videos_by_tags(
+  tag_ids uuid[],
+  exclude_ids uuid[],
+  p_limit int DEFAULT 60
+)
+RETURNS TABLE (
+  id uuid, title text, external_id text,
+  thumbnail_url text, thumbnail_vertical_url text,
+  sample_video_url text, product_url text, product_released_at timestamptz,
+  performers jsonb, tags jsonb
+)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  SELECT v.id, v.title, v.external_id,
+    v.thumbnail_url, v.thumbnail_vertical_url, v.sample_video_url,
+    coalesce(v.affiliate_url, v.product_url), v.product_released_at,
+    coalesce((SELECT jsonb_agg(jsonb_build_object('id', p.id, 'name', p.name)) FROM public.video_performers vp JOIN public.performers p ON p.id = vp.performer_id WHERE vp.video_id = v.id), '[]'::jsonb),
+    coalesce((SELECT jsonb_agg(jsonb_build_object('id', t.id, 'name', t.name)) FROM public.video_tags vt JOIN public.tags t ON t.id = vt.tag_id LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id WHERE vt.video_id = v.id AND coalesce(tg.show_in_ui, true)), '[]'::jsonb)
+  FROM public.videos v
+  WHERE v.sample_video_url IS NOT NULL
+    AND (array_length(exclude_ids, 1) IS NULL OR v.id != ALL(exclude_ids))
+    AND EXISTS (SELECT 1 FROM public.video_tags vt WHERE vt.video_id = v.id AND vt.tag_id = ANY(tag_ids))
+  ORDER BY random()
+  LIMIT p_limit;
+END;
+$$;

--- a/supabase/migrations/20260530000000_add_public_lists.sql
+++ b/supabase/migrations/20260530000000_add_public_lists.sql
@@ -6,7 +6,7 @@
 CREATE TABLE IF NOT EXISTS public.public_lists (
   id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id     uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  token       text        NOT NULL UNIQUE DEFAULT substring(encode(gen_random_bytes(9), 'base64'), 1, 12),
+  token       text        NOT NULL UNIQUE DEFAULT translate(substring(encode(gen_random_bytes(9), 'base64'), 1, 12), '+/=', '-_'),
   title       text,
   description text,
   -- 'liked'  : いいねリストを動的に表示

--- a/supabase/migrations/20260530000000_add_public_lists.sql
+++ b/supabase/migrations/20260530000000_add_public_lists.sql
@@ -1,0 +1,96 @@
+-- いいねリストの公開共有機能
+CREATE TABLE IF NOT EXISTS public.public_lists (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  token       text        NOT NULL UNIQUE DEFAULT substring(encode(gen_random_bytes(9), 'base64'), 1, 12),
+  title       text,
+  is_active   boolean     NOT NULL DEFAULT true,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.public_lists ENABLE ROW LEVEL SECURITY;
+
+-- token を知っていれば誰でも読める
+CREATE POLICY "public_lists_select"
+  ON public.public_lists FOR SELECT
+  USING (is_active = true);
+
+-- 本人のみ作成・更新・削除
+CREATE POLICY "public_lists_insert"
+  ON public.public_lists FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "public_lists_update"
+  ON public.public_lists FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "public_lists_delete"
+  ON public.public_lists FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- 公開リストのデータを取得する関数
+-- token で検索し、対応ユーザーのいいね動画＋タグ集計を返す
+CREATE OR REPLACE FUNCTION public.get_public_list_data(p_token text)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_title   text;
+  v_videos  json;
+  v_tags    json;
+BEGIN
+  -- token から user_id を取得
+  SELECT user_id, title INTO v_user_id, v_title
+  FROM public.public_lists
+  WHERE token = p_token AND is_active = true;
+
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('error', 'not_found');
+  END IF;
+
+  -- いいね動画を最新100件取得（外部IDが必要なものだけ）
+  SELECT json_agg(row_to_json(v)) INTO v_videos
+  FROM (
+    SELECT
+      vi.id,
+      vi.title,
+      vi.external_id,
+      vi.thumbnail_url,
+      vi.thumbnail_vertical_url,
+      vi.product_url,
+      uvd.created_at AS liked_at
+    FROM public.user_video_decisions uvd
+    JOIN public.videos vi ON vi.id = uvd.video_id
+    WHERE uvd.user_id = v_user_id
+      AND uvd.decision_type IN ('swipe_like', 'grid_like')
+      AND vi.external_id IS NOT NULL
+    ORDER BY uvd.created_at DESC
+    LIMIT 100
+  ) v;
+
+  -- タグ集計（上位12件）
+  SELECT json_agg(row_to_json(t)) INTO v_tags
+  FROM (
+    SELECT
+      tg.name AS tag_name,
+      COUNT(*) AS cnt
+    FROM public.user_video_decisions uvd
+    JOIN public.video_tags vt ON vt.video_id = uvd.video_id
+    JOIN public.tags tg ON tg.id = vt.tag_id
+    WHERE uvd.user_id = v_user_id
+      AND uvd.decision_type IN ('swipe_like', 'grid_like')
+    GROUP BY tg.name
+    ORDER BY cnt DESC
+    LIMIT 12
+  ) t;
+
+  RETURN json_build_object(
+    'title',  v_title,
+    'videos', COALESCE(v_videos, '[]'::json),
+    'tags',   COALESCE(v_tags, '[]'::json)
+  );
+END;
+$$;


### PR DESCRIPTION
## 概要

ログインユーザーが自分のいいねリストをランダムトークンURLで公開・シェアできる機能です。

## 動作フロー

1. 設定ドロワー →「公開リンクを作成」ボタン
2. `public_lists` テーブルにレコード作成（ランダム12文字 token）
3. `https://www.seihekilab.com/list/{token}` が公開される
4. リンクコピーボタンでクリップボードに URL をコピー
5. 削除ボタンで非公開化（`is_active = false`）

## 公開ページの内容

- 好きなジャンルタグ（上位12件）
- いいねした作品グリッド（最新100件・サムネイル表示）
- 各作品はアフィリエイト付き FANZA 直リンク
- OGP 対応（SNS でシェア時にプレビュー表示）
- `noindex` 設定（検索エンジンには載せない）

## 変更ファイル

- `migrations/20260530000000_add_public_lists.sql`: `public_lists` テーブル・RLS・`get_public_list_data()` 関数
- `app/list/[token]/page.tsx`: 公開リストページ（Server Component）
- `app/list/[token]/CopyLinkButton.tsx`: コピーボタン（Client Component）
- `components/AccountManagementDrawer.tsx`: 公開リスト作成・コピー・削除 UI

## 確認事項

- [ ] マイグレーション適用
- [ ] 設定ドロワーから公開リンク作成できる
- [ ] 公開 URL でリストが表示される
- [ ] 削除後に 404 になる
- [ ] FANZA リンクにアフィリエイト ID が付いている

🤖 Generated with [Claude Code](https://claude.com/claude-code)