### PR TITLE
fix: リモートのみのマイグレーションスタブを追加（CI修正）

### DIFF
--- a/supabase/migrations/20260530062212_remote_only_stub.sql
+++ b/supabase/migrations/20260530062212_remote_only_stub.sql
@@ -1,0 +1,2 @@
+-- Remote-only migration stub
+-- Applied directly via MCP: get_videos_by_tags RPC (uuid[] version, superseded by text[] version in later migration)

--- a/supabase/migrations/20260530093048_remote_only_stub.sql
+++ b/supabase/migrations/20260530093048_remote_only_stub.sql
@@ -1,0 +1,2 @@
+-- Remote-only migration stub
+-- Applied directly via MCP: get_videos_by_tags (text[] version), get_videos_feed and get_videos_recommendations FANZA_ANIME exclusion


### PR DESCRIPTION
## 概要

MCP で直接リモート DB に適用したマイグレーションがローカルに存在しないため、CI の `supabase db push` が失敗していた問題を修正します。

## 原因

以下の2つのマイグレーションが Supabase ダッシュボード上のリモート履歴に存在するが、ローカルの `supabase/migrations/` に対応ファイルがなかった。

| バージョン | 内容 |
|---|---|
| `20260530062212` | `get_videos_by_tags` RPC（uuid[] 版） |
| `20260530093048` | `get_videos_by_tags`（text[] 版）・`get_videos_feed` / `get_videos_recommendations` の FANZA_ANIME 除外 |

## 対応

空のスタブファイルを追加してリモートと履歴を同期。

🤖 Generated with [Claude Code](https://claude.com/claude-code)