### PR TITLE
fix: get_popular_videos の DROP FUNCTION シグネチャ順序を修正

### DIFF
--- a/supabase/migrations/20260611160000_fix_popular_and_tag_videos.sql
+++ b/supabase/migrations/20260611160000_fix_popular_and_tag_videos.sql
@@ -1,5 +1,5 @@
 -- get_popular_videos, get_videos_by_tags: has_performer で高速化
-DROP FUNCTION IF EXISTS public.get_popular_videos(uuid, int, int);
+DROP FUNCTION IF EXISTS public.get_popular_videos(int, int, uuid);
 CREATE OR REPLACE FUNCTION public.get_popular_videos(
   limit_count int DEFAULT 20,
   lookback_days int DEFAULT 7,


### PR DESCRIPTION
## 問題
`20260611160000` の `DROP FUNCTION IF EXISTS public.get_popular_videos(uuid, int, int)` で引数の順序が誤っており、DROP が効かず CI が失敗していた。

## 修正
正しい順序 `(int, int, uuid)` に修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)