### PR TITLE
fix: いいね・閲覧数の絵文字をアイコンに変更、いいねボタンUIを改善

### DIFF
--- a/frontend/src/app/list/[token]/ListStats.tsx
+++ b/frontend/src/app/list/[token]/ListStats.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { Eye, Heart } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 
 function getFingerprint(): string {
@@ -52,18 +53,20 @@ export default function ListStats({ token, initialViewCount, initialLikeCount }:
   return (
     <div className="flex items-center gap-4 text-sm text-[#656d76]">
       <span className="flex items-center gap-1.5">
-        <span>👁</span>
+        <Eye size={15} />
         <span>{initialViewCount.toLocaleString()}</span>
       </span>
       <button
         type="button"
         onClick={handleLike}
         disabled={likeLoading}
-        className={`flex items-center gap-1.5 transition-colors ${
-          liked ? 'text-rose-400' : 'hover:text-rose-400'
+        className={`flex items-center gap-1.5 transition-colors cursor-pointer select-none rounded-full px-2.5 py-1 border ${
+          liked
+            ? 'text-rose-400 border-rose-400 bg-rose-400/10'
+            : 'border-[#444c56] hover:text-rose-400 hover:border-rose-400 hover:bg-rose-400/10'
         }`}
       >
-        <span>{liked ? '❤️' : '🤍'}</span>
+        <Heart size={14} className={liked ? 'fill-rose-400' : ''} />
         <span>{likeCount.toLocaleString()}</span>
       </button>
     </div>


### PR DESCRIPTION
## 変更内容

- 👁 絵文字 → `Eye` アイコン（lucide-react）
- ❤️/🤍 絵文字 → `Heart` アイコン（lucide-react）
- いいねボタンを pill 形状のボーダー付きボタンに変更し、状態がひと目でわかるよう改善
  - 未押下: グレーのボーダー、ホバーでピンク
  - 押下済み: ピンクのボーダー + 薄いピンク背景 + Heart を塗りつぶし

## 対象ファイル

- `frontend/src/app/list/[token]/ListStats.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)