### PR TITLE
fix: サイトマップのSupabaseクライアントをservice roleキーに変更

### DIFF
--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from 'next';
-import { supabase } from '@/lib/supabase';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
 
 // 24時間ごとに再生成
 export const revalidate = 86400;
@@ -36,7 +36,7 @@ export default async function sitemap({ id }: { id: string }): Promise<MetadataR
     let page = 0;
     while (true) {
       const from = page * PAGE_SIZE;
-      const { data, error } = await supabase
+      const { data, error } = await supabaseAdmin
         .from('videos')
         .select('id, created_at')
         .order('created_at', { ascending: false })
@@ -62,7 +62,7 @@ export default async function sitemap({ id }: { id: string }): Promise<MetadataR
     let page = 0;
     while (true) {
       const from = page * PAGE_SIZE;
-      const { data, error } = await supabase
+      const { data, error } = await supabaseAdmin
         .from('tags')
         .select('id')
         .range(from, from + PAGE_SIZE - 1);
@@ -87,7 +87,7 @@ export default async function sitemap({ id }: { id: string }): Promise<MetadataR
     let page = 0;
     while (true) {
       const from = page * PAGE_SIZE;
-      const { data, error } = await supabase
+      const { data, error } = await supabaseAdmin
         .from('performers')
         .select('id')
         .range(from, from + PAGE_SIZE - 1);


### PR DESCRIPTION
## Summary
- `sitemap.ts`で使用するSupabaseクライアントを`supabase`（anonキー）から`supabaseAdmin`（service roleキー）に変更
- RLSが有効なテーブル（videos, tags, performers）へのアクセスがanonキーでは拒否されており、`sitemap/1.xml`〜`sitemap/3.xml`が空のXMLを返していた
- これによりSearch Consoleで「XMLタグが指定されていません」エラーが発生し、53,000件以上の動画ページがインデックス未登録になっていた

## Test plan
- [ ] デプロイ後に `https://www.seihekilab.com/sitemap/1.xml` を開いてURLが含まれることを確認
- [ ] Search Consoleでサイトマップを再送信してエラーが解消されることを確認
- [ ] VercelにSUPABASE_SERVICE_ROLE_KEY環境変数が設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)