### PR TITLE
fix: 20260518200000 の get_user_likes に DROP FUNCTION を追加（CI デプロイ修正）

### DIFF
--- a/supabase/migrations/20260518200000_decision_type_surface.sql
+++ b/supabase/migrations/20260518200000_decision_type_surface.sql
@@ -119,6 +119,7 @@ $$;
 grant execute on function public.get_videos_recommendations(uuid, int) to anon, authenticated;
 
 -- 5. get_user_likes
+drop function if exists public.get_user_likes(text, text, text, int, int, uuid[], uuid[], numeric, numeric, timestamptz, timestamptz);
 create or replace function public.get_user_likes(
   p_search text default null,
   p_sort text default 'liked_at',


### PR DESCRIPTION
## 問題

`20260518200000_decision_type_surface.sql` が `CREATE OR REPLACE FUNCTION get_user_likes` を実行しようとするが、リモート DB には既に新しい return type（`source`, `image_urls` 付き）の関数が存在するため CI が失敗していた。

## 修正

`CREATE OR REPLACE` の前に `DROP FUNCTION IF EXISTS` を追加。これにより：
1. `20260518200000` → DROP して旧 signature で CREATE
2. `20260611120658` → DROP して新 signature（source/image_urls 付き）で CREATE

🤖 Generated with [Claude Code](https://claude.com/claude-code)