### PR TITLE
feat: リスト編集モード — /u/[username] と /list/[token] でオーナーが直接編集

### DIFF
--- a/frontend/src/app/explore/page.tsx
+++ b/frontend/src/app/explore/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, Suspense } from 'react';
-import { Search, Heart, Plus, Check, Loader2, X, ChevronDown, Sparkles, Compass, ExternalLink, Play } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { Search, Heart, Plus, Check, Loader2, X, ChevronDown, Sparkles, Compass, ExternalLink, Play, ArrowLeft } from 'lucide-react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase';
 
 type Video = {
@@ -86,26 +86,30 @@ function AddToListMenu({ videoId, lists, onClose }: { videoId: string; lists: Pu
 }
 
 // 動画カード
-function VideoCard({ video, likedIds, onLike, lists, onClick }: {
+function VideoCard({ video, likedIds, onLike, lists, onClick, addToListId, addedToListIds, onAddToList }: {
   video: Video;
   likedIds: Set<string>;
   onLike: (video: Video) => void;
   lists: PublicList[];
   onClick: (video: Video) => void;
+  addToListId?: string | null;
+  addedToListIds?: Set<string>;
+  onAddToList?: (videoId: string) => void;
 }) {
   const [showMenu, setShowMenu] = useState(false);
   const thumb = toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
   const liked = likedIds.has(video.id);
+  const addedToList = addToListId ? (addedToListIds?.has(video.id) ?? false) : false;
 
   return (
     <div className="break-inside-avoid mb-2 relative group">
       <div
-        className="block rounded-lg overflow-hidden border border-[#21262d] group-hover:border-violet-500/40 transition-colors bg-[#161b22] cursor-pointer"
+        className={`block rounded-lg overflow-hidden border transition-colors bg-[#161b22] cursor-pointer ${addedToList ? 'border-green-500/60' : 'border-[#21262d] group-hover:border-violet-500/40'}`}
         onClick={() => onClick(video)}
       >
         {thumb ? (
           // eslint-disable-next-line @next/next/no-img-element
-          <img src={thumb} alt={video.title ?? ''} className="w-full h-auto" loading="lazy" />
+          <img src={thumb} alt={video.title ?? ''} className={`w-full h-auto ${addedToList ? 'opacity-60' : ''}`} loading="lazy" />
         ) : (
           <div className="w-full aspect-[3/4] bg-[#21262d]" />
         )}
@@ -116,24 +120,45 @@ function VideoCard({ video, likedIds, onLike, lists, onClick }: {
 
       {/* アクションボタン */}
       <div className="absolute top-1.5 right-1.5 flex flex-col gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button
-          onClick={(e) => { e.stopPropagation(); onLike(video); }}
-          className={`flex items-center justify-center w-7 h-7 rounded-full shadow-lg transition-all ${liked ? 'bg-pink-500 text-white' : 'bg-[#0d1117]/80 text-[#8b949e] hover:text-pink-400'}`}
-        >
-          <Heart size={12} fill={liked ? 'currentColor' : 'none'} />
-        </button>
-        {lists.length > 0 && (
-          <div className="relative">
+        {/* リスト追加モード: 直接追加ボタン */}
+        {addToListId ? (
+          <button
+            onClick={(e) => { e.stopPropagation(); if (!addedToList) onAddToList?.(video.id); }}
+            className={`flex items-center justify-center w-7 h-7 rounded-full shadow-lg transition-all ${addedToList ? 'bg-green-500 text-white' : 'bg-violet-600 hover:bg-violet-500 text-white'}`}
+          >
+            {addedToList ? <Check size={12} /> : <Plus size={12} />}
+          </button>
+        ) : (
+          <>
             <button
-              onClick={(e) => { e.stopPropagation(); setShowMenu((v) => !v); }}
-              className="flex items-center justify-center w-7 h-7 rounded-full bg-[#0d1117]/80 text-[#8b949e] hover:text-violet-400 shadow-lg transition-all"
+              onClick={(e) => { e.stopPropagation(); onLike(video); }}
+              className={`flex items-center justify-center w-7 h-7 rounded-full shadow-lg transition-all ${liked ? 'bg-pink-500 text-white' : 'bg-[#0d1117]/80 text-[#8b949e] hover:text-pink-400'}`}
             >
-              <Plus size={12} />
+              <Heart size={12} fill={liked ? 'currentColor' : 'none'} />
             </button>
-            {showMenu && <AddToListMenu videoId={video.id} lists={lists} onClose={() => setShowMenu(false)} />}
-          </div>
+            {lists.length > 0 && (
+              <div className="relative">
+                <button
+                  onClick={(e) => { e.stopPropagation(); setShowMenu((v) => !v); }}
+                  className="flex items-center justify-center w-7 h-7 rounded-full bg-[#0d1117]/80 text-[#8b949e] hover:text-violet-400 shadow-lg transition-all"
+                >
+                  <Plus size={12} />
+                </button>
+                {showMenu && <AddToListMenu videoId={video.id} lists={lists} onClose={() => setShowMenu(false)} />}
+              </div>
+            )}
+          </>
         )}
       </div>
+
+      {/* 追加済みオーバーレイ */}
+      {addedToList && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="w-8 h-8 rounded-full bg-green-500 flex items-center justify-center shadow-lg">
+            <Check size={16} className="text-white" />
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -217,6 +242,11 @@ function ExplorePageInner() {
   const [videos, setVideos] = useState<Video[]>([]);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState('');
+  const searchParams = useSearchParams();
+  const addToListId = searchParams.get('add_to_list');
+  const addToListTitle = searchParams.get('list_title') ?? 'リスト';
+  const returnUrl = searchParams.get('return_url') ?? null;
+
   const [selectedTag, setSelectedTag] = useState<Tag | null>(null);
   const [popularTags, setPopularTags] = useState<Tag[]>([]);
   const [likedIds, setLikedIds] = useState<Set<string>>(new Set());
@@ -225,6 +255,7 @@ function ExplorePageInner() {
   const [offset, setOffset] = useState(0);
   const [hasMore, setHasMore] = useState(true);
   const [modalVideo, setModalVideo] = useState<Video | null>(null);
+  const [addedToListIds, setAddedToListIds] = useState<Set<string>>(new Set());
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const LIMIT = 30;
 
@@ -282,6 +313,12 @@ function ExplorePageInner() {
     fetchVideos(query, selectedTag, next, true);
   };
 
+  const handleAddToList = useCallback(async (videoId: string) => {
+    if (!addToListId) return;
+    await supabase.from('public_list_videos').insert({ list_id: addToListId, video_id: videoId });
+    setAddedToListIds((prev) => new Set(prev).add(videoId));
+  }, [addToListId]);
+
   const handleLike = async (video: Video) => {
     if (!isLoggedIn) { window.dispatchEvent(new Event('open-auth-modal')); return; }
     if (likedIds.has(video.id)) return;
@@ -292,6 +329,26 @@ function ExplorePageInner() {
 
   return (
     <div className="min-h-screen bg-[#0d1117] text-[#e6edf3]">
+      {/* リスト追加モードバナー */}
+      {addToListId && (
+        <div className="sticky top-0 z-40 flex items-center justify-between gap-3 px-4 py-2.5 bg-violet-600 text-white shadow-lg">
+          <div className="flex items-center gap-2 min-w-0">
+            <Plus size={14} className="shrink-0" />
+            <span className="text-sm font-bold truncate">「{decodeURIComponent(addToListTitle)}」に追加中</span>
+            {addedToListIds.size > 0 && (
+              <span className="shrink-0 text-xs bg-white/20 px-2 py-0.5 rounded-full">{addedToListIds.size}件追加</span>
+            )}
+          </div>
+          <button
+            onClick={() => router.push(returnUrl ?? '/')}
+            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/20 hover:bg-white/30 text-sm font-bold transition-colors"
+          >
+            <ArrowLeft size={13} />
+            完了
+          </button>
+        </div>
+      )}
+
       {/* タブ */}
       <div className="flex gap-1 px-4 pt-3 pb-0">
         <button onClick={() => router.push('/grid')} className="flex items-center gap-1.5 px-4 py-2 rounded-full text-sm font-bold transition-colors text-[#8b949e] hover:text-[#e6edf3] hover:bg-white/5">
@@ -348,6 +405,9 @@ function ExplorePageInner() {
                 onLike={handleLike}
                 lists={lists}
                 onClick={setModalVideo}
+                addToListId={addToListId}
+                addedToListIds={addedToListIds}
+                onAddToList={handleAddToList}
               />
             ))}
           </div>

--- a/frontend/src/app/list/[token]/CopyLinkButton.tsx
+++ b/frontend/src/app/list/[token]/CopyLinkButton.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Link2, Check } from 'lucide-react';
 
-export default function CopyLinkButton({ url, variant = 'dark' }: { url: string; variant?: 'dark' | 'light' }) {
+export default function CopyLinkButton({ url, variant = 'dark' }: { url: string; variant?: 'dark' | 'light' | 'glass' }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -12,10 +12,11 @@ export default function CopyLinkButton({ url, variant = 'dark' }: { url: string;
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const base = 'flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-bold transition-all';
+  const base = 'flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-bold transition-all shrink-0';
   const styles = {
-    dark: 'border border-[#30363d] text-[#8b949e] hover:border-violet-500/50 hover:text-violet-400',
+    dark:  'border border-[#30363d] text-[#8b949e] hover:border-violet-500/50 hover:text-violet-400',
     light: 'bg-white/20 border border-white/30 text-white hover:bg-white/30 backdrop-blur',
+    glass: 'bg-white/50 border border-white/70 text-violet-700 hover:bg-white/70 backdrop-blur shadow-sm',
   };
 
   return (

--- a/frontend/src/app/list/[token]/CopyLinkButton.tsx
+++ b/frontend/src/app/list/[token]/CopyLinkButton.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Link2, Check } from 'lucide-react';
 
-export default function CopyLinkButton({ url }: { url: string }) {
+export default function CopyLinkButton({ url, variant = 'dark' }: { url: string; variant?: 'dark' | 'light' }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -12,13 +12,21 @@ export default function CopyLinkButton({ url }: { url: string }) {
     setTimeout(() => setCopied(false), 2000);
   };
 
+  const base = 'flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-bold transition-all';
+  const styles = {
+    dark: 'border border-[#30363d] text-[#8b949e] hover:border-violet-500/50 hover:text-violet-400',
+    light: 'bg-white/20 border border-white/30 text-white hover:bg-white/30 backdrop-blur',
+  };
+
   return (
     <button
       onClick={handleCopy}
       title={copied ? 'コピーしました' : 'リンクをコピー'}
-      className="p-2 rounded-full border border-[#30363d] text-[#8b949e] hover:border-violet-500/50 hover:text-violet-400 transition-all"
+      className={`${base} ${styles[variant]}`}
     >
-      {copied ? <Check size={14} className="text-green-400" /> : <Link2 size={14} />}
+      {copied
+        ? <><Check size={13} />コピー済み</>
+        : <><Link2 size={13} />シェア</>}
     </button>
   );
 }

--- a/frontend/src/app/list/[token]/CopyLinkButton.tsx
+++ b/frontend/src/app/list/[token]/CopyLinkButton.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Link2, Check } from 'lucide-react';
 
-export default function CopyLinkButton({ url, variant = 'dark' }: { url: string; variant?: 'dark' | 'light' | 'glass' }) {
+export default function CopyLinkButton({ url }: { url: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
@@ -12,22 +12,13 @@ export default function CopyLinkButton({ url, variant = 'dark' }: { url: string;
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const base = 'flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-bold transition-all shrink-0';
-  const styles = {
-    dark:  'border border-[#30363d] text-[#8b949e] hover:border-violet-500/50 hover:text-violet-400',
-    light: 'bg-white/20 border border-white/30 text-white hover:bg-white/30 backdrop-blur',
-    glass: 'bg-white/50 border border-white/70 text-violet-700 hover:bg-white/70 backdrop-blur shadow-sm',
-  };
-
   return (
     <button
       onClick={handleCopy}
       title={copied ? 'コピーしました' : 'リンクをコピー'}
-      className={`${base} ${styles[variant]}`}
+      className="p-2 rounded-full border border-[#30363d] text-[#8b949e] hover:border-violet-500/50 hover:text-violet-400 transition-all"
     >
-      {copied
-        ? <><Check size={13} />コピー済み</>
-        : <><Link2 size={13} />シェア</>}
+      {copied ? <Check size={14} className="text-green-400" /> : <Link2 size={14} />}
     </button>
   );
 }

--- a/frontend/src/app/list/[token]/ListEditMode.tsx
+++ b/frontend/src/app/list/[token]/ListEditMode.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { Search, Trash2, Loader2 } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+import VideoSearchModal from '@/components/lists/VideoSearchModal';
+
+interface Props {
+  ownerUserId: string;
+  listId: string;
+  listType: 'liked' | 'custom';
+}
+
+export default function ListEditMode({ ownerUserId, listId, listType }: Props) {
+  const router = useRouter();
+  const [isOwner, setIsOwner] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setIsOwner(!!user && user.id === ownerUserId);
+    });
+  }, [ownerUserId]);
+
+  const handleAdded = useCallback(() => {
+    router.refresh();
+  }, [router]);
+
+  if (!isOwner || listType !== 'custom') return null;
+
+  return (
+    <>
+      <div className="mb-6 flex items-center justify-between gap-3 px-4 py-2.5 rounded-xl border border-violet-500/40 bg-violet-500/10">
+        <span className="text-xs text-violet-300 font-semibold">編集モード</span>
+        <button
+          onClick={() => setShowSearch(true)}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors"
+        >
+          <Search size={13} />
+          動画を追加
+        </button>
+      </div>
+
+      {showSearch && (
+        <VideoSearchModal
+          listId={listId}
+          onClose={() => setShowSearch(false)}
+          onAdded={handleAdded}
+        />
+      )}
+    </>
+  );
+}
+
+export function VideoDeleteButton({
+  ownerUserId,
+  listId,
+  videoId,
+}: {
+  ownerUserId: string;
+  listId: string;
+  videoId: string;
+}) {
+  const router = useRouter();
+  const [isOwner, setIsOwner] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setIsOwner(!!user && user.id === ownerUserId);
+    });
+  }, [ownerUserId]);
+
+  const handleDelete = useCallback(async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDeleting(true);
+    const { error } = await supabase
+      .from('public_list_videos')
+      .delete()
+      .eq('list_id', listId)
+      .eq('video_id', videoId);
+    if (error) { alert('削除に失敗しました: ' + error.message); setDeleting(false); return; }
+    router.refresh();
+  }, [listId, videoId, router]);
+
+  if (!isOwner) return null;
+
+  return (
+    <button
+      onClick={handleDelete}
+      disabled={deleting}
+      className="absolute top-1.5 right-1.5 flex items-center justify-center w-7 h-7 rounded-lg bg-black/60 backdrop-blur hover:bg-red-500/80 text-white transition-colors opacity-0 group-hover:opacity-100 disabled:opacity-60 shadow"
+      aria-label="リストから削除"
+    >
+      {deleting ? <Loader2 size={12} className="animate-spin" /> : <Trash2 size={12} />}
+    </button>
+  );
+}

--- a/frontend/src/app/list/[token]/ListEditMode.tsx
+++ b/frontend/src/app/list/[token]/ListEditMode.tsx
@@ -4,18 +4,18 @@ import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Search, Trash2, Loader2 } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
-import VideoSearchModal from '@/components/lists/VideoSearchModal';
 
 interface Props {
   ownerUserId: string;
   listId: string;
   listType: 'liked' | 'custom';
+  listTitle?: string | null;
+  token: string;
 }
 
-export default function ListEditMode({ ownerUserId, listId, listType }: Props) {
+export default function ListEditMode({ ownerUserId, listId, listType, listTitle, token }: Props) {
   const router = useRouter();
   const [isOwner, setIsOwner] = useState(false);
-  const [showSearch, setShowSearch] = useState(false);
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data: { user } }) => {
@@ -23,33 +23,21 @@ export default function ListEditMode({ ownerUserId, listId, listType }: Props) {
     });
   }, [ownerUserId]);
 
-  const handleAdded = useCallback(() => {
-    router.refresh();
-  }, [router]);
-
   if (!isOwner || listType !== 'custom') return null;
 
-  return (
-    <>
-      <div className="mb-6 flex items-center justify-between gap-3 px-4 py-2.5 rounded-xl border border-violet-500/40 bg-violet-500/10">
-        <span className="text-xs text-violet-300 font-semibold">編集モード</span>
-        <button
-          onClick={() => setShowSearch(true)}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors"
-        >
-          <Search size={13} />
-          動画を追加
-        </button>
-      </div>
+  const exploreUrl = `/explore?add_to_list=${listId}&list_title=${encodeURIComponent(listTitle ?? 'リスト')}&return_url=${encodeURIComponent(`/list/${token}`)}`;
 
-      {showSearch && (
-        <VideoSearchModal
-          listId={listId}
-          onClose={() => setShowSearch(false)}
-          onAdded={handleAdded}
-        />
-      )}
-    </>
+  return (
+    <div className="mb-6 flex items-center justify-between gap-3 px-4 py-2.5 rounded-xl border border-violet-500/40 bg-violet-500/10">
+      <span className="text-xs text-violet-300 font-semibold">編集モード</span>
+      <button
+        onClick={() => router.push(exploreUrl)}
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors"
+      >
+        <Search size={13} />
+        動画を追加
+      </button>
+    </div>
   );
 }
 

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -25,6 +25,7 @@ type ListData = {
   list_id: string;
   user_id: string;
   display_name: string | null;
+  username: string | null;
   title: string | null;
   list_type: 'liked' | 'custom';
   videos: Video[];
@@ -125,15 +126,24 @@ export default async function PublicListPage(
 
         {/* ヘッダー */}
         <div className="mb-8 flex items-start justify-between gap-4">
-          <div>
-            <h1 className="text-2xl font-black text-[#e6edf3] mb-1">
-              {data.title ? (
-                data.title
-              ) : name ? (
-                <><span className="text-violet-400">{name}</span>のお気に入りリスト</>
-              ) : 'お気に入りリスト'}
+          <div className="space-y-1">
+            <h1 className="text-2xl font-black text-[#e6edf3]">
+              {data.title ?? (name ? `${name}のお気に入りリスト` : 'お気に入りリスト')}
             </h1>
-            <p className="text-sm text-[#656d76]">{data.videos.length}作品</p>
+            {/* 作者表示 — 常に表示してプロフィールへリンク */}
+            {name && (
+              data.username ? (
+                <Link
+                  href={`/u/${data.username}`}
+                  className="inline-flex items-center gap-1 text-sm text-violet-400 hover:text-violet-300 transition-colors"
+                >
+                  <span className="text-[#656d76]">by</span> {name}
+                </Link>
+              ) : (
+                <p className="text-sm text-[#656d76]">by <span className="text-violet-400">{name}</span></p>
+              )
+            )}
+            <p className="text-xs text-[#484f58]">{data.videos.length}作品</p>
           </div>
           <CopyLinkButton url={pageUrl} />
         </div>

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -8,9 +8,6 @@ import ListEditMode, { VideoDeleteButton } from './ListEditMode';
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.seihekilab.com';
 const AF_ID = process.env.NEXT_PUBLIC_FANZA_AFFILIATE_ID ?? 'yotadata2-001';
 
-// スワイプ画面と同じグラデーション
-const BG = 'linear-gradient(135deg, #C4C8E3 0%, #D7D1E3 30%, #F0D5E8 65%, #F9C9D6 100%)';
-
 type Video = {
   id: string;
   title: string | null;
@@ -54,13 +51,16 @@ function toLgThumb(url: string | null | undefined): string | null {
 }
 
 const CHIP_SIZES = [
-  { text: 'text-sm',  px: 'px-3.5', py: 'py-1.5' },
-  { text: 'text-sm',  px: 'px-3',   py: 'py-1.5' },
-  { text: 'text-xs',  px: 'px-3',   py: 'py-1' },
-  { text: 'text-xs',  px: 'px-2.5', py: 'py-1' },
-  { text: 'text-xs',  px: 'px-2',   py: 'py-0.5' },
+  { text: 'text-base', px: 'px-4',   py: 'py-2' },
+  { text: 'text-sm',   px: 'px-3.5', py: 'py-1.5' },
+  { text: 'text-sm',   px: 'px-3',   py: 'py-1.5' },
+  { text: 'text-xs',   px: 'px-3',   py: 'py-1' },
+  { text: 'text-xs',   px: 'px-2.5', py: 'py-1' },
 ];
 function chipSize(i: number) { return CHIP_SIZES[Math.min(i, CHIP_SIZES.length - 1)]; }
+
+const TAG_COLOR  = { bg: 'bg-violet-500/20', border: 'border-violet-500/40', text: 'text-violet-200', num: 'text-violet-400' };
+const PERF_COLOR = { bg: 'bg-pink-500/20',   border: 'border-pink-500/40',   text: 'text-pink-200',   num: 'text-pink-400' };
 
 const EXCLUDED_TAGS = new Set([
   '独占配信', 'ハイビジョン', '単体作品', '4K', '8K', 'VR', 'Ultra HD',
@@ -84,12 +84,12 @@ export async function generateMetadata(
   if (!data) return { title: 'リストが見つかりません | 性癖ラボ' };
 
   const name = data.display_name ?? 'あなた';
-  const topTags = filterTags(data.tags).slice(0, 3).map((t) => t.tag_name).join('・');
+  const topTags = data.tags.slice(0, 3).map((t) => t.tag_name).join('・');
   const description = topTags
-    ? `好きなジャンル: ${topTags}。${data.videos.length}作品のリスト。`
-    : `${data.videos.length}作品のリスト。`;
-  const listTitle = data.title ?? `${name}のお気に入りリスト`;
+    ? `好きなジャンル: ${topTags}。${data.videos.length}作品のいいねリスト。`
+    : `${data.videos.length}作品のいいねリスト。`;
 
+  const listTitle = data.title ?? `${name}のお気に入りリスト`;
   return {
     title: `${listTitle} | 性癖ラボ`,
     description,
@@ -116,88 +116,39 @@ export default async function PublicListPage(
   const filteredTags = filterTags(data.tags);
 
   return (
-    <div className="min-h-screen" style={{ background: BG }}>
-      <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12">
+    <div className="min-h-screen bg-[#0d1117] text-[#e6edf3]">
+      <div className="max-w-4xl mx-auto px-4 py-10">
 
         {/* ナビ */}
-        <Link
-          href="/grid"
-          className="inline-flex items-center gap-1 text-xs text-white/60 hover:text-white/90 transition-colors mb-6 drop-shadow"
-        >
+        <Link href="/grid" className="text-xs text-[#656d76] hover:text-[#8b949e] transition-colors mb-6 inline-block">
           ← 性癖ラボへ戻る
         </Link>
 
-        {/* ━━━ ヒーローカード（グラスモーフィズム） ━━━ */}
-        <div className="rounded-3xl bg-white/30 backdrop-blur-xl border border-white/50 shadow-[0_8px_32px_rgba(0,0,0,0.12)] px-6 sm:px-10 py-8 mb-6">
-          <div className="flex items-start justify-between gap-4 mb-5">
-            <div className="space-y-1.5">
-              <h1 className="text-2xl sm:text-3xl font-black text-gray-800 leading-tight">
-                {data.title ?? (name ? `${name}のお気に入りリスト` : 'お気に入りリスト')}
-              </h1>
-              {name && (
-                <p className="text-sm text-gray-500">
-                  by{' '}
-                  {data.username ? (
-                    <Link
-                      href={`/u/${data.username}`}
-                      className="text-violet-600 font-semibold hover:underline underline-offset-2"
-                    >
-                      {name}
-                    </Link>
-                  ) : (
-                    <span className="text-violet-600 font-semibold">{name}</span>
-                  )}
-                </p>
-              )}
-              <p className="text-xs text-gray-400">{data.videos.length}作品</p>
-            </div>
-            <CopyLinkButton url={pageUrl} variant="glass" />
+        {/* ヘッダー */}
+        <div className="mb-8 flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-black text-[#e6edf3]">
+              {data.title ?? (name ? `${name}のお気に入りリスト` : 'お気に入りリスト')}
+            </h1>
+            {/* 作者表示 — 常に表示してプロフィールへリンク */}
+            {name && (
+              data.username ? (
+                <Link
+                  href={`/u/${data.username}`}
+                  className="inline-flex items-center gap-1 text-sm text-violet-400 hover:text-violet-300 transition-colors"
+                >
+                  <span className="text-[#656d76]">by</span> {name}
+                </Link>
+              ) : (
+                <p className="text-sm text-[#656d76]">by <span className="text-violet-400">{name}</span></p>
+              )
+            )}
+            <p className="text-xs text-[#484f58]">{data.videos.length}作品</p>
           </div>
-
-          {/* タグランキング */}
-          {filteredTags.length > 0 && (
-            <div className="mb-4">
-              <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-2">好きなジャンル</p>
-              <div className="flex flex-wrap gap-2 items-center">
-                {filteredTags.slice(0, 8).map((t, i) => {
-                  const sz = chipSize(i);
-                  return (
-                    <span
-                      key={t.tag_name}
-                      className={`inline-flex items-center gap-1 ${sz.px} ${sz.py} rounded-full ${sz.text} font-semibold bg-white/50 border border-white/70 text-violet-700 shadow-sm`}
-                    >
-                      <span className="text-violet-400 font-black text-[9px]">{i + 1}</span>
-                      {t.tag_name}
-                    </span>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-
-          {/* 女優ランキング */}
-          {(data.performers ?? []).length > 0 && (
-            <div>
-              <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-2">推し女優</p>
-              <div className="flex flex-wrap gap-2 items-center">
-                {(data.performers ?? []).slice(0, 6).map((p, i) => {
-                  const sz = chipSize(i);
-                  return (
-                    <span
-                      key={p.performer_name}
-                      className={`inline-flex items-center gap-1 ${sz.px} ${sz.py} rounded-full ${sz.text} font-semibold bg-pink-100/70 border border-pink-200/80 text-pink-700 shadow-sm`}
-                    >
-                      <span className="text-pink-400 font-black text-[9px]">{i + 1}</span>
-                      {p.performer_name}
-                    </span>
-                  );
-                })}
-              </div>
-            </div>
-          )}
+          <CopyLinkButton url={pageUrl} />
         </div>
 
-        {/* 編集モード（オーナーのみ） */}
+        {/* 編集モードバナー＋動画追加ボタン（オーナーのみ表示） */}
         <ListEditMode
           ownerUserId={data.user_id}
           listId={data.list_id}
@@ -206,43 +157,84 @@ export default async function PublicListPage(
           token={token}
         />
 
-        {/* ━━━ 動画グリッド ━━━ */}
-        {data.videos.length === 0 ? (
-          <div className="rounded-3xl bg-white/30 backdrop-blur-xl border border-white/50 p-16 text-center text-gray-400">
-            まだ作品がありません。
+        {/* 好きなジャンルランキング */}
+        {filteredTags.length > 0 && (
+          <div className="mb-8">
+            <p className="text-xs font-semibold text-[#656d76] uppercase tracking-wider mb-3">好きなジャンルランキング</p>
+            <div className="flex flex-wrap gap-2 items-end">
+              {filteredTags.slice(0, 8).map((t, i) => {
+                const sz = chipSize(i);
+                return (
+                  <span
+                    key={t.tag_name}
+                    className={`inline-flex items-center gap-1.5 ${sz.px} ${sz.py} rounded-full border font-semibold ${sz.text} ${TAG_COLOR.bg} ${TAG_COLOR.border}`}
+                  >
+                    <span className={`font-black ${TAG_COLOR.num} text-[10px]`}>{i + 1}</span>
+                    {t.tag_name}
+                  </span>
+                );
+              })}
+            </div>
           </div>
+        )}
+
+        {/* 推し女優ランキング */}
+        {(data.performers ?? []).length > 0 && (
+          <div className="mb-8">
+            <p className="text-xs font-semibold text-[#656d76] uppercase tracking-wider mb-3">推し女優ランキング</p>
+            <div className="flex flex-wrap gap-2 items-end">
+              {(data.performers ?? []).slice(0, 8).map((p, i) => {
+                const sz = chipSize(i);
+                return (
+                  <span
+                    key={p.performer_name}
+                    className={`inline-flex items-center gap-1.5 ${sz.px} ${sz.py} rounded-full border font-semibold ${sz.text} ${PERF_COLOR.bg} ${PERF_COLOR.border}`}
+                  >
+                    <span className={`font-black ${PERF_COLOR.num} text-[10px]`}>{i + 1}</span>
+                    {p.performer_name}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* 作品グリッド */}
+        {data.videos.length === 0 ? (
+          <p className="text-center text-[#656d76] py-20">まだ作品がありません。</p>
         ) : (
-          <div className="[column-count:2] sm:[column-count:3] [column-gap:10px]">
+          <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
             {data.videos.map((video) => {
               const affiliateUrl = toAffiliateUrl(video.product_url);
               const thumb = toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
               return (
-                <div key={video.id} className="group relative mb-2.5 break-inside-avoid">
+                <div key={video.id} className="group relative mb-3 break-inside-avoid">
                   <a
                     href={affiliateUrl || '#'}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block rounded-2xl overflow-hidden bg-white/40 backdrop-blur-sm border border-white/60 shadow-sm hover:shadow-lg hover:bg-white/60 hover:-translate-y-0.5 transition-all duration-200"
+                    className="block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22]"
                   >
                     {thumb ? (
                       // eslint-disable-next-line @next/next/no-img-element
                       <img
                         src={thumb}
                         alt={video.title ?? ''}
-                        className="w-full h-auto"
+                        className="w-full h-auto group-hover:opacity-90 transition-opacity"
                         loading="lazy"
                       />
                     ) : (
-                      <div className="w-full aspect-video bg-white/20 flex items-center justify-center">
-                        <span className="text-gray-400 text-xs">No Image</span>
+                      <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
+                        <span className="text-[#484f58] text-xs">No Image</span>
                       </div>
                     )}
-                    <div className="px-2.5 py-2">
-                      <p className="text-[11px] text-gray-600 leading-tight line-clamp-2">
+                    <div className="p-2">
+                      <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
                         {video.title ?? ''}
                       </p>
                     </div>
                   </a>
+                  {/* 削除ボタン（オーナー＆カスタムリストのみ） */}
                   {data.list_type === 'custom' && (
                     <VideoDeleteButton
                       ownerUserId={data.user_id}
@@ -257,16 +249,14 @@ export default async function PublicListPage(
         )}
 
         {/* フッター */}
-        <div className="mt-12 text-center">
-          <div className="inline-block rounded-2xl bg-white/30 backdrop-blur-xl border border-white/50 px-8 py-6 shadow-sm">
-            <p className="text-sm text-gray-500 mb-3">このリストは性癖ラボで作成されました</p>
-            <Link
-              href="/grid"
-              className="inline-block px-6 py-2.5 rounded-full bg-white/60 hover:bg-white/80 text-violet-700 text-sm font-bold border border-white/70 shadow-sm transition-all"
-            >
-              自分のリストを作る →
-            </Link>
-          </div>
+        <div className="mt-12 pt-6 border-t border-[#21262d] text-center">
+          <p className="text-sm text-[#656d76] mb-3">このリストは性癖ラボで作成されました</p>
+          <Link
+            href="/grid"
+            className="inline-block px-6 py-2.5 rounded-full bg-violet-600 hover:bg-violet-500 text-white text-sm font-bold transition-colors"
+          >
+            自分のリストを作る
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -8,6 +8,9 @@ import ListEditMode, { VideoDeleteButton } from './ListEditMode';
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.seihekilab.com';
 const AF_ID = process.env.NEXT_PUBLIC_FANZA_AFFILIATE_ID ?? 'yotadata2-001';
 
+// スワイプ画面と同じグラデーション
+const BG = 'linear-gradient(135deg, #C4C8E3 0%, #D7D1E3 30%, #F0D5E8 65%, #F9C9D6 100%)';
+
 type Video = {
   id: string;
   title: string | null;
@@ -50,7 +53,6 @@ function toLgThumb(url: string | null | undefined): string | null {
   return url.replace('ps.jpg', 'pl.jpg');
 }
 
-// ランクに応じたチップサイズ
 const CHIP_SIZES = [
   { text: 'text-sm',  px: 'px-3.5', py: 'py-1.5' },
   { text: 'text-sm',  px: 'px-3',   py: 'py-1.5' },
@@ -114,64 +116,57 @@ export default async function PublicListPage(
   const filteredTags = filterTags(data.tags);
 
   return (
-    <div className="min-h-screen bg-[#f5f5f7]">
+    <div className="min-h-screen" style={{ background: BG }}>
+      <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12">
 
-      {/* ━━━ HERO ━━━ */}
-      <div className="relative overflow-hidden bg-gradient-to-br from-indigo-500 via-violet-500 to-pink-400 text-white">
-        {/* 背景の光彩 */}
-        <div className="absolute inset-0 overflow-hidden pointer-events-none">
-          <div className="absolute -top-24 -left-24 w-96 h-96 bg-white/10 rounded-full blur-3xl" />
-          <div className="absolute -bottom-16 -right-16 w-80 h-80 bg-pink-300/20 rounded-full blur-3xl" />
-        </div>
+        {/* ナビ */}
+        <Link
+          href="/grid"
+          className="inline-flex items-center gap-1 text-xs text-white/60 hover:text-white/90 transition-colors mb-6 drop-shadow"
+        >
+          ← 性癖ラボへ戻る
+        </Link>
 
-        <div className="relative max-w-4xl mx-auto px-4 pt-8 pb-10">
-          {/* ナビ */}
-          <Link
-            href="/grid"
-            className="inline-flex items-center gap-1 text-xs text-white/60 hover:text-white transition-colors mb-6"
-          >
-            ← 性癖ラボへ戻る
-          </Link>
-
-          {/* タイトル＋作者＋アクション */}
-          <div className="flex items-start justify-between gap-4 mb-6">
-            <div className="space-y-2">
-              <h1 className="text-3xl sm:text-4xl font-black leading-tight drop-shadow-sm">
+        {/* ━━━ ヒーローカード（グラスモーフィズム） ━━━ */}
+        <div className="rounded-3xl bg-white/30 backdrop-blur-xl border border-white/50 shadow-[0_8px_32px_rgba(0,0,0,0.12)] px-6 sm:px-10 py-8 mb-6">
+          <div className="flex items-start justify-between gap-4 mb-5">
+            <div className="space-y-1.5">
+              <h1 className="text-2xl sm:text-3xl font-black text-gray-800 leading-tight">
                 {data.title ?? (name ? `${name}のお気に入りリスト` : 'お気に入りリスト')}
               </h1>
               {name && (
-                <p className="text-sm text-white/70">
+                <p className="text-sm text-gray-500">
                   by{' '}
                   {data.username ? (
                     <Link
                       href={`/u/${data.username}`}
-                      className="text-white font-semibold hover:underline underline-offset-2"
+                      className="text-violet-600 font-semibold hover:underline underline-offset-2"
                     >
                       {name}
                     </Link>
                   ) : (
-                    <span className="text-white font-semibold">{name}</span>
+                    <span className="text-violet-600 font-semibold">{name}</span>
                   )}
                 </p>
               )}
-              <p className="text-sm text-white/50">{data.videos.length}作品</p>
+              <p className="text-xs text-gray-400">{data.videos.length}作品</p>
             </div>
-            <CopyLinkButton url={pageUrl} variant="light" />
+            <CopyLinkButton url={pageUrl} variant="glass" />
           </div>
 
           {/* タグランキング */}
           {filteredTags.length > 0 && (
             <div className="mb-4">
-              <p className="text-[10px] font-bold text-white/50 uppercase tracking-widest mb-2">好きなジャンル</p>
+              <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-2">好きなジャンル</p>
               <div className="flex flex-wrap gap-2 items-center">
                 {filteredTags.slice(0, 8).map((t, i) => {
                   const sz = chipSize(i);
                   return (
                     <span
                       key={t.tag_name}
-                      className={`inline-flex items-center gap-1 ${sz.px} ${sz.py} rounded-full ${sz.text} font-semibold bg-white/15 backdrop-blur border border-white/20 text-white`}
+                      className={`inline-flex items-center gap-1 ${sz.px} ${sz.py} rounded-full ${sz.text} font-semibold bg-white/50 border border-white/70 text-violet-700 shadow-sm`}
                     >
-                      <span className="text-white/50 font-black text-[9px]">{i + 1}</span>
+                      <span className="text-violet-400 font-black text-[9px]">{i + 1}</span>
                       {t.tag_name}
                     </span>
                   );
@@ -183,16 +178,16 @@ export default async function PublicListPage(
           {/* 女優ランキング */}
           {(data.performers ?? []).length > 0 && (
             <div>
-              <p className="text-[10px] font-bold text-white/50 uppercase tracking-widest mb-2">推し女優</p>
+              <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-2">推し女優</p>
               <div className="flex flex-wrap gap-2 items-center">
                 {(data.performers ?? []).slice(0, 6).map((p, i) => {
                   const sz = chipSize(i);
                   return (
                     <span
                       key={p.performer_name}
-                      className={`inline-flex items-center gap-1 ${sz.px} ${sz.py} rounded-full ${sz.text} font-semibold bg-pink-500/30 backdrop-blur border border-pink-300/30 text-white`}
+                      className={`inline-flex items-center gap-1 ${sz.px} ${sz.py} rounded-full ${sz.text} font-semibold bg-pink-100/70 border border-pink-200/80 text-pink-700 shadow-sm`}
                     >
-                      <span className="text-pink-200/60 font-black text-[9px]">{i + 1}</span>
+                      <span className="text-pink-400 font-black text-[9px]">{i + 1}</span>
                       {p.performer_name}
                     </span>
                   );
@@ -201,10 +196,6 @@ export default async function PublicListPage(
             </div>
           )}
         </div>
-      </div>
-
-      {/* ━━━ BODY ━━━ */}
-      <div className="max-w-4xl mx-auto px-4 py-8">
 
         {/* 編集モード（オーナーのみ） */}
         <ListEditMode
@@ -215,42 +206,43 @@ export default async function PublicListPage(
           token={token}
         />
 
-        {/* 作品グリッド */}
+        {/* ━━━ 動画グリッド ━━━ */}
         {data.videos.length === 0 ? (
-          <p className="text-center text-gray-400 py-20">まだ作品がありません。</p>
+          <div className="rounded-3xl bg-white/30 backdrop-blur-xl border border-white/50 p-16 text-center text-gray-400">
+            まだ作品がありません。
+          </div>
         ) : (
-          <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
+          <div className="[column-count:2] sm:[column-count:3] [column-gap:10px]">
             {data.videos.map((video) => {
               const affiliateUrl = toAffiliateUrl(video.product_url);
               const thumb = toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
               return (
-                <div key={video.id} className="group relative mb-3 break-inside-avoid">
+                <div key={video.id} className="group relative mb-2.5 break-inside-avoid">
                   <a
                     href={affiliateUrl || '#'}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block rounded-xl overflow-hidden bg-white shadow-sm hover:shadow-md transition-shadow border border-black/5"
+                    className="block rounded-2xl overflow-hidden bg-white/40 backdrop-blur-sm border border-white/60 shadow-sm hover:shadow-lg hover:bg-white/60 hover:-translate-y-0.5 transition-all duration-200"
                   >
                     {thumb ? (
                       // eslint-disable-next-line @next/next/no-img-element
                       <img
                         src={thumb}
                         alt={video.title ?? ''}
-                        className="w-full h-auto group-hover:scale-[1.02] transition-transform duration-300"
+                        className="w-full h-auto"
                         loading="lazy"
                       />
                     ) : (
-                      <div className="w-full aspect-video bg-gray-100 flex items-center justify-center">
+                      <div className="w-full aspect-video bg-white/20 flex items-center justify-center">
                         <span className="text-gray-400 text-xs">No Image</span>
                       </div>
                     )}
                     <div className="px-2.5 py-2">
-                      <p className="text-[11px] text-gray-500 leading-tight line-clamp-2">
+                      <p className="text-[11px] text-gray-600 leading-tight line-clamp-2">
                         {video.title ?? ''}
                       </p>
                     </div>
                   </a>
-                  {/* 削除ボタン（オーナー＆カスタムリストのみ） */}
                   {data.list_type === 'custom' && (
                     <VideoDeleteButton
                       ownerUserId={data.user_id}
@@ -265,14 +257,16 @@ export default async function PublicListPage(
         )}
 
         {/* フッター */}
-        <div className="mt-12 pt-6 border-t border-black/10 text-center">
-          <p className="text-sm text-gray-400 mb-3">このリストは性癖ラボで作成されました</p>
-          <Link
-            href="/grid"
-            className="inline-block px-6 py-2.5 rounded-full bg-gradient-to-r from-violet-500 to-pink-500 text-white text-sm font-bold hover:opacity-90 transition-opacity shadow-md"
-          >
-            自分のリストを作る
-          </Link>
+        <div className="mt-12 text-center">
+          <div className="inline-block rounded-2xl bg-white/30 backdrop-blur-xl border border-white/50 px-8 py-6 shadow-sm">
+            <p className="text-sm text-gray-500 mb-3">このリストは性癖ラボで作成されました</p>
+            <Link
+              href="/grid"
+              className="inline-block px-6 py-2.5 rounded-full bg-white/60 hover:bg-white/80 text-violet-700 text-sm font-bold border border-white/70 shadow-sm transition-all"
+            >
+              自分のリストを作る →
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -50,17 +50,15 @@ function toLgThumb(url: string | null | undefined): string | null {
   return url.replace('ps.jpg', 'pl.jpg');
 }
 
+// ランクに応じたチップサイズ
 const CHIP_SIZES = [
-  { text: 'text-base', px: 'px-4',   py: 'py-2' },
-  { text: 'text-sm',   px: 'px-3.5', py: 'py-1.5' },
-  { text: 'text-sm',   px: 'px-3',   py: 'py-1.5' },
-  { text: 'text-xs',   px: 'px-3',   py: 'py-1' },
-  { text: 'text-xs',   px: 'px-2.5', py: 'py-1' },
+  { text: 'text-sm',  px: 'px-3.5', py: 'py-1.5' },
+  { text: 'text-sm',  px: 'px-3',   py: 'py-1.5' },
+  { text: 'text-xs',  px: 'px-3',   py: 'py-1' },
+  { text: 'text-xs',  px: 'px-2.5', py: 'py-1' },
+  { text: 'text-xs',  px: 'px-2',   py: 'py-0.5' },
 ];
 function chipSize(i: number) { return CHIP_SIZES[Math.min(i, CHIP_SIZES.length - 1)]; }
-
-const TAG_COLOR  = { bg: 'bg-violet-500/20', border: 'border-violet-500/40', text: 'text-violet-200', num: 'text-violet-400' };
-const PERF_COLOR = { bg: 'bg-pink-500/20',   border: 'border-pink-500/40',   text: 'text-pink-200',   num: 'text-pink-400' };
 
 const EXCLUDED_TAGS = new Set([
   '独占配信', 'ハイビジョン', '単体作品', '4K', '8K', 'VR', 'Ultra HD',
@@ -84,12 +82,12 @@ export async function generateMetadata(
   if (!data) return { title: 'リストが見つかりません | 性癖ラボ' };
 
   const name = data.display_name ?? 'あなた';
-  const topTags = data.tags.slice(0, 3).map((t) => t.tag_name).join('・');
+  const topTags = filterTags(data.tags).slice(0, 3).map((t) => t.tag_name).join('・');
   const description = topTags
-    ? `好きなジャンル: ${topTags}。${data.videos.length}作品のいいねリスト。`
-    : `${data.videos.length}作品のいいねリスト。`;
-
+    ? `好きなジャンル: ${topTags}。${data.videos.length}作品のリスト。`
+    : `${data.videos.length}作品のリスト。`;
   const listTitle = data.title ?? `${name}のお気に入りリスト`;
+
   return {
     title: `${listTitle} | 性癖ラボ`,
     description,
@@ -116,39 +114,99 @@ export default async function PublicListPage(
   const filteredTags = filterTags(data.tags);
 
   return (
-    <div className="min-h-screen bg-[#0d1117] text-[#e6edf3]">
-      <div className="max-w-4xl mx-auto px-4 py-10">
+    <div className="min-h-screen bg-[#f5f5f7]">
 
-        {/* ナビ */}
-        <Link href="/grid" className="text-xs text-[#656d76] hover:text-[#8b949e] transition-colors mb-6 inline-block">
-          ← 性癖ラボへ戻る
-        </Link>
-
-        {/* ヘッダー */}
-        <div className="mb-8 flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <h1 className="text-2xl font-black text-[#e6edf3]">
-              {data.title ?? (name ? `${name}のお気に入りリスト` : 'お気に入りリスト')}
-            </h1>
-            {/* 作者表示 — 常に表示してプロフィールへリンク */}
-            {name && (
-              data.username ? (
-                <Link
-                  href={`/u/${data.username}`}
-                  className="inline-flex items-center gap-1 text-sm text-violet-400 hover:text-violet-300 transition-colors"
-                >
-                  <span className="text-[#656d76]">by</span> {name}
-                </Link>
-              ) : (
-                <p className="text-sm text-[#656d76]">by <span className="text-violet-400">{name}</span></p>
-              )
-            )}
-            <p className="text-xs text-[#484f58]">{data.videos.length}作品</p>
-          </div>
-          <CopyLinkButton url={pageUrl} />
+      {/* ━━━ HERO ━━━ */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-indigo-500 via-violet-500 to-pink-400 text-white">
+        {/* 背景の光彩 */}
+        <div className="absolute inset-0 overflow-hidden pointer-events-none">
+          <div className="absolute -top-24 -left-24 w-96 h-96 bg-white/10 rounded-full blur-3xl" />
+          <div className="absolute -bottom-16 -right-16 w-80 h-80 bg-pink-300/20 rounded-full blur-3xl" />
         </div>
 
-        {/* 編集モードバナー＋動画追加ボタン（オーナーのみ表示） */}
+        <div className="relative max-w-4xl mx-auto px-4 pt-8 pb-10">
+          {/* ナビ */}
+          <Link
+            href="/grid"
+            className="inline-flex items-center gap-1 text-xs text-white/60 hover:text-white transition-colors mb-6"
+          >
+            ← 性癖ラボへ戻る
+          </Link>
+
+          {/* タイトル＋作者＋アクション */}
+          <div className="flex items-start justify-between gap-4 mb-6">
+            <div className="space-y-2">
+              <h1 className="text-3xl sm:text-4xl font-black leading-tight drop-shadow-sm">
+                {data.title ?? (name ? `${name}のお気に入りリスト` : 'お気に入りリスト')}
+              </h1>
+              {name && (
+                <p className="text-sm text-white/70">
+                  by{' '}
+                  {data.username ? (
+                    <Link
+                      href={`/u/${data.username}`}
+                      className="text-white font-semibold hover:underline underline-offset-2"
+                    >
+                      {name}
+                    </Link>
+                  ) : (
+                    <span className="text-white font-semibold">{name}</span>
+                  )}
+                </p>
+              )}
+              <p className="text-sm text-white/50">{data.videos.length}作品</p>
+            </div>
+            <CopyLinkButton url={pageUrl} variant="light" />
+          </div>
+
+          {/* タグランキング */}
+          {filteredTags.length > 0 && (
+            <div className="mb-4">
+              <p className="text-[10px] font-bold text-white/50 uppercase tracking-widest mb-2">好きなジャンル</p>
+              <div className="flex flex-wrap gap-2 items-center">
+                {filteredTags.slice(0, 8).map((t, i) => {
+                  const sz = chipSize(i);
+                  return (
+                    <span
+                      key={t.tag_name}
+                      className={`inline-flex items-center gap-1 ${sz.px} ${sz.py} rounded-full ${sz.text} font-semibold bg-white/15 backdrop-blur border border-white/20 text-white`}
+                    >
+                      <span className="text-white/50 font-black text-[9px]">{i + 1}</span>
+                      {t.tag_name}
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* 女優ランキング */}
+          {(data.performers ?? []).length > 0 && (
+            <div>
+              <p className="text-[10px] font-bold text-white/50 uppercase tracking-widest mb-2">推し女優</p>
+              <div className="flex flex-wrap gap-2 items-center">
+                {(data.performers ?? []).slice(0, 6).map((p, i) => {
+                  const sz = chipSize(i);
+                  return (
+                    <span
+                      key={p.performer_name}
+                      className={`inline-flex items-center gap-1 ${sz.px} ${sz.py} rounded-full ${sz.text} font-semibold bg-pink-500/30 backdrop-blur border border-pink-300/30 text-white`}
+                    >
+                      <span className="text-pink-200/60 font-black text-[9px]">{i + 1}</span>
+                      {p.performer_name}
+                    </span>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ━━━ BODY ━━━ */}
+      <div className="max-w-4xl mx-auto px-4 py-8">
+
+        {/* 編集モード（オーナーのみ） */}
         <ListEditMode
           ownerUserId={data.user_id}
           listId={data.list_id}
@@ -157,51 +215,9 @@ export default async function PublicListPage(
           token={token}
         />
 
-        {/* 好きなジャンルランキング */}
-        {filteredTags.length > 0 && (
-          <div className="mb-8">
-            <p className="text-xs font-semibold text-[#656d76] uppercase tracking-wider mb-3">好きなジャンルランキング</p>
-            <div className="flex flex-wrap gap-2 items-end">
-              {filteredTags.slice(0, 8).map((t, i) => {
-                const sz = chipSize(i);
-                return (
-                  <span
-                    key={t.tag_name}
-                    className={`inline-flex items-center gap-1.5 ${sz.px} ${sz.py} rounded-full border font-semibold ${sz.text} ${TAG_COLOR.bg} ${TAG_COLOR.border}`}
-                  >
-                    <span className={`font-black ${TAG_COLOR.num} text-[10px]`}>{i + 1}</span>
-                    {t.tag_name}
-                  </span>
-                );
-              })}
-            </div>
-          </div>
-        )}
-
-        {/* 推し女優ランキング */}
-        {(data.performers ?? []).length > 0 && (
-          <div className="mb-8">
-            <p className="text-xs font-semibold text-[#656d76] uppercase tracking-wider mb-3">推し女優ランキング</p>
-            <div className="flex flex-wrap gap-2 items-end">
-              {(data.performers ?? []).slice(0, 8).map((p, i) => {
-                const sz = chipSize(i);
-                return (
-                  <span
-                    key={p.performer_name}
-                    className={`inline-flex items-center gap-1.5 ${sz.px} ${sz.py} rounded-full border font-semibold ${sz.text} ${PERF_COLOR.bg} ${PERF_COLOR.border}`}
-                  >
-                    <span className={`font-black ${PERF_COLOR.num} text-[10px]`}>{i + 1}</span>
-                    {p.performer_name}
-                  </span>
-                );
-              })}
-            </div>
-          </div>
-        )}
-
         {/* 作品グリッド */}
         {data.videos.length === 0 ? (
-          <p className="text-center text-[#656d76] py-20">まだ作品がありません。</p>
+          <p className="text-center text-gray-400 py-20">まだ作品がありません。</p>
         ) : (
           <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
             {data.videos.map((video) => {
@@ -213,23 +229,23 @@ export default async function PublicListPage(
                     href={affiliateUrl || '#'}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22]"
+                    className="block rounded-xl overflow-hidden bg-white shadow-sm hover:shadow-md transition-shadow border border-black/5"
                   >
                     {thumb ? (
                       // eslint-disable-next-line @next/next/no-img-element
                       <img
                         src={thumb}
                         alt={video.title ?? ''}
-                        className="w-full h-auto group-hover:opacity-90 transition-opacity"
+                        className="w-full h-auto group-hover:scale-[1.02] transition-transform duration-300"
                         loading="lazy"
                       />
                     ) : (
-                      <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
-                        <span className="text-[#484f58] text-xs">No Image</span>
+                      <div className="w-full aspect-video bg-gray-100 flex items-center justify-center">
+                        <span className="text-gray-400 text-xs">No Image</span>
                       </div>
                     )}
-                    <div className="p-2">
-                      <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
+                    <div className="px-2.5 py-2">
+                      <p className="text-[11px] text-gray-500 leading-tight line-clamp-2">
                         {video.title ?? ''}
                       </p>
                     </div>
@@ -249,11 +265,11 @@ export default async function PublicListPage(
         )}
 
         {/* フッター */}
-        <div className="mt-12 pt-6 border-t border-[#21262d] text-center">
-          <p className="text-sm text-[#656d76] mb-3">このリストは性癖ラボで作成されました</p>
+        <div className="mt-12 pt-6 border-t border-black/10 text-center">
+          <p className="text-sm text-gray-400 mb-3">このリストは性癖ラボで作成されました</p>
           <Link
             href="/grid"
-            className="inline-block px-6 py-2.5 rounded-full bg-violet-600 hover:bg-violet-500 text-white text-sm font-bold transition-colors"
+            className="inline-block px-6 py-2.5 rounded-full bg-gradient-to-r from-violet-500 to-pink-500 text-white text-sm font-bold hover:opacity-90 transition-opacity shadow-md"
           >
             自分のリストを作る
           </Link>

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -125,28 +125,41 @@ export default async function PublicListPage(
         </Link>
 
         {/* ヘッダー */}
-        <div className="mb-8 flex items-start justify-between gap-4">
+        <div className="mb-6 flex items-start justify-between gap-4">
           <div className="space-y-1">
             <h1 className="text-2xl font-black text-[#e6edf3]">
               {data.title ?? (name ? `${name}のお気に入りリスト` : 'お気に入りリスト')}
             </h1>
-            {/* 作者表示 — 常に表示してプロフィールへリンク */}
             {name && (
-              data.username ? (
-                <Link
-                  href={`/u/${data.username}`}
-                  className="inline-flex items-center gap-1 text-sm text-violet-400 hover:text-violet-300 transition-colors"
-                >
-                  <span className="text-[#656d76]">by</span> {name}
-                </Link>
-              ) : (
-                <p className="text-sm text-[#656d76]">by <span className="text-violet-400">{name}</span></p>
-              )
+              <p className="text-sm text-[#656d76]">
+                by <span className="text-violet-400">{name}</span>
+              </p>
             )}
             <p className="text-xs text-[#484f58]">{data.videos.length}作品</p>
           </div>
           <CopyLinkButton url={pageUrl} />
         </div>
+
+        {/* 作者のリスト一覧へ */}
+        {data.username && (
+          <Link
+            href={`/u/${data.username}`}
+            className="flex items-center justify-between gap-3 mb-8 px-4 py-3 rounded-xl bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 hover:bg-[#1c2128] transition-all group"
+          >
+            <div className="flex items-center gap-2.5 min-w-0">
+              <div className="w-8 h-8 rounded-full bg-violet-500/20 border border-violet-500/30 flex items-center justify-center shrink-0 text-sm">
+                {name?.charAt(0) ?? '?'}
+              </div>
+              <div className="min-w-0">
+                <p className="text-xs text-[#656d76]">作成者</p>
+                <p className="text-sm font-bold text-[#e6edf3] truncate">{name}</p>
+              </div>
+            </div>
+            <span className="text-xs text-[#656d76] group-hover:text-violet-400 transition-colors shrink-0">
+              他のリストを見る →
+            </span>
+          </Link>
+        )}
 
         {/* 編集モードバナー＋動画追加ボタン（オーナーのみ表示） */}
         <ListEditMode

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -153,6 +153,8 @@ export default async function PublicListPage(
           ownerUserId={data.user_id}
           listId={data.list_id}
           listType={data.list_type}
+          listTitle={data.title}
+          token={token}
         />
 
         {/* 好きなジャンルランキング */}

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { supabase } from '@/lib/supabase';
 import CopyLinkButton from './CopyLinkButton';
+import ListEditMode, { VideoDeleteButton } from './ListEditMode';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.seihekilab.com';
 const AF_ID = process.env.NEXT_PUBLIC_FANZA_AFFILIATE_ID ?? 'yotadata2-001';
@@ -21,8 +22,11 @@ type TagStat = { tag_name: string; cnt: number };
 type PerformerStat = { performer_name: string; cnt: number };
 
 type ListData = {
+  list_id: string;
+  user_id: string;
   display_name: string | null;
   title: string | null;
+  list_type: 'liked' | 'custom';
   videos: Video[];
   tags: TagStat[];
   performers: PerformerStat[];
@@ -45,7 +49,6 @@ function toLgThumb(url: string | null | undefined): string | null {
   return url.replace('ps.jpg', 'pl.jpg');
 }
 
-// ランク(0始まり)に応じたチップサイズ
 const CHIP_SIZES = [
   { text: 'text-base', px: 'px-4',   py: 'py-2' },
   { text: 'text-sm',   px: 'px-3.5', py: 'py-1.5' },
@@ -58,7 +61,6 @@ function chipSize(i: number) { return CHIP_SIZES[Math.min(i, CHIP_SIZES.length -
 const TAG_COLOR  = { bg: 'bg-violet-500/20', border: 'border-violet-500/40', text: 'text-violet-200', num: 'text-violet-400' };
 const PERF_COLOR = { bg: 'bg-pink-500/20',   border: 'border-pink-500/40',   text: 'text-pink-200',   num: 'text-pink-400' };
 
-// 技術的・流通系タグ（嗜好を表さないもの）は除外
 const EXCLUDED_TAGS = new Set([
   '独占配信', 'ハイビジョン', '単体作品', '4K', '8K', 'VR', 'Ultra HD',
   '無修正', '高画質', 'フルHD', 'DVD', 'Blu-ray', '収録時間4時間以上',
@@ -131,10 +133,17 @@ export default async function PublicListPage(
                 <><span className="text-violet-400">{name}</span>のお気に入りリスト</>
               ) : 'お気に入りリスト'}
             </h1>
-            <p className="text-sm text-[#656d76]">いいね {data.videos.length}作品</p>
+            <p className="text-sm text-[#656d76]">{data.videos.length}作品</p>
           </div>
           <CopyLinkButton url={pageUrl} />
         </div>
+
+        {/* 編集モードバナー＋動画追加ボタン（オーナーのみ表示） */}
+        <ListEditMode
+          ownerUserId={data.user_id}
+          listId={data.list_id}
+          listType={data.list_type}
+        />
 
         {/* 好きなジャンルランキング */}
         {filteredTags.length > 0 && (
@@ -178,41 +187,50 @@ export default async function PublicListPage(
           </div>
         )}
 
-        {/* 作品グリッド（Pinterest風マソンリー） */}
+        {/* 作品グリッド */}
         {data.videos.length === 0 ? (
-          <p className="text-center text-[#656d76] py-20">まだいいねした作品がありません。</p>
+          <p className="text-center text-[#656d76] py-20">まだ作品がありません。</p>
         ) : (
           <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
             {data.videos.map((video) => {
               const affiliateUrl = toAffiliateUrl(video.product_url);
               const thumb = toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
               return (
-                <a
-                  key={video.id}
-                  href={affiliateUrl || '#'}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22] mb-3 break-inside-avoid"
-                >
-                  {thumb ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={thumb}
-                      alt={video.title ?? ''}
-                      className="w-full h-auto group-hover:opacity-90 transition-opacity"
-                      loading="lazy"
-                    />
-                  ) : (
-                    <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
-                      <span className="text-[#484f58] text-xs">No Image</span>
+                <div key={video.id} className="group relative mb-3 break-inside-avoid">
+                  <a
+                    href={affiliateUrl || '#'}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22]"
+                  >
+                    {thumb ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={thumb}
+                        alt={video.title ?? ''}
+                        className="w-full h-auto group-hover:opacity-90 transition-opacity"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
+                        <span className="text-[#484f58] text-xs">No Image</span>
+                      </div>
+                    )}
+                    <div className="p-2">
+                      <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
+                        {video.title ?? ''}
+                      </p>
                     </div>
+                  </a>
+                  {/* 削除ボタン（オーナー＆カスタムリストのみ） */}
+                  {data.list_type === 'custom' && (
+                    <VideoDeleteButton
+                      ownerUserId={data.user_id}
+                      listId={data.list_id}
+                      videoId={video.id}
+                    />
                   )}
-                  <div className="p-2">
-                    <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
-                      {video.title ?? ''}
-                    </p>
-                  </div>
-                </a>
+                </div>
               );
             })}
           </div>

--- a/frontend/src/app/my/lists/page.tsx
+++ b/frontend/src/app/my/lists/page.tsx
@@ -1,228 +1,29 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
-import { Plus, ExternalLink, Loader2, Search, Trash2, ListVideo } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
-import VideoSearchModal from '@/components/lists/VideoSearchModal';
-import ListVideosModal from '@/components/lists/ListVideosModal';
+import { Loader2 } from 'lucide-react';
 
-type PublicList = {
-  id: string;
-  token: string;
-  title: string | null;
-  description: string | null;
-  list_type: 'liked' | 'custom';
-  is_active: boolean;
-  created_at: string;
-};
-
-export default function MyListsPage() {
+/** /my/lists は廃止。ログインユーザーの /u/[username] にリダイレクト */
+export default function MyListsRedirectPage() {
   const router = useRouter();
-  const [lists, setLists] = useState<PublicList[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [creating, setCreating] = useState(false);
-  const [newTitle, setNewTitle] = useState('');
-  const [newDesc, setNewDesc] = useState('');
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [searchTarget, setSearchTarget] = useState<PublicList | null>(null);
-  const [manageTarget, setManageTarget] = useState<PublicList | null>(null);
 
-  const fetchLists = useCallback(async () => {
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) { router.push('/'); return; }
-    const { data } = await supabase
-      .from('public_lists')
-      .select('*')
-      .eq('user_id', user.id)
-      .eq('is_active', true)
-      .order('created_at', { ascending: false });
-    setLists((data as PublicList[]) ?? []);
-    setLoading(false);
+  useEffect(() => {
+    supabase.auth.getUser().then(async ({ data: { user } }) => {
+      if (!user) { router.replace('/'); return; }
+      const username = user.user_metadata?.username as string | undefined;
+      if (username) {
+        router.replace(`/u/${username}`);
+      } else {
+        router.replace('/');
+      }
+    });
   }, [router]);
 
-  useEffect(() => { fetchLists(); }, [fetchLists]);
-
-  const handleCreate = async () => {
-    if (!newTitle.trim()) return;
-    setCreating(true);
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return;
-    await supabase.from('public_lists').insert({
-      user_id: user.id,
-      title: newTitle.trim(),
-      description: newDesc.trim() || null,
-      list_type: 'custom',
-    });
-    setNewTitle('');
-    setNewDesc('');
-    setShowCreateForm(false);
-    setCreating(false);
-    await fetchLists();
-  };
-
-  const handleDelete = async (id: string) => {
-    if (!confirm('このリストを削除しますか？')) return;
-    const { error } = await supabase
-      .from('public_lists')
-      .update({ is_active: false })
-      .eq('id', id);
-    if (error) {
-      alert('削除に失敗しました: ' + error.message);
-      return;
-    }
-    await fetchLists();
-  };
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-[#0d1117] flex items-center justify-center">
-        <Loader2 className="text-violet-400 animate-spin" size={24} />
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen bg-[#0d1117] text-[#e6edf3]">
-      <div className="max-w-2xl mx-auto px-4 py-10">
-
-        {/* ナビ */}
-        <Link href="/grid" className="text-xs text-[#656d76] hover:text-[#8b949e] transition-colors mb-6 inline-block">
-          ← 性癖ラボへ戻る
-        </Link>
-
-        {/* ヘッダー */}
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-xl font-black text-[#e6edf3]">マイリスト</h1>
-          <button
-            onClick={() => setShowCreateForm(true)}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors"
-          >
-            <Plus size={14} />
-            新しいリスト
-          </button>
-        </div>
-
-        {/* 新規作成フォーム */}
-        {showCreateForm && (
-          <div className="mb-6 p-4 rounded-xl border border-violet-500/40 bg-violet-500/10">
-            <p className="text-sm font-bold text-[#e6edf3] mb-3">新しいリストを作成</p>
-            <input
-              type="text"
-              value={newTitle}
-              onChange={(e) => setNewTitle(e.target.value)}
-              placeholder="リストのタイトル（例: NTR厳選リスト）"
-              className="w-full bg-[#0d1117] border border-[#30363d] rounded-lg px-3 py-2 text-sm text-[#e6edf3] placeholder-[#484f58] outline-none focus:border-violet-500/50 mb-2"
-            />
-            <textarea
-              value={newDesc}
-              onChange={(e) => setNewDesc(e.target.value)}
-              placeholder="説明（省略可）"
-              rows={2}
-              className="w-full bg-[#0d1117] border border-[#30363d] rounded-lg px-3 py-2 text-sm text-[#e6edf3] placeholder-[#484f58] outline-none focus:border-violet-500/50 resize-none mb-3"
-            />
-            <div className="flex gap-2">
-              <button
-                onClick={handleCreate}
-                disabled={creating || !newTitle.trim()}
-                className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors disabled:opacity-50"
-              >
-                {creating ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
-                作成
-              </button>
-              <button
-                onClick={() => setShowCreateForm(false)}
-                className="px-4 py-2 rounded-lg bg-white/5 text-[#8b949e] text-xs font-bold hover:bg-white/10 transition-colors"
-              >
-                キャンセル
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* リスト一覧 */}
-        {lists.length === 0 ? (
-          <p className="text-center text-[#656d76] py-20 text-sm">まだリストがありません</p>
-        ) : (
-          <div className="space-y-3">
-            {lists.map((list) => (
-              <div
-                key={list.id}
-                className="flex items-center gap-3 p-4 rounded-xl border border-[#21262d] bg-[#161b22] hover:border-[#30363d] transition-colors"
-              >
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-bold text-[#e6edf3] line-clamp-1">
-                    {list.list_type === 'liked' ? 'お気に入りリスト' : (list.title ?? '無題のリスト')}
-                  </p>
-                  {list.description && (
-                    <p className="text-xs text-[#656d76] mt-0.5 line-clamp-1">{list.description}</p>
-                  )}
-                  <span className="inline-block mt-1 text-[10px] px-2 py-0.5 rounded-full bg-white/5 text-[#484f58]">
-                    {list.list_type === 'liked' ? 'いいねリスト' : 'カスタム'}
-                  </span>
-                </div>
-
-                <div className="flex items-center gap-1.5 shrink-0">
-                  {list.list_type === 'custom' && (
-                    <>
-                      <button
-                        onClick={() => setSearchTarget(list)}
-                        className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-violet-600/20 hover:bg-violet-600/40 text-violet-400 text-xs font-bold transition-colors border border-violet-500/30"
-                      >
-                        <Search size={11} />
-                        動画追加
-                      </button>
-                      <button
-                        onClick={() => setManageTarget(list)}
-                        className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-white/5 hover:bg-white/10 text-[#8b949e] text-xs font-bold transition-colors border border-[#30363d]"
-                      >
-                        <ListVideo size={11} />
-                        動画管理
-                      </button>
-                    </>
-                  )}
-                  <a
-                    href={`/list/${list.token}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center justify-center w-8 h-8 rounded-lg bg-white/5 hover:bg-white/10 text-[#8b949e] transition-colors"
-                  >
-                    <ExternalLink size={14} />
-                  </a>
-                  {list.list_type === 'custom' && (
-                    <button
-                      onClick={() => handleDelete(list.id)}
-                      className="flex items-center justify-center w-8 h-8 rounded-lg bg-red-500/10 hover:bg-red-500/20 text-red-400 transition-colors"
-                    >
-                      <Trash2 size={14} />
-                    </button>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* 動画検索モーダル */}
-      {searchTarget && (
-        <VideoSearchModal
-          listId={searchTarget.id}
-          onClose={() => setSearchTarget(null)}
-          onAdded={fetchLists}
-        />
-      )}
-
-      {/* 動画管理モーダル */}
-      {manageTarget && (
-        <ListVideosModal
-          listId={manageTarget.id}
-          listTitle={manageTarget.title ?? '無題のリスト'}
-          onClose={() => setManageTarget(null)}
-          onChanged={fetchLists}
-        />
-      )}
+    <div className="min-h-screen bg-[#0d1117] flex items-center justify-center">
+      <Loader2 className="text-violet-400 animate-spin" size={24} />
     </div>
   );
 }

--- a/frontend/src/app/u/[username]/UserListsEditMode.tsx
+++ b/frontend/src/app/u/[username]/UserListsEditMode.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect, useState, useCallback, useTransition } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { Plus, Trash2, Loader2, Search } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
-import VideoSearchModal from '@/components/lists/VideoSearchModal';
 
 export type ListItem = {
   id: string;
@@ -39,10 +39,7 @@ export default function UserListsClient({ ownerUserId, username, displayName, in
   const [newDesc, setNewDesc] = useState('');
   const [creating, setCreating] = useState(false);
 
-  // 動画追加モーダル
-  const [searchTarget, setSearchTarget] = useState<ListItem | null>(null);
-
-  const [, startTransition] = useTransition();
+  const router = useRouter();
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data: { user } }) => {
@@ -54,7 +51,7 @@ export default function UserListsClient({ ownerUserId, username, displayName, in
   const reloadLists = useCallback(async () => {
     const { data } = await supabase.rpc('get_user_public_lists', { p_username: username });
     if (data && !data.error) {
-      startTransition(() => setLists((data as { lists: ListItem[] }).lists ?? []));
+      setLists((data as { lists: ListItem[] }).lists ?? []);
     }
   }, [username]);
 
@@ -187,7 +184,10 @@ export default function UserListsClient({ ownerUserId, username, displayName, in
                 {isOwner && list.list_type === 'custom' && (
                   <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                     <button
-                      onClick={() => setSearchTarget(list)}
+                      onClick={() => {
+                        const exploreUrl = `/explore?add_to_list=${list.id}&list_title=${encodeURIComponent(list.title ?? 'リスト')}&return_url=${encodeURIComponent(`/u/${username}`)}`;
+                        router.push(exploreUrl);
+                      }}
                       className="flex items-center gap-1 px-2 py-1 rounded-lg bg-violet-600/90 backdrop-blur text-white text-[10px] font-bold hover:bg-violet-500 transition-colors shadow"
                     >
                       <Search size={10} />
@@ -205,15 +205,6 @@ export default function UserListsClient({ ownerUserId, username, displayName, in
             );
           })}
         </div>
-      )}
-
-      {/* 動画追加モーダル */}
-      {searchTarget && (
-        <VideoSearchModal
-          listId={searchTarget.id}
-          onClose={() => setSearchTarget(null)}
-          onAdded={reloadLists}
-        />
       )}
     </>
   );

--- a/frontend/src/app/u/[username]/UserListsEditMode.tsx
+++ b/frontend/src/app/u/[username]/UserListsEditMode.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useEffect, useState, useCallback, useTransition } from 'react';
+import Link from 'next/link';
+import { Plus, Trash2, Loader2, Search } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+import VideoSearchModal from '@/components/lists/VideoSearchModal';
+
+export type ListItem = {
+  id: string;
+  token: string;
+  title: string | null;
+  description: string | null;
+  list_type: 'liked' | 'custom';
+  created_at: string;
+  video_count: number;
+  thumbnails: string[] | null;
+};
+
+function toLgThumb(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return url.replace('ps.jpg', 'pl.jpg');
+}
+
+interface Props {
+  ownerUserId: string;
+  username: string;
+  displayName: string;
+  initialLists: ListItem[];
+}
+
+export default function UserListsClient({ ownerUserId, username, displayName, initialLists }: Props) {
+  const [isOwner, setIsOwner] = useState(false);
+  const [lists, setLists] = useState<ListItem[]>(initialLists);
+
+  // 新規リスト作成
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newDesc, setNewDesc] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  // 動画追加モーダル
+  const [searchTarget, setSearchTarget] = useState<ListItem | null>(null);
+
+  const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setIsOwner(!!user && user.id === ownerUserId);
+    });
+  }, [ownerUserId]);
+
+  // リスト一覧を再取得
+  const reloadLists = useCallback(async () => {
+    const { data } = await supabase.rpc('get_user_public_lists', { p_username: username });
+    if (data && !data.error) {
+      startTransition(() => setLists((data as { lists: ListItem[] }).lists ?? []));
+    }
+  }, [username]);
+
+  const handleCreate = useCallback(async () => {
+    if (!newTitle.trim()) return;
+    setCreating(true);
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+    const { error } = await supabase.from('public_lists').insert({
+      user_id: user.id,
+      title: newTitle.trim(),
+      description: newDesc.trim() || null,
+      list_type: 'custom',
+    });
+    if (error) { alert('作成に失敗しました: ' + error.message); }
+    setNewTitle('');
+    setNewDesc('');
+    setShowCreateForm(false);
+    setCreating(false);
+    await reloadLists();
+  }, [newTitle, newDesc, reloadLists]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    if (!confirm('このリストを削除しますか？')) return;
+    const { error } = await supabase.from('public_lists').delete().eq('id', id);
+    if (error) { alert('削除に失敗しました: ' + error.message); return; }
+    await reloadLists();
+  }, [reloadLists]);
+
+  return (
+    <>
+      {/* 編集モードバナー＋新規作成ボタン */}
+      {isOwner && (
+        <div className="mb-6 flex items-center justify-between gap-3 px-4 py-2.5 rounded-xl border border-violet-500/40 bg-violet-500/10">
+          <span className="text-xs text-violet-300 font-semibold">編集モード</span>
+          <button
+            onClick={() => setShowCreateForm(true)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors"
+          >
+            <Plus size={13} />
+            新しいリスト
+          </button>
+        </div>
+      )}
+
+      {/* 新規作成フォーム */}
+      {isOwner && showCreateForm && (
+        <div className="mb-6 p-4 rounded-xl border border-violet-500/40 bg-violet-500/10">
+          <p className="text-sm font-bold text-[#e6edf3] mb-3">新しいリストを作成</p>
+          <input
+            type="text"
+            value={newTitle}
+            onChange={(e) => setNewTitle(e.target.value)}
+            placeholder="リストのタイトル（例: NTR厳選リスト）"
+            className="w-full bg-[#0d1117] border border-[#30363d] rounded-lg px-3 py-2 text-sm text-[#e6edf3] placeholder-[#484f58] outline-none focus:border-violet-500/50 mb-2"
+          />
+          <textarea
+            value={newDesc}
+            onChange={(e) => setNewDesc(e.target.value)}
+            placeholder="説明（省略可）"
+            rows={2}
+            className="w-full bg-[#0d1117] border border-[#30363d] rounded-lg px-3 py-2 text-sm text-[#e6edf3] placeholder-[#484f58] outline-none focus:border-violet-500/50 resize-none mb-3"
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={handleCreate}
+              disabled={creating || !newTitle.trim()}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors disabled:opacity-50"
+            >
+              {creating ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+              作成
+            </button>
+            <button
+              onClick={() => setShowCreateForm(false)}
+              className="px-4 py-2 rounded-lg bg-white/5 text-[#8b949e] text-xs font-bold hover:bg-white/10 transition-colors"
+            >
+              キャンセル
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* リスト一覧 */}
+      {lists.length === 0 ? (
+        <p className="text-center text-[#656d76] py-20">
+          {isOwner ? 'まだリストがありません。「新しいリスト」から作成できます。' : 'まだ公開リストがありません。'}
+        </p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {lists.map((list) => {
+            const thumbs = (list.thumbnails ?? []).slice(0, 3).map(toLgThumb).filter(Boolean) as string[];
+            const label = list.list_type === 'liked' ? 'お気に入りリスト' : list.title ?? '無題のリスト';
+            return (
+              <div key={list.id} className="group relative">
+                <Link
+                  href={`/list/${list.token}`}
+                  className="block rounded-xl border border-[#21262d] hover:border-violet-500/50 bg-[#161b22] overflow-hidden transition-all hover:shadow-lg hover:shadow-violet-500/10"
+                >
+                  {/* サムネイル */}
+                  <div className="flex h-28 overflow-hidden">
+                    {thumbs.length > 0 ? (
+                      thumbs.map((url, i) => (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          key={i}
+                          src={url}
+                          alt=""
+                          className={`object-cover flex-1 min-w-0 ${i > 0 ? 'border-l border-[#0d1117]' : ''} group-hover:opacity-90 transition-opacity`}
+                          loading="lazy"
+                        />
+                      ))
+                    ) : (
+                      <div className="w-full h-full bg-[#21262d] flex items-center justify-center">
+                        <span className="text-[#484f58] text-xs">No Image</span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="p-3">
+                    <p className="text-sm font-bold text-[#e6edf3] group-hover:text-violet-400 transition-colors line-clamp-1">
+                      {label}
+                    </p>
+                    {list.description && (
+                      <p className="text-xs text-[#656d76] mt-0.5 line-clamp-2">{list.description}</p>
+                    )}
+                    <p className="text-xs text-[#484f58] mt-1.5">{list.video_count.toLocaleString('ja-JP')}作品</p>
+                  </div>
+                </Link>
+
+                {/* 編集ボタン（オーナーのみ、カード右上に重ねる） */}
+                {isOwner && list.list_type === 'custom' && (
+                  <div className="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button
+                      onClick={() => setSearchTarget(list)}
+                      className="flex items-center gap-1 px-2 py-1 rounded-lg bg-violet-600/90 backdrop-blur text-white text-[10px] font-bold hover:bg-violet-500 transition-colors shadow"
+                    >
+                      <Search size={10} />
+                      動画追加
+                    </button>
+                    <button
+                      onClick={() => handleDelete(list.id)}
+                      className="flex items-center justify-center w-6 h-6 rounded-lg bg-red-500/80 backdrop-blur hover:bg-red-500 text-white transition-colors shadow"
+                    >
+                      <Trash2 size={11} />
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* 動画追加モーダル */}
+      {searchTarget && (
+        <VideoSearchModal
+          listId={searchTarget.id}
+          onClose={() => setSearchTarget(null)}
+          onAdded={reloadLists}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/app/u/[username]/page.tsx
+++ b/frontend/src/app/u/[username]/page.tsx
@@ -2,29 +2,16 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { supabase } from '@/lib/supabase';
+import UserListsClient, { type ListItem } from './UserListsEditMode';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.seihekilab.com';
 
-type ListItem = {
-  id: string;
-  token: string;
-  title: string | null;
-  description: string | null;
-  list_type: 'liked' | 'custom';
-  created_at: string;
-  video_count: number;
-  thumbnails: string[] | null;
-};
-
 type UserListsData = {
+  user_id: string;
   display_name: string;
+  username: string;
   lists: ListItem[];
 };
-
-function toLgThumb(url: string | null | undefined): string | null {
-  if (!url) return null;
-  return url.replace('ps.jpg', 'pl.jpg');
-}
 
 async function fetchUserLists(username: string): Promise<UserListsData | null> {
   const { data, error } = await supabase.rpc('get_user_public_lists', {
@@ -55,49 +42,6 @@ export async function generateMetadata(
   };
 }
 
-function ListCard({ list }: { list: ListItem }) {
-  const thumbs = (list.thumbnails ?? []).slice(0, 3).map(toLgThumb).filter(Boolean) as string[];
-  const label = list.list_type === 'liked' ? 'お気に入りリスト' : list.title ?? '無題のリスト';
-
-  return (
-    <Link
-      href={`/list/${list.token}`}
-      className="group block rounded-xl border border-[#21262d] hover:border-violet-500/50 bg-[#161b22] overflow-hidden transition-all hover:shadow-lg hover:shadow-violet-500/10"
-    >
-      {/* サムネイルプレビュー */}
-      <div className="flex h-28 overflow-hidden">
-        {thumbs.length > 0 ? (
-          thumbs.map((url, i) => (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              key={i}
-              src={url}
-              alt=""
-              className={`object-cover flex-1 min-w-0 ${i > 0 ? 'border-l border-[#0d1117]' : ''} group-hover:opacity-90 transition-opacity`}
-              loading="lazy"
-            />
-          ))
-        ) : (
-          <div className="w-full h-full bg-[#21262d] flex items-center justify-center">
-            <span className="text-[#484f58] text-xs">No Image</span>
-          </div>
-        )}
-      </div>
-
-      {/* 情報 */}
-      <div className="p-3">
-        <p className="text-sm font-bold text-[#e6edf3] group-hover:text-violet-400 transition-colors line-clamp-1">
-          {label}
-        </p>
-        {list.description && (
-          <p className="text-xs text-[#656d76] mt-0.5 line-clamp-2">{list.description}</p>
-        )}
-        <p className="text-xs text-[#484f58] mt-1.5">{list.video_count.toLocaleString('ja-JP')}作品</p>
-      </div>
-    </Link>
-  );
-}
-
 export default async function UserListsPage(
   { params }: { params: Promise<{ username: string }> }
 ) {
@@ -122,16 +66,13 @@ export default async function UserListsPage(
           <p className="text-sm text-[#656d76]">{data.lists.length}件のリスト</p>
         </div>
 
-        {/* リスト一覧 */}
-        {data.lists.length === 0 ? (
-          <p className="text-center text-[#656d76] py-20">まだ公開リストがありません。</p>
-        ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {data.lists.map((list) => (
-              <ListCard key={list.id} list={list} />
-            ))}
-          </div>
-        )}
+        {/* リスト一覧（編集モード対応クライアントコンポーネント） */}
+        <UserListsClient
+          ownerUserId={data.user_id}
+          username={username}
+          displayName={data.display_name}
+          initialLists={data.lists}
+        />
 
         {/* フッター */}
         <div className="mt-12 pt-6 border-t border-[#21262d] text-center">

--- a/frontend/src/components/AccountManagementDrawer.tsx
+++ b/frontend/src/components/AccountManagementDrawer.tsx
@@ -15,6 +15,7 @@ type PerformerItem = { id: string; name: string; cnt: number };
 
 const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpen, onClose }) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [username, setUsername] = useState<string | null>(null);
   const [likeCount, setLikeCount] = useState<number | null>(null);
   const [totalCount, setTotalCount] = useState<number | null>(null);
   const [tags, setTags] = useState<TagItem[]>([]);
@@ -64,6 +65,7 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
       // 自分の公開トークンを取得（user_id フィルタ必須）
       supabase.auth.getUser().then(({ data: { user } }) => {
         if (!user) return;
+        setUsername((user.user_metadata?.username as string) ?? null);
         supabase.from('public_lists').select('token')
           .eq('user_id', user.id).eq('is_active', true).eq('list_type', 'liked').maybeSingle()
           .then(({ data }) => { if (data) setPublicToken(data.token); });
@@ -100,7 +102,7 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
 
   const handleDeletePublicList = async () => {
     if (!publicToken) return;
-    await supabase.from('public_lists').update({ is_active: false }).eq('token', publicToken);
+    await supabase.from('public_lists').delete().eq('token', publicToken);
     setPublicToken(null);
   };
 
@@ -220,71 +222,68 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
                         </>
                       )}
 
-                      {/* 公開リスト */}
-                      {isLoggedIn && (
-                        <>
-                          <div className="border-t border-white/10" />
-                          <section className="space-y-3">
-                            <p className="text-[11px] text-[#8b949e] font-semibold uppercase tracking-wider">公開リスト</p>
-                            <p className="text-xs text-[#656d76]">いいねリストを URL で公開・シェアできます。</p>
-                            {publicToken ? (
-                              <div className="space-y-2">
-                                <div className="flex items-center gap-2 p-2.5 rounded-lg bg-[#161b22] border border-[#30363d] text-xs text-[#8b949e] truncate">
-                                  <Link2 size={12} className="shrink-0" />
-                                  <span className="truncate">{typeof window !== 'undefined' ? window.location.host : 'seihekilab.com'}/list/{publicToken}</span>
-                                </div>
-                                <div className="flex gap-2">
-                                  <button
-                                    onClick={handleCopyLink}
-                                    className="flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors"
-                                  >
-                                    {copied ? <><Check size={12} />コピー済み</> : <><Link2 size={12} />リンクをコピー</>}
-                                  </button>
-                                  <button
-                                    onClick={handleDeletePublicList}
-                                    className="px-3 py-2 rounded-lg bg-red-500/20 text-red-400 border border-red-500/30 text-xs font-bold hover:bg-red-500/30 transition-colors"
-                                  >
-                                    削除
-                                  </button>
-                                </div>
-                                <a
-                                  href={`/list/${publicToken}`}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="w-full flex items-center justify-center gap-1.5 py-2 rounded-lg bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-[#e6edf3] text-xs font-bold transition-all"
-                                >
-                                  <ExternalLink size={12} />
-                                  自分のリストを確認
-                                </a>
-                              </div>
-                            ) : (
-                              <button
-                                onClick={handleCreatePublicList}
-                                disabled={tokenLoading}
-                                className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-[#e6edf3] text-sm font-bold transition-all disabled:opacity-50"
-                              >
-                                {tokenLoading
-                                  ? <><Loader2 size={14} className="animate-spin" />作成中…</>
-                                  : <><Link2 size={14} />公開リンクを作成</>}
-                              </button>
-                            )}
-                          </section>
-                        </>
-                      )}
-
                       {/* マイリスト */}
                       {isLoggedIn && (
                         <>
                           <div className="border-t border-white/10" />
-                          <section className="space-y-2">
-                            <p className="text-[11px] text-[#8b949e] font-semibold uppercase tracking-wider mb-3">マイリスト</p>
-                            <a
-                              href="/my/lists"
-                              className="w-full flex items-center gap-2 py-2.5 px-4 rounded-xl bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-[#e6edf3] text-sm font-bold transition-all"
-                            >
-                              <ListVideo size={14} />
-                              リストを管理する
-                            </a>
+                          <section className="space-y-3">
+                            <p className="text-[11px] text-[#8b949e] font-semibold uppercase tracking-wider">マイリスト</p>
+
+                            {/* マイページへ */}
+                            {username ? (
+                              <a
+                                href={`/u/${username}`}
+                                className="w-full flex items-center gap-2 py-2.5 px-4 rounded-xl bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-[#e6edf3] text-sm font-bold transition-all"
+                              >
+                                <ListVideo size={14} />
+                                マイページを開く
+                              </a>
+                            ) : (
+                              <a
+                                href="/my/lists"
+                                className="w-full flex items-center gap-2 py-2.5 px-4 rounded-xl bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-[#e6edf3] text-sm font-bold transition-all"
+                              >
+                                <ListVideo size={14} />
+                                マイリストを開く
+                              </a>
+                            )}
+
+                            {/* いいねリストのURL共有（サブ機能） */}
+                            <div>
+                              <p className="text-[10px] text-[#484f58] mb-2">いいねリストを URL で共有</p>
+                              {publicToken ? (
+                                <div className="space-y-1.5">
+                                  <div className="flex items-center gap-2 p-2 rounded-lg bg-[#161b22] border border-[#30363d] text-xs text-[#8b949e] truncate">
+                                    <Link2 size={11} className="shrink-0" />
+                                    <span className="truncate">{typeof window !== 'undefined' ? window.location.host : 'seihekilab.com'}/list/{publicToken}</span>
+                                  </div>
+                                  <div className="flex gap-2">
+                                    <button
+                                      onClick={handleCopyLink}
+                                      className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 text-white text-xs font-bold transition-colors"
+                                    >
+                                      {copied ? <><Check size={11} />コピー済み</> : <><Link2 size={11} />URLをコピー</>}
+                                    </button>
+                                    <button
+                                      onClick={handleDeletePublicList}
+                                      className="px-3 py-1.5 rounded-lg bg-red-500/20 text-red-400 border border-red-500/30 text-xs font-bold hover:bg-red-500/30 transition-colors"
+                                    >
+                                      削除
+                                    </button>
+                                  </div>
+                                </div>
+                              ) : (
+                                <button
+                                  onClick={handleCreatePublicList}
+                                  disabled={tokenLoading}
+                                  className="w-full flex items-center justify-center gap-2 py-2 rounded-lg bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-[#e6edf3] text-xs font-bold transition-all disabled:opacity-50"
+                                >
+                                  {tokenLoading
+                                    ? <><Loader2 size={12} className="animate-spin" />作成中…</>
+                                    : <><Link2 size={12} />共有URLを作成</>}
+                                </button>
+                              )}
+                            </div>
                           </section>
                         </>
                       )}

--- a/frontend/src/components/BrowseTabBar.tsx
+++ b/frontend/src/components/BrowseTabBar.tsx
@@ -153,6 +153,7 @@ function BrowseTabBarInner() {
   const [isAccountOpen, setIsAccountOpen] = useState(false);
   const [likeCount, setLikeCount] = useState<number | null>(null);
   const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
+  const [myPageUrl, setMyPageUrl] = useState('/my/lists');
   const [particles, setParticles] = useState<number[]>([]);
   const [levelUpLevel, setLevelUpLevel] = useState<Level | null>(null);
   const prevLevelRef = useRef<Level | null>(null);
@@ -169,6 +170,8 @@ function BrowseTabBarInner() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) { setLikeCount(0); setIsLoggedIn(false); return; }
       setIsLoggedIn(true);
+      const uname = user.user_metadata?.username as string | undefined;
+      if (uname) setMyPageUrl(`/u/${uname}`);
       const { count } = await supabase
         .from('user_video_decisions')
         .select('*', { count: 'exact', head: true })
@@ -234,7 +237,7 @@ function BrowseTabBarInner() {
               <Link href="/explore" className={`flex items-center gap-1 px-2 py-1 rounded-md transition-colors text-[11px] font-bold whitespace-nowrap ${isGrid ? 'text-violet-400' : 'text-[#8b949e] hover:text-[#e6edf3]'}`}>
                 <LayoutGrid size={13} /><span>さがす</span>
               </Link>
-              <Link href="/my/lists" className={`flex items-center gap-1 px-2 py-1 rounded-md transition-colors text-[11px] font-bold whitespace-nowrap ${isMyLists ? 'text-violet-400' : 'text-[#8b949e] hover:text-[#e6edf3]'}`}>
+              <Link href={myPageUrl} className={`flex items-center gap-1 px-2 py-1 rounded-md transition-colors text-[11px] font-bold whitespace-nowrap ${isMyLists ? 'text-violet-400' : 'text-[#8b949e] hover:text-[#e6edf3]'}`}>
                 <ListVideo size={13} /><span>リスト</span>
               </Link>
             </div>
@@ -284,7 +287,7 @@ function BrowseTabBarInner() {
             <LayoutGrid size={15} />
             <span className="text-[9px] font-bold whitespace-nowrap">さがす</span>
           </Link>
-          <Link href="/my/lists" className={`flex flex-col items-center gap-0.5 px-3 py-0.5 rounded-md transition-colors ${isMyLists ? 'text-violet-400' : 'text-[#8b949e]'}`}>
+          <Link href={myPageUrl} className={`flex flex-col items-center gap-0.5 px-3 py-0.5 rounded-md transition-colors ${isMyLists ? 'text-violet-400' : 'text-[#8b949e]'}`}>
             <ListVideo size={15} />
             <span className="text-[9px] font-bold whitespace-nowrap">リスト</span>
           </Link>

--- a/supabase/migrations/20260611100000_update_get_user_public_lists_add_user_id.sql
+++ b/supabase/migrations/20260611100000_update_get_user_public_lists_add_user_id.sql
@@ -1,0 +1,73 @@
+-- get_user_public_lists に user_id を追加（クライアント側のオーナー判定用）
+CREATE OR REPLACE FUNCTION get_user_public_lists(p_username text)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id      uuid;
+  v_display_name text;
+  v_lists        json;
+BEGIN
+  SELECT id, COALESCE(raw_user_meta_data->>'display_name', '')
+  INTO v_user_id, v_display_name
+  FROM auth.users
+  WHERE raw_user_meta_data->>'username' = p_username
+  LIMIT 1;
+
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('error', 'not_found');
+  END IF;
+
+  SELECT json_agg(row_to_json(l)) INTO v_lists
+  FROM (
+    SELECT
+      pl.id,
+      pl.token,
+      pl.title,
+      pl.description,
+      pl.list_type,
+      pl.created_at,
+      CASE
+        WHEN pl.list_type = 'custom' THEN
+          (SELECT COUNT(*) FROM public.public_list_videos WHERE list_id = pl.id)
+        ELSE
+          (SELECT COUNT(*) FROM public.user_video_decisions
+           WHERE user_id = v_user_id
+             AND decision_type IN ('swipe_like', 'grid_like'))
+      END AS video_count,
+      CASE
+        WHEN pl.list_type = 'custom' THEN
+          (SELECT json_agg(thumbnail_url)
+           FROM (
+             SELECT vi.thumbnail_url
+             FROM public.public_list_videos plv
+             JOIN public.videos vi ON vi.id = plv.video_id
+             WHERE plv.list_id = pl.id AND vi.thumbnail_url IS NOT NULL
+             ORDER BY plv.sort_order, plv.added_at LIMIT 3
+           ) t)
+        ELSE
+          (SELECT json_agg(thumbnail_url)
+           FROM (
+             SELECT vi.thumbnail_url
+             FROM public.user_video_decisions uvd
+             JOIN public.videos vi ON vi.id = uvd.video_id
+             WHERE uvd.user_id = v_user_id
+               AND uvd.decision_type IN ('swipe_like', 'grid_like')
+               AND vi.thumbnail_url IS NOT NULL
+             ORDER BY uvd.created_at DESC LIMIT 3
+           ) t)
+      END AS thumbnails
+    FROM public.public_lists pl
+    WHERE pl.user_id = v_user_id AND pl.is_active = true
+    ORDER BY pl.created_at DESC
+  ) l;
+
+  RETURN json_build_object(
+    'user_id',      v_user_id,
+    'display_name', v_display_name,
+    'username',     p_username,
+    'lists',        COALESCE(v_lists, '[]'::json)
+  );
+END;
+$$;

--- a/supabase/migrations/20260611110000_update_get_public_list_data_add_owner_fields.sql
+++ b/supabase/migrations/20260611110000_update_get_public_list_data_add_owner_fields.sql
@@ -1,0 +1,110 @@
+-- get_public_list_data に list_id / user_id を追加（クライアント側の編集モード判定用）
+CREATE OR REPLACE FUNCTION public.get_public_list_data(p_token text)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_list_id      uuid;
+  v_user_id      uuid;
+  v_title        text;
+  v_desc         text;
+  v_list_type    text;
+  v_display_name text;
+  v_videos       json;
+  v_tags         json;
+  v_performers   json;
+BEGIN
+  SELECT id, user_id, title, description, list_type
+  INTO v_list_id, v_user_id, v_title, v_desc, v_list_type
+  FROM public.public_lists
+  WHERE token = p_token AND is_active = true;
+
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('error', 'not_found');
+  END IF;
+
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(v)) INTO v_videos
+    FROM (
+      SELECT vi.id, vi.title, vi.external_id, vi.thumbnail_url,
+             vi.thumbnail_vertical_url, vi.product_url, plv.added_at AS liked_at
+      FROM public.public_list_videos plv
+      JOIN public.videos vi ON vi.id = plv.video_id
+      WHERE plv.list_id = v_list_id AND vi.external_id IS NOT NULL
+      ORDER BY plv.sort_order, plv.added_at DESC LIMIT 200
+    ) v;
+  ELSE
+    SELECT json_agg(row_to_json(v)) INTO v_videos
+    FROM (
+      SELECT vi.id, vi.title, vi.external_id, vi.thumbnail_url,
+             vi.thumbnail_vertical_url, vi.product_url, uvd.created_at AS liked_at
+      FROM public.user_video_decisions uvd
+      JOIN public.videos vi ON vi.id = uvd.video_id
+      WHERE uvd.user_id = v_user_id
+        AND uvd.decision_type IN ('swipe_like', 'grid_like')
+        AND vi.external_id IS NOT NULL
+      ORDER BY uvd.created_at DESC
+    ) v;
+  END IF;
+
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(t)) INTO v_tags
+    FROM (
+      SELECT tg.name AS tag_name, COUNT(*) AS cnt
+      FROM public.public_list_videos plv
+      JOIN public.video_tags vt ON vt.video_id = plv.video_id
+      JOIN public.tags tg ON tg.id = vt.tag_id
+      WHERE plv.list_id = v_list_id
+      GROUP BY tg.name ORDER BY cnt DESC LIMIT 12
+    ) t;
+  ELSE
+    SELECT json_agg(row_to_json(t)) INTO v_tags
+    FROM (
+      SELECT tg.name AS tag_name, COUNT(*) AS cnt
+      FROM public.user_video_decisions uvd
+      JOIN public.video_tags vt ON vt.video_id = uvd.video_id
+      JOIN public.tags tg ON tg.id = vt.tag_id
+      WHERE uvd.user_id = v_user_id AND uvd.decision_type IN ('swipe_like', 'grid_like')
+      GROUP BY tg.name ORDER BY cnt DESC LIMIT 12
+    ) t;
+  END IF;
+
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(p)) INTO v_performers
+    FROM (
+      SELECT pf.name AS performer_name, COUNT(*) AS cnt
+      FROM public.public_list_videos plv
+      JOIN public.video_performers vp ON vp.video_id = plv.video_id
+      JOIN public.performers pf ON pf.id = vp.performer_id
+      WHERE plv.list_id = v_list_id
+      GROUP BY pf.name ORDER BY cnt DESC LIMIT 10
+    ) p;
+  ELSE
+    SELECT json_agg(row_to_json(p)) INTO v_performers
+    FROM (
+      SELECT pf.name AS performer_name, COUNT(*) AS cnt
+      FROM public.user_video_decisions uvd
+      JOIN public.video_performers vp ON vp.video_id = uvd.video_id
+      JOIN public.performers pf ON pf.id = vp.performer_id
+      WHERE uvd.user_id = v_user_id AND uvd.decision_type IN ('swipe_like', 'grid_like')
+      GROUP BY pf.name ORDER BY cnt DESC LIMIT 10
+    ) p;
+  END IF;
+
+  SELECT display_name INTO v_display_name
+  FROM public.profiles WHERE user_id = v_user_id;
+
+  RETURN json_build_object(
+    'list_id',      v_list_id,
+    'user_id',      v_user_id,
+    'display_name', v_display_name,
+    'title',        v_title,
+    'description',  v_desc,
+    'list_type',    v_list_type,
+    'videos',       COALESCE(v_videos,     '[]'::json),
+    'tags',         COALESCE(v_tags,       '[]'::json),
+    'performers',   COALESCE(v_performers, '[]'::json)
+  );
+END;
+$$;

--- a/supabase/migrations/20260611120000_update_get_public_list_data_add_username.sql
+++ b/supabase/migrations/20260611120000_update_get_public_list_data_add_username.sql
@@ -1,0 +1,115 @@
+-- get_public_list_data に username を追加（リストページで作者リンクを表示するため）
+CREATE OR REPLACE FUNCTION public.get_public_list_data(p_token text)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_list_id      uuid;
+  v_user_id      uuid;
+  v_title        text;
+  v_desc         text;
+  v_list_type    text;
+  v_display_name text;
+  v_username     text;
+  v_videos       json;
+  v_tags         json;
+  v_performers   json;
+BEGIN
+  SELECT id, user_id, title, description, list_type
+  INTO v_list_id, v_user_id, v_title, v_desc, v_list_type
+  FROM public.public_lists
+  WHERE token = p_token AND is_active = true;
+
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('error', 'not_found');
+  END IF;
+
+  SELECT
+    COALESCE(raw_user_meta_data->>'display_name', ''),
+    raw_user_meta_data->>'username'
+  INTO v_display_name, v_username
+  FROM auth.users WHERE id = v_user_id;
+
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(v)) INTO v_videos
+    FROM (
+      SELECT vi.id, vi.title, vi.external_id, vi.thumbnail_url,
+             vi.thumbnail_vertical_url, vi.product_url, plv.added_at AS liked_at
+      FROM public.public_list_videos plv
+      JOIN public.videos vi ON vi.id = plv.video_id
+      WHERE plv.list_id = v_list_id AND vi.external_id IS NOT NULL
+      ORDER BY plv.sort_order, plv.added_at DESC LIMIT 200
+    ) v;
+  ELSE
+    SELECT json_agg(row_to_json(v)) INTO v_videos
+    FROM (
+      SELECT vi.id, vi.title, vi.external_id, vi.thumbnail_url,
+             vi.thumbnail_vertical_url, vi.product_url, uvd.created_at AS liked_at
+      FROM public.user_video_decisions uvd
+      JOIN public.videos vi ON vi.id = uvd.video_id
+      WHERE uvd.user_id = v_user_id
+        AND uvd.decision_type IN ('swipe_like', 'grid_like')
+        AND vi.external_id IS NOT NULL
+      ORDER BY uvd.created_at DESC
+    ) v;
+  END IF;
+
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(t)) INTO v_tags
+    FROM (
+      SELECT tg.name AS tag_name, COUNT(*) AS cnt
+      FROM public.public_list_videos plv
+      JOIN public.video_tags vt ON vt.video_id = plv.video_id
+      JOIN public.tags tg ON tg.id = vt.tag_id
+      WHERE plv.list_id = v_list_id
+      GROUP BY tg.name ORDER BY cnt DESC LIMIT 12
+    ) t;
+  ELSE
+    SELECT json_agg(row_to_json(t)) INTO v_tags
+    FROM (
+      SELECT tg.name AS tag_name, COUNT(*) AS cnt
+      FROM public.user_video_decisions uvd
+      JOIN public.video_tags vt ON vt.video_id = uvd.video_id
+      JOIN public.tags tg ON tg.id = vt.tag_id
+      WHERE uvd.user_id = v_user_id AND uvd.decision_type IN ('swipe_like', 'grid_like')
+      GROUP BY tg.name ORDER BY cnt DESC LIMIT 12
+    ) t;
+  END IF;
+
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(p)) INTO v_performers
+    FROM (
+      SELECT pf.name AS performer_name, COUNT(*) AS cnt
+      FROM public.public_list_videos plv
+      JOIN public.video_performers vp ON vp.video_id = plv.video_id
+      JOIN public.performers pf ON pf.id = vp.performer_id
+      WHERE plv.list_id = v_list_id
+      GROUP BY pf.name ORDER BY cnt DESC LIMIT 10
+    ) p;
+  ELSE
+    SELECT json_agg(row_to_json(p)) INTO v_performers
+    FROM (
+      SELECT pf.name AS performer_name, COUNT(*) AS cnt
+      FROM public.user_video_decisions uvd
+      JOIN public.video_performers vp ON vp.video_id = uvd.video_id
+      JOIN public.performers pf ON pf.id = vp.performer_id
+      WHERE uvd.user_id = v_user_id AND uvd.decision_type IN ('swipe_like', 'grid_like')
+      GROUP BY pf.name ORDER BY cnt DESC LIMIT 10
+    ) p;
+  END IF;
+
+  RETURN json_build_object(
+    'list_id',      v_list_id,
+    'user_id',      v_user_id,
+    'display_name', v_display_name,
+    'username',     v_username,
+    'title',        v_title,
+    'description',  v_desc,
+    'list_type',    v_list_type,
+    'videos',       COALESCE(v_videos,     '[]'::json),
+    'tags',         COALESCE(v_tags,       '[]'::json),
+    'performers',   COALESCE(v_performers, '[]'::json)
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary

- **`/u/[username]`** — ログインユーザーが自分のページを開くと編集モードバナーが表示
  - リスト新規作成・削除（カスタムのみ）・動画追加をその場で操作可能
  - カードホバーで「動画追加」「削除」ボタンをオーバーレイ表示
- **`/list/[token]`** — カスタムリストのオーナーは動画追加・個別削除が可能
  - 動画カードホバーでゴミ箱ボタンが出現、削除後 `router.refresh()` で即反映
- **`/my/lists`** — `/u/[username]` へのリダイレクトページに変更（廃止）
- **RPC 更新** — `get_user_public_lists` / `get_public_list_data` に `user_id`・`list_id` を追加（オーナー判定用）

## Test plan

- [ ] `/u/自分のusername` を開き、編集モードバナーが表示されることを確認
- [ ] 新しいリストを作成・削除できることを確認
- [ ] カスタムリストカードにホバーして「動画追加」ボタンが表示されることを確認
- [ ] `/list/[token]` で自分のカスタムリストを開き、動画追加・個別削除が動作することを確認
- [ ] 他人のページ・リストでは編集ボタンが表示されないことを確認
- [ ] `/my/lists` にアクセスすると `/u/[username]` にリダイレクトされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)