### PR TITLE
fix: 重複していた 20260612210000_remote_only_stub.sql を削除

### DIFF
--- a/supabase/migrations/20260612210000_remote_only_stub.sql
+++ b/supabase/migrations/20260612210000_remote_only_stub.sql
@@ -1,1 +1,0 @@
--- Remote-only migration stub (applied directly to remote)


### PR DESCRIPTION
## Summary

`20260612210000_optimize_feed_rpcs_v2.sql` が既に存在するにもかかわらず `20260612210000_remote_only_stub.sql` を作成してしまったため、同じバージョンのファイルが2つ存在し `duplicate key` エラーが発生していた。stubを削除して解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)