### PR TITLE
fix: get_videos_by_tags に DROP FUNCTION を追加（CI デプロイ修正）

### DIFF
--- a/supabase/migrations/20260611160000_fix_popular_and_tag_videos.sql
+++ b/supabase/migrations/20260611160000_fix_popular_and_tag_videos.sql
@@ -67,6 +67,7 @@ BEGIN
 END;
 $$;
 
+DROP FUNCTION IF EXISTS public.get_videos_by_tags(uuid[], uuid[], int);
 CREATE OR REPLACE FUNCTION public.get_videos_by_tags(
   tag_ids uuid[],
   exclude_ids uuid[] DEFAULT '{}',


### PR DESCRIPTION
## 問題
`20260611160000` の `get_videos_by_tags` が `CREATE OR REPLACE` で return type 変更エラーになっていた。

## 修正
`DROP FUNCTION IF EXISTS public.get_videos_by_tags(uuid[], uuid[], int)` を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)