### PR TITLE
fix: オンボーディングのタグ表示閾値を50件→10件以上に変更

### DIFF
--- a/frontend/src/components/OnboardingModal.tsx
+++ b/frontend/src/components/OnboardingModal.tsx
@@ -55,7 +55,7 @@ export default function OnboardingModal({ onComplete }: Props) {
         const sorted = Array.from(groupMap.values())
           .map((g) => ({
             ...g,
-            tags: g.tags.filter((t) => t.video_count >= 50).sort((a, b) => b.video_count - a.video_count),
+            tags: g.tags.filter((t) => t.video_count >= 10).sort((a, b) => b.video_count - a.video_count),
           }))
           .filter((g) => g.tags.length > 0)
           .sort((a, b) => b.tags[0].video_count - a.tags[0].video_count);


### PR DESCRIPTION
## Summary

- オンボーディングモーダルで表示するタグのフィルタ閾値を `video_count >= 50` から `video_count >= 10` に変更
- これにより、動画が10件以上紐づくタグがすべて表示されるようになる（以前は50件未満のタグが非表示だった）

## Test plan

- [ ] オンボーディングモーダルを開き、各カテゴリに以前より多くのタグが表示されることを確認
- [ ] タグ選択・完了フローが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)