### PR TITLE
fix: マイリスト削除を物理DELETE に変更（RLS ポリシーエラー修正）

### DIFF
--- a/frontend/src/app/my/lists/page.tsx
+++ b/frontend/src/app/my/lists/page.tsx
@@ -66,7 +66,7 @@ export default function MyListsPage() {
     if (!confirm('このリストを削除しますか？')) return;
     const { error } = await supabase
       .from('public_lists')
-      .update({ is_active: false })
+      .delete()
       .eq('id', id);
     if (error) {
       alert('削除に失敗しました: ' + error.message);


### PR DESCRIPTION
## Summary

- リスト削除が `UPDATE { is_active: false }` だったため、PostgREST が UPDATE 後に SELECT ポリシー（`is_active = true`）を WITH CHECK として評価し「new row violates row-level security policy」エラーが発生していた
- `public_lists_delete` ポリシーは既に存在しているため、`DELETE` に変更することで解決

## Test plan

- [ ] マイリストページでカスタムリストの削除ボタンを押し、エラーなく削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)