### PR TITLE
fix: get_videos_feed/get_popular_videos に DROP FUNCTION を追加（CI デプロイ修正）

### DIFF
--- a/supabase/migrations/20260611130000_fix_videos_feed_allow_amateur.sql
+++ b/supabase/migrations/20260611130000_fix_videos_feed_allow_amateur.sql
@@ -1,6 +1,7 @@
 -- get_videos_feed: FANZA_AMATEUR は出演者情報がないため、
 -- EXISTS (video_performers) 条件を FANZA_AMATEUR に限り免除する
 
+DROP FUNCTION IF EXISTS public.get_videos_feed(int);
 CREATE OR REPLACE FUNCTION public.get_videos_feed(page_limit int DEFAULT 20)
 RETURNS TABLE(
   id uuid,

--- a/supabase/migrations/20260611150000_add_has_performer_and_fix_feed.sql
+++ b/supabase/migrations/20260611150000_add_has_performer_and_fix_feed.sql
@@ -8,6 +8,7 @@ CREATE INDEX IF NOT EXISTS videos_feed_eligible_idx
     AND source NOT IN ('FANZA_ANIME')
     AND (has_performer = true OR source = 'FANZA_AMATEUR');
 
+DROP FUNCTION IF EXISTS public.get_videos_feed(int);
 CREATE OR REPLACE FUNCTION public.get_videos_feed(page_limit int DEFAULT 20)
 RETURNS TABLE(
   id uuid, title text, description text, external_id text,

--- a/supabase/migrations/20260611160000_fix_popular_and_tag_videos.sql
+++ b/supabase/migrations/20260611160000_fix_popular_and_tag_videos.sql
@@ -1,4 +1,5 @@
 -- get_popular_videos, get_videos_by_tags: has_performer で高速化
+DROP FUNCTION IF EXISTS public.get_popular_videos(uuid, int, int);
 CREATE OR REPLACE FUNCTION public.get_popular_videos(
   limit_count int DEFAULT 20,
   lookback_days int DEFAULT 7,


### PR DESCRIPTION
## 問題

`20260611130000`・`20260611150000`（get_videos_feed）、`20260611160000`（get_popular_videos）が `CREATE OR REPLACE` を試みるが、リモート DB には既に新 return type（source/image_urls 付き）が存在するため CI が失敗する。

## 修正

各 migration の `CREATE OR REPLACE` 前に `DROP FUNCTION IF EXISTS` を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)