### PR TITLE
fix: feed RPC に source/image_urls 追加・videos-grid 高速化インデックス

### DIFF
--- a/supabase/migrations/20260611200000_add_source_image_urls_to_all_feed_rpcs.sql
+++ b/supabase/migrations/20260611200000_add_source_image_urls_to_all_feed_rpcs.sql
@@ -1,0 +1,240 @@
+-- get_videos_feed / get_popular_videos / get_videos_by_tags / explore_videos に
+-- source, image_urls を追加（FANZA_AMATEUR サムネイル高画質化）
+-- ※150000/160000/170000 はすでにリモートに適用済みのため新規 migration で対応
+
+DROP FUNCTION IF EXISTS public.get_videos_feed(int);
+CREATE OR REPLACE FUNCTION public.get_videos_feed(page_limit int DEFAULT 20)
+RETURNS TABLE(
+  id uuid, title text, description text, external_id text,
+  thumbnail_url text, thumbnail_vertical_url text,
+  sample_video_url text, preview_video_url text,
+  product_url text, product_released_at timestamptz,
+  performers jsonb, tags jsonb,
+  source text, image_urls text[]
+)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    v.id, v.title, v.description, v.external_id,
+    v.thumbnail_url, v.thumbnail_vertical_url,
+    v.sample_video_url, v.preview_video_url,
+    coalesce(v.affiliate_url, v.product_url),
+    v.product_released_at,
+    coalesce((
+      SELECT jsonb_agg(jsonb_build_object('id', p.id, 'name', p.name) ORDER BY p.name)
+      FROM public.video_performers vp JOIN public.performers p ON p.id = vp.performer_id
+      WHERE vp.video_id = v.id
+    ), '[]'::jsonb),
+    coalesce((
+      SELECT jsonb_agg(jsonb_build_object('id', t.id, 'name', t.name) ORDER BY t.name)
+      FROM public.video_tags vt JOIN public.tags t ON t.id = vt.tag_id
+      LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
+      WHERE vt.video_id = v.id AND coalesce(tg.show_in_ui, true)
+    ), '[]'::jsonb),
+    v.source,
+    v.image_urls
+  FROM public.videos v TABLESAMPLE SYSTEM(5)
+  WHERE v.sample_video_url IS NOT NULL
+    AND v.source NOT IN ('FANZA_ANIME')
+    AND (v.has_performer = true OR v.source = 'FANZA_AMATEUR')
+    AND NOT EXISTS (
+      SELECT 1 FROM public.user_video_decisions uvd
+      WHERE uvd.video_id = v.id
+        AND auth.uid() IS NOT NULL AND uvd.user_id = auth.uid()
+    )
+  ORDER BY random()
+  LIMIT page_limit;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.get_popular_videos(int, int, uuid);
+CREATE OR REPLACE FUNCTION public.get_popular_videos(
+  limit_count int DEFAULT 20,
+  lookback_days int DEFAULT 7,
+  user_uuid uuid DEFAULT NULL
+)
+RETURNS TABLE(
+  id uuid, title text, description text, external_id text,
+  thumbnail_url text, thumbnail_vertical_url text,
+  sample_video_url text, product_url text, product_released_at timestamptz,
+  performers jsonb, tags jsonb, score double precision,
+  source text, image_urls text[]
+)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  WITH user_likes AS (
+    SELECT vpd.video_id, SUM(vpd.likes)::double precision AS total_likes
+    FROM public.video_popularity_daily vpd
+    WHERE vpd.d >= (NOW() - make_interval(days => lookback_days))
+    GROUP BY vpd.video_id
+  ),
+  best_rank AS (
+    SELECT fr.video_id, MIN(fr.rank) AS rank
+    FROM public.fanza_rankings fr
+    WHERE fr.video_id IS NOT NULL
+    GROUP BY fr.video_id
+  ),
+  ranked AS (
+    SELECT v.id,
+      COALESCE(ul.total_likes, 0) AS like_score,
+      CASE WHEN br.rank IS NOT NULL
+        THEN (501 - LEAST(br.rank, 500))::double precision / 500.0
+        ELSE 0
+      END AS rank_score
+    FROM public.videos v
+    LEFT JOIN user_likes ul ON ul.video_id = v.id
+    LEFT JOIN best_rank br ON br.video_id = v.id
+    WHERE v.sample_video_url IS NOT NULL
+      AND v.source NOT IN ('FANZA_ANIME')
+      AND (v.has_performer = true OR v.source = 'FANZA_AMATEUR')
+      AND (user_uuid IS NULL OR NOT EXISTS (
+        SELECT 1 FROM public.user_video_decisions uvd
+        WHERE uvd.user_id = user_uuid AND uvd.video_id = v.id
+      ))
+  )
+  SELECT
+    v.id, v.title, v.description, v.external_id,
+    v.thumbnail_url, v.thumbnail_vertical_url, v.sample_video_url,
+    coalesce(v.affiliate_url, v.product_url), v.product_released_at,
+    coalesce((
+      SELECT jsonb_agg(jsonb_build_object('id', p.id, 'name', p.name) ORDER BY p.name)
+      FROM public.video_performers vp JOIN public.performers p ON p.id = vp.performer_id
+      WHERE vp.video_id = v.id
+    ), '[]'::jsonb),
+    coalesce((
+      SELECT jsonb_agg(jsonb_build_object('id', t.id, 'name', t.name) ORDER BY t.name)
+      FROM public.video_tags vt JOIN public.tags t ON t.id = vt.tag_id
+      LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
+      WHERE vt.video_id = v.id AND coalesce(tg.show_in_ui, true)
+    ), '[]'::jsonb),
+    (r.like_score + r.rank_score) AS score,
+    v.source,
+    v.image_urls
+  FROM ranked r
+  JOIN public.videos v ON v.id = r.id
+  ORDER BY score DESC
+  LIMIT limit_count;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS public.get_videos_by_tags(uuid[], uuid[], int);
+CREATE OR REPLACE FUNCTION public.get_videos_by_tags(
+  tag_ids uuid[],
+  exclude_ids uuid[] DEFAULT '{}',
+  p_limit int DEFAULT 20
+)
+RETURNS TABLE(
+  id uuid, title text, external_id text,
+  thumbnail_url text, thumbnail_vertical_url text,
+  sample_video_url text, product_url text, product_released_at timestamptz,
+  performers jsonb, tags jsonb,
+  source text, image_urls text[]
+)
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  RETURN QUERY
+  SELECT v.id, v.title, v.external_id,
+    v.thumbnail_url, v.thumbnail_vertical_url, v.sample_video_url,
+    coalesce(v.affiliate_url, v.product_url), v.product_released_at,
+    coalesce((
+      SELECT jsonb_agg(jsonb_build_object('id', p.id, 'name', p.name))
+      FROM public.video_performers vp JOIN public.performers p ON p.id = vp.performer_id
+      WHERE vp.video_id = v.id
+    ), '[]'::jsonb),
+    coalesce((
+      SELECT jsonb_agg(jsonb_build_object('id', t.id, 'name', t.name))
+      FROM public.video_tags vt JOIN public.tags t ON t.id = vt.tag_id
+      LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
+      WHERE vt.video_id = v.id AND coalesce(tg.show_in_ui, true)
+    ), '[]'::jsonb),
+    v.source,
+    v.image_urls
+  FROM public.videos v
+  WHERE v.sample_video_url IS NOT NULL
+    AND v.source NOT IN ('FANZA_ANIME')
+    AND (v.has_performer = true OR v.source = 'FANZA_AMATEUR')
+    AND (array_length(exclude_ids, 1) IS NULL OR v.id != ALL(exclude_ids))
+    AND EXISTS (SELECT 1 FROM public.video_tags vt WHERE vt.video_id = v.id AND vt.tag_id = ANY(tag_ids))
+  ORDER BY random()
+  LIMIT p_limit;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.explore_videos(
+  p_query text DEFAULT NULL,
+  p_tag_id uuid DEFAULT NULL,
+  p_performer_id uuid DEFAULT NULL,
+  p_limit int DEFAULT 20,
+  p_offset int DEFAULT 0
+)
+RETURNS json
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  IF p_query IS NULL AND p_tag_id IS NULL AND p_performer_id IS NULL THEN
+    RETURN (
+      SELECT json_agg(row_to_json(v))
+      FROM (
+        SELECT vi.id, vi.title, vi.external_id,
+          vi.thumbnail_url, vi.thumbnail_vertical_url,
+          vi.product_url, vi.distribution_code, vi.product_released_at,
+          vi.source, vi.image_urls
+        FROM public.videos vi
+        WHERE vi.external_id IS NOT NULL
+          AND vi.sample_video_url IS NOT NULL
+          AND (vi.has_performer = true OR vi.source = 'FANZA_AMATEUR')
+          AND vi.source NOT IN ('FANZA_ANIME')
+        ORDER BY vi.product_released_at DESC NULLS LAST
+        LIMIT p_limit OFFSET p_offset
+      ) v
+    );
+  END IF;
+
+  IF p_tag_id IS NOT NULL AND p_query IS NULL AND p_performer_id IS NULL THEN
+    RETURN (
+      SELECT json_agg(row_to_json(v))
+      FROM (
+        SELECT vi.id, vi.title, vi.external_id,
+          vi.thumbnail_url, vi.thumbnail_vertical_url,
+          vi.product_url, vi.distribution_code, vi.product_released_at,
+          vi.source, vi.image_urls
+        FROM public.video_tags vt
+        JOIN public.videos vi ON vi.id = vt.video_id
+        LEFT JOIN public.fanza_rankings fr ON fr.video_id = vi.id
+        WHERE vt.tag_id = p_tag_id
+          AND vi.external_id IS NOT NULL
+          AND vi.sample_video_url IS NOT NULL
+          AND (vi.has_performer = true OR vi.source = 'FANZA_AMATEUR')
+          AND vi.source NOT IN ('FANZA_ANIME')
+        ORDER BY fr.rank ASC NULLS LAST, vi.product_released_at DESC NULLS LAST
+        LIMIT p_limit OFFSET p_offset
+      ) v
+    );
+  END IF;
+
+  RETURN (
+    SELECT json_agg(row_to_json(v))
+    FROM (
+      SELECT vi.id, vi.title, vi.external_id,
+        vi.thumbnail_url, vi.thumbnail_vertical_url,
+        vi.product_url, vi.distribution_code, vi.product_released_at,
+        vi.source, vi.image_urls
+      FROM public.videos vi
+      LEFT JOIN public.fanza_rankings fr ON fr.video_id = vi.id
+      WHERE vi.external_id IS NOT NULL
+        AND (p_query IS NULL
+          OR vi.title ILIKE '%' || p_query || '%'
+          OR vi.distribution_code ILIKE '%' || p_query || '%')
+        AND (p_tag_id IS NULL
+          OR EXISTS (SELECT 1 FROM public.video_tags vt WHERE vt.video_id = vi.id AND vt.tag_id = p_tag_id))
+        AND (p_performer_id IS NULL
+          OR EXISTS (SELECT 1 FROM public.video_performers vp WHERE vp.video_id = vi.id AND vp.performer_id = p_performer_id))
+      ORDER BY
+        CASE WHEN p_tag_id IS NOT NULL OR p_query IS NOT NULL THEN fr.rank END ASC NULLS LAST,
+        vi.product_released_at DESC NULLS LAST
+      LIMIT p_limit OFFSET p_offset
+    ) v
+  );
+END;
+$$;

--- a/supabase/migrations/20260612000000_add_indexes_for_grid_rpcs.sql
+++ b/supabase/migrations/20260612000000_add_indexes_for_grid_rpcs.sql
@@ -32,6 +32,7 @@ CREATE INDEX IF NOT EXISTS video_embeddings_hnsw_cosine_idx
   WITH (m = 16, ef_construction = 64);
 
 -- 5. get_videos_recommendations: <-> (L2) → <=> (cosine) に変更して cosine HNSW を活用
+DROP FUNCTION IF EXISTS public.get_videos_recommendations(uuid, int);
 CREATE OR REPLACE FUNCTION public.get_videos_recommendations(user_uuid uuid, page_limit int DEFAULT 20)
 RETURNS TABLE (
   id uuid,

--- a/supabase/migrations/20260612000000_add_indexes_for_grid_rpcs.sql
+++ b/supabase/migrations/20260612000000_add_indexes_for_grid_rpcs.sql
@@ -1,0 +1,145 @@
+-- videos-grid RPC 高速化インデックス
+--
+-- 追加するインデックス:
+--   1. user_video_decisions (user_id, video_id) — NOT EXISTS サブクエリ高速化
+--      (get_popular_videos / get_videos_recommendations 共通)
+--   2. user_video_decisions (user_id, decision_type, created_at DESC)
+--      — get_videos_recommendations の recent_likes CTE 高速化
+--   3. video_popularity_daily (d, video_id)
+--      — get_popular_videos の d >= threshold レンジスキャン高速化
+--   4. video_embeddings HNSW を halfvec_cosine_ops に置き換え
+--      — get_videos_recommendations の <=> 近傍探索に合致させる
+--      — 既存 halfvec_ip_ops (内積) では <-> (L2) クエリがインデックスを使えない
+
+-- 1. user_video_decisions: NOT EXISTS 用複合インデックス
+CREATE INDEX IF NOT EXISTS uvd_user_video_idx
+  ON public.user_video_decisions (user_id, video_id);
+
+-- 2. user_video_decisions: recent_likes CTE 用インデックス
+CREATE INDEX IF NOT EXISTS uvd_user_type_created_idx
+  ON public.user_video_decisions (user_id, decision_type, created_at DESC);
+
+-- 3. video_popularity_daily: d レンジスキャン用インデックス
+CREATE INDEX IF NOT EXISTS vpd_d_video_idx
+  ON public.video_popularity_daily (d, video_id);
+
+-- 4. video_embeddings: HNSW を cosine_ops に差し替え
+--    halfvec_ip_ops (内積) では <=> (cosine) / <-> (L2) クエリで使われない
+DROP INDEX IF EXISTS public.video_embeddings_embedding_hnsw_idx;
+CREATE INDEX IF NOT EXISTS video_embeddings_hnsw_cosine_idx
+  ON public.video_embeddings
+  USING hnsw (embedding halfvec_cosine_ops)
+  WITH (m = 16, ef_construction = 64);
+
+-- 5. get_videos_recommendations: <-> (L2) → <=> (cosine) に変更して cosine HNSW を活用
+CREATE OR REPLACE FUNCTION public.get_videos_recommendations(user_uuid uuid, page_limit int DEFAULT 20)
+RETURNS TABLE (
+  id uuid,
+  title text,
+  description text,
+  external_id text,
+  thumbnail_url text,
+  thumbnail_vertical_url text,
+  sample_video_url text,
+  product_url text,
+  product_released_at timestamptz,
+  performers jsonb,
+  tags jsonb,
+  score double precision,
+  model_version text,
+  source text,
+  image_urls text[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  user_vec halfvec(128);
+  approx_vec halfvec(128);
+  latest_version text;
+BEGIN
+  -- 近似ユーザー埋め込み: いいね済み動画の埋め込み平均（直近200件）
+  -- uvd_user_type_created_idx を使用
+  SELECT avg(ve.embedding)::halfvec(128)
+    INTO approx_vec
+  FROM (
+    SELECT uvd.video_id
+    FROM public.user_video_decisions uvd
+    WHERE uvd.user_id = user_uuid
+      AND uvd.decision_type = 'like'
+    ORDER BY uvd.created_at DESC
+    LIMIT 200
+  ) recent_likes
+  JOIN public.video_embeddings ve ON ve.video_id = recent_likes.video_id;
+
+  -- いいねがゼロの場合はバッチ生成済み埋め込みにフォールバック
+  IF approx_vec IS NULL THEN
+    SELECT ue.embedding INTO user_vec
+    FROM public.user_embeddings ue
+    WHERE ue.user_id = user_uuid;
+  END IF;
+
+  user_vec := coalesce(approx_vec, user_vec);
+
+  IF user_vec IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT ve.model_version
+    INTO latest_version
+  FROM public.video_embeddings ve
+  WHERE ve.model_version IS NOT NULL
+  ORDER BY ve.updated_at DESC
+  LIMIT 1;
+
+  -- <=> (cosine distance) を使用して video_embeddings_hnsw_cosine_idx を活用
+  RETURN QUERY
+  SELECT
+    v.id,
+    v.title,
+    v.description,
+    v.external_id,
+    v.thumbnail_url,
+    v.thumbnail_vertical_url,
+    v.sample_video_url,
+    coalesce(v.affiliate_url, v.product_url) AS product_url,
+    v.product_released_at,
+    coalesce(
+      (
+        SELECT jsonb_agg(jsonb_build_object('id', p.id, 'name', p.name) ORDER BY p.name)
+        FROM public.video_performers vp
+        JOIN public.performers p ON p.id = vp.performer_id
+        WHERE vp.video_id = v.id
+      ), '[]'::jsonb
+    ) AS performers,
+    coalesce(
+      (
+        SELECT jsonb_agg(jsonb_build_object('id', t.id, 'name', t.name) ORDER BY t.name)
+        FROM public.video_tags vt
+        JOIN public.tags t ON t.id = vt.tag_id
+        LEFT JOIN public.tag_groups tg ON tg.id = t.tag_group_id
+        WHERE vt.video_id = v.id
+          AND coalesce(tg.show_in_ui, true)
+      ), '[]'::jsonb
+    ) AS tags,
+    (1 - (ve.embedding <=> user_vec))::double precision AS score,
+    ve.model_version,
+    v.source,
+    v.image_urls
+  FROM public.video_embeddings ve
+  JOIN public.videos v ON v.id = ve.video_id
+  WHERE v.sample_video_url IS NOT NULL
+    AND (latest_version IS NULL OR ve.model_version = latest_version)
+    AND NOT EXISTS (
+      -- uvd_user_video_idx を使用
+      SELECT 1 FROM public.user_video_decisions uvd
+      WHERE uvd.user_id = user_uuid
+        AND uvd.video_id = v.id
+    )
+  ORDER BY ve.embedding <=> user_vec
+  LIMIT page_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_videos_recommendations(uuid, int) TO anon, authenticated;


### PR DESCRIPTION
## Summary

- `get_videos_feed` / `get_popular_videos` / `get_videos_by_tags` / `explore_videos` の戻り値に `source` と `image_urls` を追加（FANZA_AMATEUR サムネイル高画質化対応）
- `videos-grid` Edge Function が呼び出す各 RPC にインデックスを追加し、レスポンスを高速化
  - `user_video_decisions(user_id, video_id)` — NOT EXISTS サブクエリ（既見除外）を高速化
  - `user_video_decisions(user_id, decision_type, created_at DESC)` — recent_likes CTE を高速化
  - `video_popularity_daily(d, video_id)` — ルックバック期間レンジスキャンを高速化
  - `video_embeddings` HNSW インデックスを `halfvec_ip_ops` → `halfvec_cosine_ops` に差し替え（既存インデックスが `<=>` クエリでヒットしていなかった）
- `get_videos_recommendations` のベクトル演算子を `<->` (L2) → `<=>` (cosine) に変更して HNSW インデックスを活用
- `get_videos_recommendations` の戻り値に `source` / `image_urls` を追加して他 RPC と統一

## Test plan

- [ ] `videos-grid` Edge Function を呼び出し、レスポンスに `source` / `image_urls` が含まれることを確認
- [ ] ログイン済みユーザーで grid ページを開き、exploitation / popularity / exploration 各枠が正常に表示されること
- [ ] ゲストユーザー（未ログイン）で grid ページを開き、popularity + exploration 枠が表示されること
- [ ] Supabase の実行プランで `uvd_user_video_idx` / `uvd_user_type_created_idx` / `vpd_d_video_idx` / `video_embeddings_hnsw_cosine_idx` が使われていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)