### PR TITLE
fix: ログアウト後のリダイレクト先を /swipe から /grid に変更

### DIFF
--- a/frontend/src/app/account-management/page.tsx
+++ b/frontend/src/app/account-management/page.tsx
@@ -104,7 +104,7 @@ export default function AccountManagementPage() {
       await supabase.auth.signOut({ scope: 'global' });
       toast.success('ログアウトしました');
       closeModal();
-      router.push('/swipe');
+      router.push('/grid');
       router.refresh();
     } catch {
       toast.error('ログアウトに失敗しました');

--- a/frontend/src/components/AccountManagementDrawer.tsx
+++ b/frontend/src/components/AccountManagementDrawer.tsx
@@ -112,7 +112,7 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
       console.error('logout exception', e);
     }
     onClose();
-    try { if (typeof window !== 'undefined') window.location.assign('/swipe'); } catch {}
+    try { if (typeof window !== 'undefined') window.location.assign('/grid'); } catch {}
   };
 
   const likeRate = likeCount !== null && totalCount ? Math.round((likeCount / totalCount) * 100) : null;


### PR DESCRIPTION
## Summary

- `account-management/page.tsx` と `AccountManagementDrawer.tsx` の2箇所でログアウト後のリダイレクト先を `/swipe` → `/grid` に修正

## Test plan

- [ ] アカウント管理ページからログアウトして `/grid` に遷移すること
- [ ] ドロワーからログアウトして `/grid` に遷移すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)