### PR TITLE
fix: public_listsマイグレーションのRLSポリシーを冪等化

### DIFF
--- a/supabase/migrations/20260530000000_add_public_lists.sql
+++ b/supabase/migrations/20260530000000_add_public_lists.sql
@@ -39,24 +39,29 @@ CREATE INDEX IF NOT EXISTS idx_public_list_videos_list ON public.public_list_vid
 ALTER TABLE public.public_lists        ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.public_list_videos  ENABLE ROW LEVEL SECURITY;
 
--- public_lists: token を知っていれば誰でも読める
+-- public_lists ポリシー（冪等）
+DROP POLICY IF EXISTS "public_lists_select" ON public.public_lists;
 CREATE POLICY "public_lists_select"
   ON public.public_lists FOR SELECT
   USING (is_active = true);
 
+DROP POLICY IF EXISTS "public_lists_insert" ON public.public_lists;
 CREATE POLICY "public_lists_insert"
   ON public.public_lists FOR INSERT
   WITH CHECK (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "public_lists_update" ON public.public_lists;
 CREATE POLICY "public_lists_update"
   ON public.public_lists FOR UPDATE
   USING (auth.uid() = user_id);
 
+DROP POLICY IF EXISTS "public_lists_delete" ON public.public_lists;
 CREATE POLICY "public_lists_delete"
   ON public.public_lists FOR DELETE
   USING (auth.uid() = user_id);
 
--- public_list_videos: リストが公開中なら誰でも読める
+-- public_list_videos ポリシー（冪等）
+DROP POLICY IF EXISTS "public_list_videos_select" ON public.public_list_videos;
 CREATE POLICY "public_list_videos_select"
   ON public.public_list_videos FOR SELECT
   USING (
@@ -66,6 +71,7 @@ CREATE POLICY "public_list_videos_select"
     )
   );
 
+DROP POLICY IF EXISTS "public_list_videos_insert" ON public.public_list_videos;
 CREATE POLICY "public_list_videos_insert"
   ON public.public_list_videos FOR INSERT
   WITH CHECK (
@@ -75,6 +81,7 @@ CREATE POLICY "public_list_videos_insert"
     )
   );
 
+DROP POLICY IF EXISTS "public_list_videos_update" ON public.public_list_videos;
 CREATE POLICY "public_list_videos_update"
   ON public.public_list_videos FOR UPDATE
   USING (
@@ -84,6 +91,7 @@ CREATE POLICY "public_list_videos_update"
     )
   );
 
+DROP POLICY IF EXISTS "public_list_videos_delete" ON public.public_list_videos;
 CREATE POLICY "public_list_videos_delete"
   ON public.public_list_videos FOR DELETE
   USING (


### PR DESCRIPTION
## 概要

`supabase db push` 実行時に `CREATE POLICY` が既存ポリシーと衝突してエラーになる問題を修正します。

## 原因

`20260530000000_add_public_lists.sql` 内の `CREATE POLICY` 文が冪等でなく、ポリシーが既に存在する場合に `42710: policy already exists` エラーが発生。

## 修正

全ての `CREATE POLICY` の前に `DROP POLICY IF EXISTS` を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)