### PR TITLE
fix: ListStats改善・いいねボタンUI・MGSアフィリエイト対応

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,14 @@
+## Copy to frontend/.env.local (do not commit real secrets)
+
+# Supabase (browser)
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# FANZA affiliate for links and iframe embed (litevideo)
+NEXT_PUBLIC_FANZA_AFFILIATE_ID=yotadata2-001
+
+# MGS affiliate ID for product links
+NEXT_PUBLIC_MGS_AFFILIATE_ID=your-mgs-affiliate-id
+
+# Guest swipe limit before requiring signup
+NEXT_PUBLIC_GUEST_DECISIONS_LIMIT=20

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.local.example
 
 # vercel
 .vercel

--- a/frontend/src/app/list/[token]/ListStats.tsx
+++ b/frontend/src/app/list/[token]/ListStats.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { Eye, Heart } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 
 function getFingerprint(): string {
@@ -52,18 +53,20 @@ export default function ListStats({ token, initialViewCount, initialLikeCount }:
   return (
     <div className="flex items-center gap-4 text-sm text-[#656d76]">
       <span className="flex items-center gap-1.5">
-        <span>👁</span>
+        <Eye size={15} />
         <span>{initialViewCount.toLocaleString()}</span>
       </span>
       <button
         type="button"
         onClick={handleLike}
         disabled={likeLoading}
-        className={`flex items-center gap-1.5 transition-colors ${
-          liked ? 'text-rose-400' : 'hover:text-rose-400'
+        className={`flex items-center gap-1.5 transition-colors cursor-pointer select-none rounded-full px-2.5 py-1 border ${
+          liked
+            ? 'text-rose-400 border-rose-400 bg-rose-400/10'
+            : 'border-[#444c56] hover:text-rose-400 hover:border-rose-400 hover:bg-rose-400/10'
         }`}
       >
-        <span>{liked ? '❤️' : '🤍'}</span>
+        <Heart size={14} className={liked ? 'fill-rose-400' : ''} />
         <span>{likeCount.toLocaleString()}</span>
       </button>
     </div>

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -32,7 +32,6 @@ type ListData = {
   display_name: string | null;
   username: string | null;
   affiliate_fanza_id: string | null;
-  affiliate_fc2_id: string | null;
   affiliate_mgs_id: string | null;
   title: string | null;
   list_type: 'liked' | 'custom';

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -9,7 +9,8 @@ import { resolveThumbnail } from '@/utils/thumbnail';
 
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.seihekilab.com';
-const SYS_AF_ID = process.env.NEXT_PUBLIC_FANZA_AFFILIATE_ID ?? 'yotadata2-001';
+const SYS_AF_ID     = process.env.NEXT_PUBLIC_FANZA_AFFILIATE_ID ?? 'yotadata2-001';
+const SYS_MGS_AF_ID = process.env.NEXT_PUBLIC_MGS_AFFILIATE_ID   ?? 'HU3ADNBETQPYWHO8EFF88GY3NH';
 
 type Video = {
   id: string;
@@ -42,9 +43,23 @@ type ListData = {
   performers: PerformerStat[];
 };
 
-function toAffiliateUrl(raw?: string | null, curatorAfId?: string | null): string {
+function toAffiliateUrl(raw?: string | null, source?: string | null, curatorFanzaId?: string | null, curatorMgsId?: string | null): string {
   if (!raw) return '';
-  const afId = curatorAfId ?? SYS_AF_ID;
+  if (source === 'mgs') {
+    const mgsId = curatorMgsId ?? SYS_MGS_AF_ID;
+    try {
+      const u = new URL(raw);
+      u.searchParams.set('agef', '1');
+      u.searchParams.set('utm_medium', 'mgs_affiliate');
+      u.searchParams.set('utm_source', 'mgs_affiliate_linktool');
+      u.searchParams.set('utm_campaign', 'mgs_affiliate_linktool');
+      u.searchParams.set('utm_content', mgsId);
+      u.searchParams.set('form', `mgs_asp_linktool_${mgsId}`);
+      return u.toString();
+    } catch { /* ignore */ }
+    return raw;
+  }
+  const afId = curatorFanzaId ?? SYS_AF_ID;
   if (raw.startsWith('https://al.fanza.co.jp/')) {
     try {
       const u = new URL(raw);
@@ -233,7 +248,7 @@ export default async function PublicListPage(
         ) : (
           <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
             {data.videos.map((video) => {
-              const affiliateUrl = toAffiliateUrl(video.product_url, data.affiliate_fanza_id);
+              const affiliateUrl = toAffiliateUrl(video.product_url, video.source, data.affiliate_fanza_id, data.affiliate_mgs_id);
               const { primary: resolvedThumb } = resolveThumbnail({ source: video.source, thumbnail_url: video.thumbnail_url, image_urls: video.image_urls });
               const thumb = resolvedThumb ?? toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
               return (

--- a/frontend/src/app/swipe/page.tsx
+++ b/frontend/src/app/swipe/page.tsx
@@ -8,7 +8,7 @@ import useWindowSize from "@/hooks/useWindowSize";
 import MobileVideoLayout from "@/components/MobileVideoLayout";
 import { supabase } from "@/lib/supabase";
 import { trackEvent, generateSessionId } from "@/lib/analytics";
-import { resolveEmbedUrl } from "@/lib/videoMeta";
+import { resolveEmbedUrl, isVrContent } from "@/lib/videoMeta";
 import { ChevronsLeft, Heart, List } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useDecisionCount } from "@/hooks/useDecisionCount";
@@ -266,6 +266,8 @@ function SwipePage() {
           recommendationParams: video.params ?? null,
           source: video.video_source ?? null,
           image_urls: video.image_urls ?? null,
+          isVr: isVrContent(video.tags as { name: string }[]),
+          externalId: video.external_id ?? null,
         };
       });
       setCards(fetchedCards);

--- a/frontend/src/components/AccountManagementDrawer.tsx
+++ b/frontend/src/components/AccountManagementDrawer.tsx
@@ -18,7 +18,7 @@ interface AccountManagementDrawerProps {
 type TagItem = { id: string; name: string; cnt: number };
 type PerformerItem = { id: string; name: string; cnt: number };
 type ExcludedTag = { tag_id: string; name: string };
-type CuratorProfile = { bio: string; x_url: string; affiliate_fanza_id: string; affiliate_fc2_id: string; affiliate_mgs_id: string };
+type CuratorProfile = { bio: string; x_url: string; affiliate_fanza_id: string; affiliate_mgs_id: string };
 
 const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpen, onClose }) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -47,7 +47,7 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
   const [newDisplayName, setNewDisplayName] = useState('');
   const [passwords, setPasswords] = useState({ next: '', confirm: '' });
   const [accountSaving, setAccountSaving] = useState(false);
-  const [curatorProfile, setCuratorProfile] = useState<CuratorProfile>({ bio: '', x_url: '', affiliate_fanza_id: '', affiliate_fc2_id: '', affiliate_mgs_id: '' });
+  const [curatorProfile, setCuratorProfile] = useState<CuratorProfile>({ bio: '', x_url: '', affiliate_fanza_id: '', affiliate_mgs_id: '' });
   const [curatorSaving, setCuratorSaving] = useState(false);
 
   useEffect(() => {
@@ -95,13 +95,12 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
           .eq('user_id', user.id).eq('is_active', true).eq('list_type', 'liked').maybeSingle()
           .then(({ data }) => { if (data) setPublicToken(data.token); });
         supabase.from('user_profiles')
-          .select('bio, x_url, affiliate_fanza_id, affiliate_fc2_id, affiliate_mgs_id')
+          .select('bio, x_url, affiliate_fanza_id, affiliate_mgs_id')
           .eq('user_id', user.id).maybeSingle()
           .then(({ data: up }) => {
             if (up) setCuratorProfile({
               bio: up.bio ?? '', x_url: up.x_url ?? '',
               affiliate_fanza_id: up.affiliate_fanza_id ?? '',
-              affiliate_fc2_id: up.affiliate_fc2_id ?? '',
               affiliate_mgs_id: up.affiliate_mgs_id ?? '',
             });
           });
@@ -213,7 +212,6 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
         p_bio: curatorProfile.bio || null,
         p_x_url: curatorProfile.x_url || null,
         p_affiliate_fanza_id: curatorProfile.affiliate_fanza_id || null,
-        p_affiliate_fc2_id: curatorProfile.affiliate_fc2_id || null,
         p_affiliate_mgs_id: curatorProfile.affiliate_mgs_id || null,
       });
       if (error) throw error;
@@ -532,10 +530,6 @@ const AccountManagementDrawer: React.FC<AccountManagementDrawerProps> = ({ isOpe
                                       <div>
                                         <label className={labelCls}>FANZA アフィリエイトID</label>
                                         <input type="text" value={curatorProfile.affiliate_fanza_id} onChange={(e) => setCuratorProfile((p) => ({ ...p, affiliate_fanza_id: e.target.value }))} className={inputCls} placeholder="例: yourname-001" />
-                                      </div>
-                                      <div>
-                                        <label className={labelCls}>FC2 アフィリエイトID</label>
-                                        <input type="text" value={curatorProfile.affiliate_fc2_id} onChange={(e) => setCuratorProfile((p) => ({ ...p, affiliate_fc2_id: e.target.value }))} className={inputCls} placeholder="FC2アフィリエイトID" />
                                       </div>
                                       <div>
                                         <label className={labelCls}>MGS アフィリエイトID</label>

--- a/frontend/src/components/MobileVideoLayout.tsx
+++ b/frontend/src/components/MobileVideoLayout.tsx
@@ -2,7 +2,8 @@
 
 import { CardData } from '@/components/SwipeCard';
 import { useEffect, useRef, useState, RefObject } from 'react';
-import { Play, Calendar, User, Tag, ChevronsLeft, Heart, List, Share2 } from 'lucide-react';
+import { Play, Calendar, User, Tag, ChevronsLeft, Heart, List, Share2, ExternalLink } from 'lucide-react';
+import { resolveFanzaVrUrl } from '@/lib/videoMeta';
 import { resolveThumbnail } from '@/utils/thumbnail';
 
 interface MobileVideoLayoutProps {
@@ -83,22 +84,39 @@ const MobileVideoLayout: React.FC<MobileVideoLayoutProps> = ({ cardData, onSkip,
           <div className="w-full p-3">
             <div className="w-full overflow-hidden relative aspect-[4/3] bg-black flex items-center justify-center rounded-xl">
           {showOverlay && (
-            <div
-              className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10"
-              style={{ backgroundImage: thumbSrc ? `url(${thumbSrc})` : undefined, backgroundColor: thumbSrc ? undefined : '#1f2937' }}
-              onClick={() => {
-                // iframe再生に統一。オーバーレイを即時非表示
-                setShowOverlay(false);
-                onSamplePlay?.(cardData);
-              }}
-            >
-              <div className="absolute inset-0 bg-black bg-opacity-40 flex items-center justify-center">
-                <Play className="text-white w-16 h-16 opacity-80" fill="white" />
+            cardData.isVr ? (
+              // VR動画: FANZAのページを別タブで開く
+              <a
+                href={resolveFanzaVrUrl({ productUrl: cardData.productUrl, externalId: cardData.externalId })}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10"
+                style={{ backgroundImage: thumbSrc ? `url(${thumbSrc})` : undefined, backgroundColor: thumbSrc ? undefined : '#1f2937' }}
+                onClick={() => onSamplePlay?.(cardData)}
+              >
+                <div className="absolute inset-0 bg-black bg-opacity-40 flex flex-col items-center justify-center gap-2">
+                  <ExternalLink className="text-white w-12 h-12 opacity-80" />
+                  <span className="text-white text-xs font-medium bg-black/50 px-3 py-1 rounded-full">FANZAでサンプルを見る</span>
+                </div>
+              </a>
+            ) : (
+              <div
+                className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10"
+                style={{ backgroundImage: thumbSrc ? `url(${thumbSrc})` : undefined, backgroundColor: thumbSrc ? undefined : '#1f2937' }}
+                onClick={() => {
+                  // iframe再生に統一。オーバーレイを即時非表示
+                  setShowOverlay(false);
+                  onSamplePlay?.(cardData);
+                }}
+              >
+                <div className="absolute inset-0 bg-black bg-opacity-40 flex items-center justify-center">
+                  <Play className="text-white w-16 h-16 opacity-80" fill="white" />
+                </div>
+                <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-[10px] sm:text-xs text-white/80 bg-black/40 px-2 py-0.5 rounded">
+                  注: 再生には最大2回のクリックが必要な場合があります
+                </div>
               </div>
-              <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-[10px] sm:text-xs text-white/80 bg-black/40 px-2 py-0.5 rounded">
-                注: 再生には最大2回のクリックが必要な場合があります
-              </div>
-            </div>
+            )
           )}
           {/* iframe 埋め込み（litevideo） */}
           <iframe

--- a/frontend/src/components/SwipeCard.tsx
+++ b/frontend/src/components/SwipeCard.tsx
@@ -2,8 +2,9 @@
 
 import { motion, useAnimation, PanInfo } from 'framer-motion';
 import { forwardRef, useImperativeHandle, useState, useEffect, useRef } from 'react';
-import { Play, User, Tag, Calendar, Share2 } from 'lucide-react'; // アイコンをインポート
+import { Play, User, Tag, Calendar, Share2, ExternalLink } from 'lucide-react'; // アイコンをインポート
 import { resolveThumbnail } from '@/utils/thumbnail';
+import { resolveFanzaVrUrl } from '@/lib/videoMeta';
 
 // カードデータの型定義
 export interface CardData {
@@ -26,6 +27,8 @@ export interface CardData {
   recommendationParams?: Record<string, unknown> | null;
   source?: string | null;
   image_urls?: string[] | null;
+  isVr?: boolean;
+  externalId?: string | null;
 }
 
 export interface SwipeCardHandle {
@@ -161,22 +164,39 @@ const SwipeCard = forwardRef<SwipeCardHandle, SwipeCardProps>(({ cardData, onSwi
           <img src={thumbPrimary ?? ''} alt="" className="hidden" onError={() => setThumbSrc(thumbFallback)} />
         )}
         {showOverlay && (
-          <div
-            className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10"
-            style={{ backgroundImage: thumbSrc ? `url(${thumbSrc})` : undefined, backgroundColor: thumbSrc ? undefined : '#1f2937' }}
-            onClick={() => {
-              // iframe再生に統一。オーバーレイを即時非表示
-              setShowOverlay(false);
-              onSamplePlay?.(cardData);
-            }}
-          >
-            <div className="absolute inset-0 bg-black bg-opacity-40 flex items-center justify-center">
-              <Play className="text-white w-16 h-16 opacity-80" fill="white" />
+          cardData.isVr ? (
+            // VR動画: FANZAのVRプレイヤーページを別タブで開く
+            <a
+              href={resolveFanzaVrUrl({ productUrl: cardData.productUrl, externalId: cardData.externalId })}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10"
+              style={{ backgroundImage: thumbSrc ? `url(${thumbSrc})` : undefined, backgroundColor: thumbSrc ? undefined : '#1f2937' }}
+              onClick={() => onSamplePlay?.(cardData)}
+            >
+              <div className="absolute inset-0 bg-black bg-opacity-40 flex flex-col items-center justify-center gap-2">
+                <ExternalLink className="text-white w-12 h-12 opacity-80" />
+                <span className="text-white text-xs font-medium bg-black/50 px-3 py-1 rounded-full">FANZAでサンプルを見る</span>
+              </div>
+            </a>
+          ) : (
+            <div
+              className="absolute inset-0 w-full h-full bg-contain bg-no-repeat bg-center flex items-center justify-center z-10"
+              style={{ backgroundImage: thumbSrc ? `url(${thumbSrc})` : undefined, backgroundColor: thumbSrc ? undefined : '#1f2937' }}
+              onClick={() => {
+                // iframe再生に統一。オーバーレイを即時非表示
+                setShowOverlay(false);
+                onSamplePlay?.(cardData);
+              }}
+            >
+              <div className="absolute inset-0 bg-black bg-opacity-40 flex items-center justify-center">
+                <Play className="text-white w-16 h-16 opacity-80" fill="white" />
+              </div>
+              <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-[10px] sm:text-xs text-white/80 bg-black/40 px-2 py-0.5 rounded">
+                注: 再生には最大2回のクリックが必要な場合があります
+              </div>
             </div>
-            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-[10px] sm:text-xs text-white/80 bg-black/40 px-2 py-0.5 rounded">
-              注: 再生には最大2回のクリックが必要な場合があります
-            </div>
-          </div>
+          )
         )}
         {/* プレイヤー: MGS=MP4直接再生 / FANZA=iframeプレイヤー */}
         {cardData.embedType === 'mp4' ? (

--- a/frontend/src/lib/videoMeta.ts
+++ b/frontend/src/lib/videoMeta.ts
@@ -50,6 +50,23 @@ export function resolveEmbedUrl({
   };
 }
 
+const VR_TAG_NAMES = ['VR', 'VR対応', 'VR専用', 'ハイクオリティVR', '8KVR'];
+
+export const isVrContent = (tags?: { name: string }[] | null): boolean =>
+  tags?.some((t) => VR_TAG_NAMES.includes(t.name)) ?? false;
+
+export const resolveFanzaVrUrl = ({
+  productUrl,
+  externalId,
+}: {
+  productUrl?: string | null;
+  externalId?: string | null;
+}): string => {
+  if (productUrl) return productUrl;
+  if (externalId) return `https://video.dmm.co.jp/av/content/?id=${externalId}`;
+  return '';
+};
+
 export const isUpcomingRelease = (value?: string | null): boolean => {
   if (!value) return false;
   const releaseDate = new Date(value);


### PR DESCRIPTION
## Summary

- ListStats の絵文字をアイコンに変更し、いいねボタンの UI を改善
- VR動画のサンプル再生を FANZA 別タブ誘導に変更
- FC2 アフィリエイトID の入力欄を画面から削除（未使用のため）
- MGS アフィリエイトリンク生成を実装（`source=mgs` のとき UTM パラメータを付与）
- `NEXT_PUBLIC_MGS_AFFILIATE_ID` を環境変数で管理できるよう `.env.local.example` に追加

## Test plan

- [ ] リスト詳細ページで MGS 動画の外部リンクにアフィリエイトパラメータが付与されていること
- [ ] アカウント管理ドロワーに FC2 アフィリエイトIDの入力欄が表示されないこと
- [ ] ListStats のアイコン表示・いいねボタンが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)