### PR TITLE
fix: get_popular_videos の戻り型変更エラーを修正

### DIFF
--- a/supabase/migrations/20260518300000_add_fanza_rank.sql
+++ b/supabase/migrations/20260518300000_add_fanza_rank.sql
@@ -7,6 +7,7 @@ CREATE INDEX IF NOT EXISTS idx_videos_fanza_rank ON public.videos (fanza_rank AS
   WHERE fanza_rank IS NOT NULL;
 
 -- get_popular_videos: fanza_rank をフォールバックとして使用
+DROP FUNCTION IF EXISTS public.get_popular_videos(uuid, int, int);
 CREATE OR REPLACE FUNCTION public.get_popular_videos(
   user_uuid uuid DEFAULT NULL,
   limit_count int DEFAULT 20,


### PR DESCRIPTION
## Summary

`20260518300000_add_fanza_rank.sql` で `CREATE OR REPLACE` が戻り型変更エラーになるため `DROP FUNCTION IF EXISTS` を追加。

## Cause

戻り値に `thumbnail_vertical_url` と `product_url` が追加されており、既存の関数シグネチャと不一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)