### PR TITLE
fix: リストページ作品グリッドをPinterest風マソンリーに変更

### DIFF
--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -191,19 +191,21 @@ export default async function PublicListPage(
                   rel="noopener noreferrer"
                   className="group block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22]"
                 >
-                  {thumb ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={thumb}
-                      alt={video.title ?? ''}
-                      className="w-full aspect-video object-cover group-hover:opacity-90 transition-opacity"
-                      loading="lazy"
-                    />
-                  ) : (
-                    <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
-                      <span className="text-[#484f58] text-xs">No Image</span>
-                    </div>
-                  )}
+                  <div className="w-full aspect-video bg-[#21262d] overflow-hidden">
+                    {thumb ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={thumb}
+                        alt={video.title ?? ''}
+                        className="w-full h-full object-cover group-hover:opacity-90 transition-opacity"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center">
+                        <span className="text-[#484f58] text-xs">No Image</span>
+                      </div>
+                    )}
+                  </div>
                   <div className="p-2">
                     <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
                       {video.title ?? ''}

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -175,37 +175,35 @@ export default async function PublicListPage(
           </div>
         )}
 
-        {/* 作品グリッド */}
+        {/* 作品グリッド（Pinterest風マソンリー） */}
         {data.videos.length === 0 ? (
           <p className="text-center text-[#656d76] py-20">まだいいねした作品がありません。</p>
         ) : (
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
             {data.videos.map((video) => {
               const affiliateUrl = toAffiliateUrl(video.product_url);
-              const thumb = toLgThumb(video.thumbnail_url);
+              const thumb = toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
               return (
                 <a
                   key={video.id}
                   href={affiliateUrl || '#'}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22]"
+                  className="group block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22] mb-3 break-inside-avoid"
                 >
-                  <div className="w-full aspect-video bg-[#21262d] overflow-hidden">
-                    {thumb ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={thumb}
-                        alt={video.title ?? ''}
-                        className="w-full h-full object-cover group-hover:opacity-90 transition-opacity"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <div className="w-full h-full flex items-center justify-center">
-                        <span className="text-[#484f58] text-xs">No Image</span>
-                      </div>
-                    )}
-                  </div>
+                  {thumb ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={thumb}
+                      alt={video.title ?? ''}
+                      className="w-full h-auto group-hover:opacity-90 transition-opacity"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
+                      <span className="text-[#484f58] text-xs">No Image</span>
+                    </div>
+                  )}
                   <div className="p-2">
                     <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
                       {video.title ?? ''}


### PR DESCRIPTION
## Summary

- 作品グリッドを Pinterest 風マソンリーレイアウトに変更
  - CSS `columns` プロパティで JS なし・軽量に実装
  - 縦横混在の画像をアスペクト比を維持したまま自然に配置
  - `break-inside-avoid` でカードの列またぎを防止
  - モバイル2列 / sm以上3列
- 縦長画像によるレイアウト崩れを修正
  - `aspect-video` を `img` 直接指定 → `div` ラッパーで囲む方式に変更
  - `thumbnail_url`（横）がなければ `thumbnail_vertical_url`（縦）にフォールバック

## Test plan

- [ ] `/list/[token]` で縦長・横長混在の画像がアスペクト比を維持して表示される
- [ ] カードが列をまたいで分割されない
- [ ] モバイルで2列、デスクトップで3列になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)