### PR TITLE
fix: サイトマップビルドタイムアウト修正・thumbFallback 未使用変数削除

### DIFF
--- a/frontend/src/app/sitemap.ts
+++ b/frontend/src/app/sitemap.ts
@@ -3,6 +3,8 @@ import { supabaseAdmin } from '@/lib/supabaseAdmin';
 
 // 24時間ごとに再生成
 export const revalidate = 86400;
+// ビルド時の静的生成をスキップ（DBアクセスによるタイムアウト防止）
+export const dynamic = 'force-dynamic';
 
 const SITE_URL = 'https://www.seihekilab.com';
 const PAGE_SIZE = 1000;

--- a/frontend/src/components/MobileVideoLayout.tsx
+++ b/frontend/src/components/MobileVideoLayout.tsx
@@ -16,7 +16,7 @@ interface MobileVideoLayoutProps {
 }
 
 const MobileVideoLayout: React.FC<MobileVideoLayoutProps> = ({ cardData, onSkip, onLike, onSamplePlay, skipButtonRef, likeButtonRef, likedListButtonRef }) => {
-  const { primary: thumbPrimary, fallback: thumbFallback } = resolveThumbnail({
+  const { primary: thumbPrimary } = resolveThumbnail({
     source: cardData.source,
     thumbnail_url: cardData.thumbnail_url,
     image_urls: cardData.image_urls,


### PR DESCRIPTION
## 問題
1. CI ビルド時にサイトマップ `/sitemap/1.xml` が全動画をDBから取得しようとして60秒タイムアウト
2. `MobileVideoLayout.tsx` の `thumbFallback` が未使用変数として ESLint 警告

## 修正
1. `sitemap.ts` に `export const dynamic = 'force-dynamic'` を追加し、ビルド時の静的生成をスキップ（`revalidate = 86400` による ISR は維持）
2. `thumbFallback` を destructuring から削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)