### PR TITLE
fix: migration 20260518200000 の get_videos_recommendations シグネチャ競合を修正

### DIFF
--- a/supabase/migrations/20260518200000_decision_type_surface.sql
+++ b/supabase/migrations/20260518200000_decision_type_surface.sql
@@ -28,6 +28,8 @@ group by uvd.video_id, date_trunc('day', uvd.created_at at time zone 'UTC');
 create unique index mv_pop_daily_uidx on public.video_popularity_daily (video_id, d);
 
 -- 4. get_videos_recommendations
+-- シグネチャ変更（source, image_urls 追加）のため事前に DROP
+drop function if exists public.get_videos_recommendations(uuid, int);
 create or replace function public.get_videos_recommendations(user_uuid uuid, page_limit int default 20)
 returns table (
   id uuid, title text, description text, external_id text,


### PR DESCRIPTION
## 概要

CI の `supabase db push` が `20260518200000_decision_type_surface.sql` でエラーになる問題を修正。

## 原因

`get_videos_recommendations` の戻り値に `source`, `image_urls` カラムを追加したが、`20260518200000` 内の古い定義がリモートの新シグネチャと競合していた。

## 変更内容

`20260518200000_decision_type_surface.sql` の `create or replace function` 前に `drop function if exists` を追加し、シグネチャ変更を安全に適用できるよう修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)