### PR TITLE
fix: RPC に source/image_urls 追加・VideoListDrawer レイアウト修正

### DIFF
--- a/frontend/src/components/VideoListDrawer.tsx
+++ b/frontend/src/components/VideoListDrawer.tsx
@@ -437,7 +437,7 @@ export default function VideoListDrawer({
                       ))}
                     </div>
                   ) : (
-                    <div className="p-4 overflow-y-auto rounded-3xl grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div className="p-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
                       {videos.map((video) => (
                         <article
                           key={video.external_id}

--- a/supabase/migrations/20260611150000_add_has_performer_and_fix_feed.sql
+++ b/supabase/migrations/20260611150000_add_has_performer_and_fix_feed.sql
@@ -15,7 +15,8 @@ RETURNS TABLE(
   thumbnail_url text, thumbnail_vertical_url text,
   sample_video_url text, preview_video_url text,
   product_url text, product_released_at timestamptz,
-  performers jsonb, tags jsonb
+  performers jsonb, tags jsonb,
+  source text, image_urls text[]
 )
 LANGUAGE plpgsql SECURITY DEFINER AS $$
 BEGIN
@@ -36,7 +37,9 @@ BEGIN
       FROM public.video_tags vt JOIN public.tags t ON t.id = vt.tag_id
       LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
       WHERE vt.video_id = v.id AND coalesce(tg.show_in_ui, true)
-    ), '[]'::jsonb)
+    ), '[]'::jsonb),
+    v.source,
+    v.image_urls
   FROM public.videos v TABLESAMPLE SYSTEM(5)
   WHERE v.sample_video_url IS NOT NULL
     AND v.source NOT IN ('FANZA_ANIME')

--- a/supabase/migrations/20260611160000_fix_popular_and_tag_videos.sql
+++ b/supabase/migrations/20260611160000_fix_popular_and_tag_videos.sql
@@ -9,7 +9,8 @@ RETURNS TABLE(
   id uuid, title text, description text, external_id text,
   thumbnail_url text, thumbnail_vertical_url text,
   sample_video_url text, product_url text, product_released_at timestamptz,
-  performers jsonb, tags jsonb, score double precision
+  performers jsonb, tags jsonb, score double precision,
+  source text, image_urls text[]
 )
 LANGUAGE plpgsql SECURITY DEFINER AS $$
 BEGIN
@@ -59,7 +60,9 @@ BEGIN
       LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
       WHERE vt.video_id = v.id AND coalesce(tg.show_in_ui, true)
     ), '[]'::jsonb),
-    (r.like_score + r.rank_score) AS score
+    (r.like_score + r.rank_score) AS score,
+    v.source,
+    v.image_urls
   FROM ranked r
   JOIN public.videos v ON v.id = r.id
   ORDER BY score DESC
@@ -77,7 +80,8 @@ RETURNS TABLE(
   id uuid, title text, external_id text,
   thumbnail_url text, thumbnail_vertical_url text,
   sample_video_url text, product_url text, product_released_at timestamptz,
-  performers jsonb, tags jsonb
+  performers jsonb, tags jsonb,
+  source text, image_urls text[]
 )
 LANGUAGE plpgsql SECURITY DEFINER AS $$
 BEGIN
@@ -95,7 +99,9 @@ BEGIN
       FROM public.video_tags vt JOIN public.tags t ON t.id = vt.tag_id
       LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
       WHERE vt.video_id = v.id AND coalesce(tg.show_in_ui, true)
-    ), '[]'::jsonb)
+    ), '[]'::jsonb),
+    v.source,
+    v.image_urls
   FROM public.videos v
   WHERE v.sample_video_url IS NOT NULL
     AND v.source NOT IN ('FANZA_ANIME')

--- a/supabase/migrations/20260611170000_fix_explore_videos.sql
+++ b/supabase/migrations/20260611170000_fix_explore_videos.sql
@@ -33,7 +33,8 @@ BEGIN
       FROM (
         SELECT vi.id, vi.title, vi.external_id,
           vi.thumbnail_url, vi.thumbnail_vertical_url,
-          vi.product_url, vi.distribution_code, vi.product_released_at
+          vi.product_url, vi.distribution_code, vi.product_released_at,
+          vi.source, vi.image_urls
         FROM public.videos vi
         WHERE vi.external_id IS NOT NULL
           AND vi.sample_video_url IS NOT NULL
@@ -51,7 +52,8 @@ BEGIN
       FROM (
         SELECT vi.id, vi.title, vi.external_id,
           vi.thumbnail_url, vi.thumbnail_vertical_url,
-          vi.product_url, vi.distribution_code, vi.product_released_at
+          vi.product_url, vi.distribution_code, vi.product_released_at,
+          vi.source, vi.image_urls
         FROM public.video_tags vt
         JOIN public.videos vi ON vi.id = vt.video_id
         LEFT JOIN public.fanza_rankings fr ON fr.video_id = vi.id


### PR DESCRIPTION
## 問題

1. **いいねリスト画像バグ**: VideoListDrawer の grid に `overflow-y-auto` が重複し画像が潰れていた
2. **探す画面・おすすめ画面の素人サムネイル**: `get_videos_feed`/`get_popular_videos`/`get_videos_by_tags`/`explore_videos` が `source`/`image_urls` を返していなかったため、`resolveThumbnail` が FANZA_AMATEUR と判定できず低画質のまま

## 修正

- `20260611150000`: `get_videos_feed` に `source text, image_urls text[]` を追加
- `20260611160000`: `get_popular_videos`/`get_videos_by_tags` に同追加
- `20260611170000`: `explore_videos` の SELECT に `vi.source, vi.image_urls` を追加
- `VideoListDrawer`: grid コンテナの `overflow-y-auto` を除去

🤖 Generated with [Claude Code](https://claude.com/claude-code)