### PR TITLE
マイリスト：削除バグ修正・動画管理機能追加 / ingest_fanza videoc フロア対応

### DIFF
--- a/.github/workflows/cicd-pr-tests.yml
+++ b/.github/workflows/cicd-pr-tests.yml
@@ -56,6 +56,8 @@ jobs:
           CREATE TABLE IF NOT EXISTS auth.users (
             id UUID PRIMARY KEY,
             email TEXT UNIQUE,
+            raw_user_meta_data JSONB NOT NULL DEFAULT '{}',
+            raw_app_meta_data  JSONB NOT NULL DEFAULT '{}',
             created_at TIMESTAMPTZ DEFAULT NOW()
           );
           CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE plpgsql STABLE AS $$

--- a/frontend/src/app/grid/page.tsx
+++ b/frontend/src/app/grid/page.tsx
@@ -469,6 +469,12 @@ function GridPage() {
                   <Heart size={15} className="text-white" fill={likedIds.has(video.id) ? 'white' : 'none'} strokeWidth={2} />
                 </button>
               )}
+              {/* サンプルなしバッジ（左上） */}
+              {!video.sample_video_url && (
+                <div className="absolute top-1.5 left-1.5 text-[9px] font-bold px-1.5 py-0.5 rounded bg-black/60 text-white/60 border border-white/20 pointer-events-none">
+                  サンプルなし
+                </div>
+              )}
               {isDebug && (
                 <div className="absolute bottom-1 left-1">
                   <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded ${SOURCE_BADGE_COLORS[video.source] ?? 'bg-gray-600 text-white'}`}>{video.source}</span>
@@ -562,6 +568,12 @@ function GridPage() {
                   <Heart size={15} className="text-white" fill={likedIds.has(video.id) ? 'white' : 'none'} strokeWidth={2} />
                 </button>
               )}
+              {/* サンプルなしバッジ（左上） */}
+              {!video.sample_video_url && !viewedIds.has(video.id) && (
+                <div className="absolute top-1.5 left-1.5 text-[9px] font-bold px-1.5 py-0.5 rounded bg-black/60 text-white/60 border border-white/20 pointer-events-none">
+                  サンプルなし
+                </div>
+              )}
               {/* 既読バッジ（いいね済みでない場合のみ・左上） */}
               {viewedIds.has(video.id) && !likedIds.has(video.id) && (
                 <div className="absolute top-1.5 left-1.5 w-5 h-5 rounded-full bg-black/60 border border-white/20 flex items-center justify-center pointer-events-none">
@@ -631,39 +643,57 @@ function GridPage() {
 
             {/* 動画エリア（SwipeCardと同じ4:3） */}
             <div className="relative w-full aspect-[4/3] bg-black/90 flex items-center justify-center rounded-t-2xl overflow-hidden">
-              {showVideo === false && (
+              {selected.sample_video_url ? (
+                <>
+                  {showVideo === false && (
+                    <div
+                      className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10 cursor-pointer"
+                      style={{
+                        backgroundImage: selected.thumbnail_url ? `url(${selected.thumbnail_url})` : undefined,
+                        backgroundColor: selected.thumbnail_url ? undefined : '#1f2937',
+                      }}
+                      onClick={() => setShowVideo(true)}
+                    >
+                      <div className="absolute inset-0 bg-black bg-opacity-40 flex items-center justify-center">
+                        <Play className="text-white w-16 h-16 opacity-80" fill="white" />
+                      </div>
+                      <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-[10px] text-white/80 bg-black/40 px-2 py-0.5 rounded whitespace-nowrap">
+                        注: 再生には最大2回のクリックが必要な場合があります
+                      </div>
+                    </div>
+                  )}
+                  <iframe
+                    scrolling="no"
+                    referrerPolicy="no-referrer"
+                    src={toFanzaEmbedUrl(selected.external_id)}
+                    frameBorder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"
+                    loading="eager"
+                    onLoad={() => {
+                      if (overlayHideTimer.current) clearTimeout(overlayHideTimer.current);
+                      overlayHideTimer.current = setTimeout(() => {
+                        setShowVideo(true);
+                        overlayHideTimer.current = null;
+                      }, OVERLAY_HIDE_DELAY_MS);
+                    }}
+                    className="absolute top-0 left-0 w-full h-full overflow-hidden"
+                  />
+                </>
+              ) : (
                 <div
-                  className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10 cursor-pointer"
+                  className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex flex-col items-center justify-center gap-3"
                   style={{
                     backgroundImage: selected.thumbnail_url ? `url(${selected.thumbnail_url})` : undefined,
                     backgroundColor: selected.thumbnail_url ? undefined : '#1f2937',
                   }}
-                  onClick={() => setShowVideo(true)}
                 >
-                  <div className="absolute inset-0 bg-black bg-opacity-40 flex items-center justify-center">
-                    <Play className="text-white w-16 h-16 opacity-80" fill="white" />
-                  </div>
-                  <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-[10px] text-white/80 bg-black/40 px-2 py-0.5 rounded whitespace-nowrap">
-                    注: 再生には最大2回のクリックが必要な場合があります
+                  <div className="absolute inset-0 bg-black/60" />
+                  <div className="relative z-10 flex flex-col items-center gap-2">
+                    <span className="text-white/90 text-sm font-bold">サンプル動画なし</span>
+                    <span className="text-white/50 text-xs">この作品はサンプル動画を提供していません</span>
                   </div>
                 </div>
               )}
-              <iframe
-                scrolling="no"
-                referrerPolicy="no-referrer"
-                src={toFanzaEmbedUrl(selected.external_id)}
-                frameBorder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share; fullscreen"
-                loading="eager"
-                onLoad={() => {
-                  if (overlayHideTimer.current) clearTimeout(overlayHideTimer.current);
-                  overlayHideTimer.current = setTimeout(() => {
-                    setShowVideo(true);
-                    overlayHideTimer.current = null;
-                  }, OVERLAY_HIDE_DELAY_MS);
-                }}
-                className="absolute top-0 left-0 w-full h-full overflow-hidden"
-              />
             </div>
 
             {/* 情報エリア */}

--- a/frontend/src/app/my/lists/page.tsx
+++ b/frontend/src/app/my/lists/page.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { Plus, ExternalLink, Loader2, Search, Trash2 } from 'lucide-react';
+import { Plus, ExternalLink, Loader2, Search, Trash2, ListVideo } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import VideoSearchModal from '@/components/lists/VideoSearchModal';
+import ListVideosModal from '@/components/lists/ListVideosModal';
 
 type PublicList = {
   id: string;
@@ -26,6 +27,7 @@ export default function MyListsPage() {
   const [newDesc, setNewDesc] = useState('');
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [searchTarget, setSearchTarget] = useState<PublicList | null>(null);
+  const [manageTarget, setManageTarget] = useState<PublicList | null>(null);
 
   const fetchLists = useCallback(async () => {
     const { data: { user } } = await supabase.auth.getUser();
@@ -62,7 +64,14 @@ export default function MyListsPage() {
 
   const handleDelete = async (id: string) => {
     if (!confirm('このリストを削除しますか？')) return;
-    await supabase.from('public_lists').update({ is_active: false }).eq('id', id);
+    const { error } = await supabase
+      .from('public_lists')
+      .update({ is_active: false })
+      .eq('id', id);
+    if (error) {
+      alert('削除に失敗しました: ' + error.message);
+      return;
+    }
     await fetchLists();
   };
 
@@ -156,13 +165,22 @@ export default function MyListsPage() {
 
                 <div className="flex items-center gap-1.5 shrink-0">
                   {list.list_type === 'custom' && (
-                    <button
-                      onClick={() => setSearchTarget(list)}
-                      className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-violet-600/20 hover:bg-violet-600/40 text-violet-400 text-xs font-bold transition-colors border border-violet-500/30"
-                    >
-                      <Search size={11} />
-                      動画追加
-                    </button>
+                    <>
+                      <button
+                        onClick={() => setSearchTarget(list)}
+                        className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-violet-600/20 hover:bg-violet-600/40 text-violet-400 text-xs font-bold transition-colors border border-violet-500/30"
+                      >
+                        <Search size={11} />
+                        動画追加
+                      </button>
+                      <button
+                        onClick={() => setManageTarget(list)}
+                        className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 text-[#8b949e] text-xs font-bold transition-colors border border-[#30363d]"
+                      >
+                        <ListVideo size={11} />
+                        動画管理
+                      </button>
+                    </>
                   )}
                   <a
                     href={`/list/${list.token}`}
@@ -193,6 +211,16 @@ export default function MyListsPage() {
           listId={searchTarget.id}
           onClose={() => setSearchTarget(null)}
           onAdded={fetchLists}
+        />
+      )}
+
+      {/* 動画管理モーダル */}
+      {manageTarget && (
+        <ListVideosModal
+          listId={manageTarget.id}
+          listTitle={manageTarget.title ?? '無題のリスト'}
+          onClose={() => setManageTarget(null)}
+          onChanged={fetchLists}
         />
       )}
     </div>

--- a/frontend/src/components/lists/ListVideosModal.tsx
+++ b/frontend/src/components/lists/ListVideosModal.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { X, Trash2, Loader2 } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+
+type ListVideo = {
+  id: string;
+  video_id: string;
+  title: string | null;
+  thumbnail_url: string | null;
+  distribution_code: string | null;
+};
+
+interface ListVideosModalProps {
+  listId: string;
+  listTitle: string;
+  onClose: () => void;
+  onChanged?: () => void;
+}
+
+export default function ListVideosModal({ listId, listTitle, onClose, onChanged }: ListVideosModalProps) {
+  const [videos, setVideos] = useState<ListVideo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchVideos = useCallback(async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('public_list_videos')
+      .select('id, video_id, videos(title, thumbnail_url, distribution_code)')
+      .eq('list_id', listId)
+      .order('added_at', { ascending: false });
+
+    if (error) {
+      setError('動画の取得に失敗しました');
+      setLoading(false);
+      return;
+    }
+
+    const rows = ((data ?? []) as unknown as Array<{
+      id: string;
+      video_id: string;
+      videos: { title: string | null; thumbnail_url: string | null; distribution_code: string | null } | null;
+    }>).map((row) => ({
+      id: row.id,
+      video_id: row.video_id,
+      title: row.videos?.title ?? null,
+      thumbnail_url: row.videos?.thumbnail_url ?? null,
+      distribution_code: row.videos?.distribution_code ?? null,
+    }));
+
+    setVideos(rows);
+    setLoading(false);
+  }, [listId]);
+
+  useEffect(() => { fetchVideos(); }, [fetchVideos]);
+
+  const handleRemove = async (rowId: string) => {
+    setRemovingId(rowId);
+    const { error } = await supabase
+      .from('public_list_videos')
+      .delete()
+      .eq('id', rowId);
+
+    if (error) {
+      alert('削除に失敗しました: ' + error.message);
+      setRemovingId(null);
+      return;
+    }
+
+    setVideos((prev) => prev.filter((v) => v.id !== rowId));
+    setRemovingId(null);
+    onChanged?.();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative w-full sm:max-w-lg bg-[#161b22] rounded-t-2xl sm:rounded-2xl border border-[#30363d] flex flex-col max-h-[85vh]">
+
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[#30363d] shrink-0">
+          <div>
+            <h2 className="text-sm font-bold text-[#e6edf3]">動画を管理</h2>
+            <p className="text-[10px] text-[#656d76] mt-0.5 line-clamp-1">{listTitle}</p>
+          </div>
+          <button onClick={onClose} className="text-[#8b949e] hover:text-white transition-colors">
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {loading && (
+            <div className="flex items-center justify-center py-16">
+              <Loader2 size={20} className="text-violet-400 animate-spin" />
+            </div>
+          )}
+          {error && (
+            <p className="text-center text-red-400 text-sm py-10">{error}</p>
+          )}
+          {!loading && !error && videos.length === 0 && (
+            <p className="text-center text-[#484f58] text-xs py-10">このリストにはまだ動画がありません</p>
+          )}
+          {!loading && videos.map((video) => (
+            <div
+              key={video.id}
+              className="flex items-center gap-3 px-4 py-2.5 border-b border-[#21262d] last:border-0"
+            >
+              <div className="w-12 h-16 shrink-0 rounded overflow-hidden bg-[#21262d]">
+                {video.thumbnail_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={video.thumbnail_url} alt="" className="w-full h-full object-cover" loading="lazy" />
+                ) : (
+                  <div className="w-full h-full" />
+                )}
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-xs text-[#e6edf3] line-clamp-2 leading-snug">{video.title}</p>
+                {video.distribution_code && (
+                  <p className="text-[10px] text-[#484f58] mt-0.5">{video.distribution_code}</p>
+                )}
+              </div>
+              <button
+                onClick={() => handleRemove(video.id)}
+                disabled={removingId === video.id}
+                className="shrink-0 flex items-center justify-center w-8 h-8 rounded-full bg-red-500/10 hover:bg-red-500/20 text-red-400 transition-colors disabled:opacity-50"
+                aria-label="リストから削除"
+              >
+                {removingId === video.id
+                  ? <Loader2 size={14} className="animate-spin" />
+                  : <Trash2 size={14} />}
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/scripts/ingest_fanza/index.ts
+++ b/scripts/ingest_fanza/index.ts
@@ -649,12 +649,23 @@ async function main() {
     return;
   }
 
-  const sources = [
+  const allSources = [
     { service: 'digital', floor: 'videoa', source: 'FANZA' },
     { service: 'digital', floor: 'videoc', source: 'FANZA_AMATEUR' },
     // アニメは取り込まない（非実写コンテンツ除外）
     // { service: 'digital', floor: 'anime',  source: 'FANZA_ANIME' },
   ];
+
+  // FLOOR env var で特定フロアのみ実行可能（例: FLOOR=videoc）
+  const floorFilter = process.env.FLOOR?.trim();
+  const sources = floorFilter
+    ? allSources.filter((s) => s.floor === floorFilter)
+    : allSources;
+
+  if (sources.length === 0) {
+    console.error(`[ingest_fanza] No matching sources for FLOOR="${floorFilter}". Available: ${allSources.map((s) => s.floor).join(', ')}`);
+    process.exit(1);
+  }
 
   let totalSuccess = 0;
   let totalFailure = 0;

--- a/scripts/ingest_fanza/index.ts
+++ b/scripts/ingest_fanza/index.ts
@@ -141,6 +141,27 @@ function coalesce<T>(...vals: (T | undefined | null)[]): T | null {
   return null;
 }
 
+function parseDurationSeconds(raw: string | number | null | undefined): number | null {
+  if (raw == null) return null;
+  // HH:MM:SS または MM:SS 形式 (videoc)
+  if (typeof raw === 'string' && raw.includes(':')) {
+    const parts = raw.split(':').map(Number);
+    if (parts.some(isNaN)) return null;
+    if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+    if (parts.length === 2) return parts[0] * 60 + parts[1];
+    return null;
+  }
+  // 数値（分）形式 (videoa)
+  if (typeof raw === 'number') return raw > 0 ? raw * 60 : null;
+  // 文字列の数値（分）
+  const asNum = Number(raw);
+  if (!isNaN(asNum) && asNum > 0) return asNum * 60;
+  // "X分" 形式
+  const minMatch = String(raw).match(/(\d+)\s*分/);
+  if (minMatch) return parseInt(minMatch[1], 10) * 60;
+  return null;
+}
+
 function normalizeFanzaDateTime(input: string | undefined | null): string | null {
   if (!input) return null;
   const raw = input.trim();
@@ -445,9 +466,8 @@ async function ingestSource(
     }
 
     for (const item of result.items) {
-      const volumeText: string | null = item.iteminfo?.volume ?? null;
-      const durationMinutesMatch = typeof volumeText === 'string' ? volumeText.match(/(\d+)\s*分/) : null;
-      const durationSeconds: number | null = durationMinutesMatch ? parseInt(durationMinutesMatch[1], 10) * 60 : null;
+      // volume は root level (item.volume) にある。videoa は分数の数値、videoc は HH:MM:SS 形式
+      const durationSeconds: number | null = parseDurationSeconds(item.volume ?? item.iteminfo?.volume ?? null);
 
       let parsedPrice: number | null = null;
       if (item.prices && item.prices.price != null) {
@@ -537,6 +557,7 @@ async function updateRankings() {
   console.log('[ingest_fanza] === Starting ranking update ===');
   const rankingSources = [
     { service: 'digital', floor: 'videoa', source: 'fanza_videoa' },
+    { service: 'digital', floor: 'videoc', source: 'fanza_videoc' },
     // アニメはランキングからも除外
     // { service: 'digital', floor: 'anime',  source: 'fanza_anime'  },
   ];
@@ -630,6 +651,7 @@ async function main() {
 
   const sources = [
     { service: 'digital', floor: 'videoa', source: 'FANZA' },
+    { service: 'digital', floor: 'videoc', source: 'FANZA_AMATEUR' },
     // アニメは取り込まない（非実写コンテンツ除外）
     // { service: 'digital', floor: 'anime',  source: 'FANZA_ANIME' },
   ];

--- a/scripts/ingest_fanza/run.sh
+++ b/scripts/ingest_fanza/run.sh
@@ -33,6 +33,9 @@ fi
 if [[ "${RANKING_ONLY:-}" != "" ]]; then
   DOCKER_ENV_ARGS+=(--env "RANKING_ONLY=${RANKING_ONLY}")
 fi
+if [[ "${FLOOR:-}" != "" ]]; then
+  DOCKER_ENV_ARGS+=(--env "FLOOR=${FLOOR}")
+fi
 
 exec docker run "${DOCKER_FLAGS[@]}" \
   --env-file "$ENV_FILE" \

--- a/supabase/migrations/20260611000000_add_missing_insert_delete_policies.sql
+++ b/supabase/migrations/20260611000000_add_missing_insert_delete_policies.sql
@@ -1,0 +1,22 @@
+-- public_lists / public_list_videos の INSERT・DELETE ポリシー
+-- （リモートに直接適用済みのため、ローカル追跡用に記録）
+
+DROP POLICY IF EXISTS "public_lists_insert" ON public.public_lists;
+CREATE POLICY "public_lists_insert"
+  ON public.public_lists FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "public_lists_delete" ON public.public_lists;
+CREATE POLICY "public_lists_delete"
+  ON public.public_lists FOR DELETE
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "public_list_videos_insert" ON public.public_list_videos;
+CREATE POLICY "public_list_videos_insert"
+  ON public.public_list_videos FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.public_lists pl
+      WHERE pl.id = list_id AND pl.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary

- **リスト削除ボタンのバグ修正**: `handleDelete` がエラーを無視していたため、削除失敗時にユーザーへ何も伝わらなかった。エラー時に `alert()` で原因を表示するよう修正
- **動画管理モーダル追加**: カスタムリストの各行に「動画管理」ボタンを追加。`ListVideosModal` でリスト内動画を一覧表示し、個別削除できる UI を実装
- **RLS ポリシー追記**: リモートに直接適用済みだった INSERT/DELETE ポリシーをマイグレーションファイルに記録
- **ingest_fanza videoc フロア対応**: 素人フロア（videoc）の取り込み追加・`FLOOR` env var による絞り込み・volume パース改善

## Test plan

- [ ] マイリストページでカスタムリストの「削除」ボタンを押し、confirm → 削除されることを確認
- [ ] 削除失敗時（権限なし等）にエラーメッセージが表示されることを確認
- [ ] カスタムリストの「動画管理」ボタンを押し、追加済み動画が一覧表示されることを確認
- [ ] 動画管理モーダルでゴミ箱アイコンを押すと動画がリストから削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)