### PR TITLE
feat: リスト・プロフィールページのOGP改善とXシェアボタン追加

### DIFF
--- a/frontend/src/app/list/[token]/opengraph-image.tsx
+++ b/frontend/src/app/list/[token]/opengraph-image.tsx
@@ -1,0 +1,170 @@
+import { ImageResponse } from 'next/og';
+import { supabase } from '@/lib/supabase';
+
+export const runtime = 'edge';
+export const alt = '性癖ラボ リスト';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+type Video = {
+  thumbnail_url: string | null;
+};
+
+type ListData = {
+  title: string | null;
+  display_name: string | null;
+  view_count: number;
+  like_count: number;
+  videos: Video[];
+};
+
+export default async function Image({ params }: { params: { token: string } }) {
+  const { data } = await supabase.rpc('get_public_list_data', { p_token: params.token });
+
+  if (!data || data.error === 'not_found') {
+    // フォールバック: シンプルなデフォルト画像
+    return new ImageResponse(
+      (
+        <div style={{
+          width: '1200px', height: '630px',
+          background: 'linear-gradient(135deg, #0d1117 0%, #161b22 100%)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}>
+          <span style={{ color: '#656d76', fontSize: '32px', fontFamily: 'sans-serif' }}>
+            性癖ラボ
+          </span>
+        </div>
+      ),
+      { width: 1200, height: 630 }
+    );
+  }
+
+  const list = data as ListData;
+  const title = list.title ?? (list.display_name ? `${list.display_name}のお気に入りリスト` : 'お気に入りリスト');
+  const thumbs = (list.videos ?? [])
+    .map((v) => v.thumbnail_url)
+    .filter(Boolean)
+    .slice(0, 5) as string[];
+
+  const videoCount = (list.videos ?? []).length;
+  const viewCount = list.view_count ?? 0;
+  const likeCount = list.like_count ?? 0;
+
+  // サムネイルを1〜5枚の横並びコラージュとして表示
+  const thumbCount = thumbs.length;
+  const thumbWidth = thumbCount > 0 ? Math.floor(840 / thumbCount) : 840;
+
+  return new ImageResponse(
+    (
+      <div style={{
+        width: '1200px',
+        height: '630px',
+        background: '#0d1117',
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: 'sans-serif',
+        overflow: 'hidden',
+      }}>
+        {/* サムネイルエリア（上部 約70%） */}
+        <div style={{
+          display: 'flex',
+          width: '1200px',
+          height: '440px',
+          overflow: 'hidden',
+          position: 'relative',
+        }}>
+          {thumbCount > 0 ? (
+            thumbs.map((url, i) => (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                key={i}
+                src={url}
+                width={thumbWidth}
+                height={440}
+                style={{
+                  objectFit: 'cover',
+                  flexShrink: 0,
+                  borderRight: i < thumbCount - 1 ? '2px solid #0d1117' : 'none',
+                }}
+                alt=""
+              />
+            ))
+          ) : (
+            <div style={{
+              width: '1200px',
+              height: '440px',
+              background: 'linear-gradient(135deg, #161b22 0%, #21262d 100%)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}>
+              <span style={{ color: '#484f58', fontSize: '24px' }}>No Image</span>
+            </div>
+          )}
+          {/* グラデーションオーバーレイ（下部フェード） */}
+          <div style={{
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: '160px',
+            background: 'linear-gradient(to bottom, transparent, #0d1117)',
+            display: 'flex',
+          }} />
+        </div>
+
+        {/* 情報エリア（下部） */}
+        <div style={{
+          display: 'flex',
+          flexDirection: 'column',
+          padding: '0 48px 32px',
+          gap: '12px',
+          marginTop: '-40px',
+          position: 'relative',
+          zIndex: 1,
+        }}>
+          {/* タイトル */}
+          <div style={{
+            color: '#e6edf3',
+            fontSize: '40px',
+            fontWeight: 900,
+            lineHeight: 1.2,
+            display: 'flex',
+            maxWidth: '1100px',
+          }}>
+            {title.length > 30 ? `${title.slice(0, 30)}…` : title}
+          </div>
+
+          {/* 統計 */}
+          <div style={{
+            display: 'flex',
+            gap: '24px',
+            alignItems: 'center',
+          }}>
+            <span style={{ color: '#8b949e', fontSize: '22px' }}>
+              {videoCount.toLocaleString()}作品
+            </span>
+            {viewCount > 0 && (
+              <span style={{ color: '#8b949e', fontSize: '22px' }}>
+                👁 {viewCount.toLocaleString()}
+              </span>
+            )}
+            {likeCount > 0 && (
+              <span style={{ color: '#8b949e', fontSize: '22px' }}>
+                ❤️ {likeCount.toLocaleString()}
+              </span>
+            )}
+            <span style={{
+              marginLeft: 'auto',
+              color: '#484f58',
+              fontSize: '18px',
+            }}>
+              seihekilab.com
+            </span>
+          </div>
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  );
+}

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -115,6 +115,10 @@ export async function generateMetadata(
     : `${data.videos.length}作品のいいねリスト。`;
 
   const listTitle = data.title ?? `${name}のお気に入りリスト`;
+
+  // 先頭作品のサムネイルをOGP画像に使用
+  const ogImage = data.videos[0]?.thumbnail_url ?? null;
+
   return {
     title: `${listTitle} | 性癖ラボ`,
     description,
@@ -124,8 +128,15 @@ export async function generateMetadata(
       url: `${SITE_URL}/list/${token}`,
       siteName: '性癖ラボ',
       type: 'website',
+      ...(ogImage ? { images: [{ url: ogImage, width: 800, height: 450, alt: listTitle }] } : {}),
     },
-    robots: { index: false, follow: false },
+    twitter: {
+      card: ogImage ? 'summary_large_image' : 'summary',
+      title: `${listTitle} | 性癖ラボ`,
+      description,
+      ...(ogImage ? { images: [ogImage] } : {}),
+    },
+    robots: { index: true, follow: true },
   };
 }
 
@@ -167,7 +178,20 @@ export default async function PublicListPage(
               initialLikeCount={data.like_count}
             />
           </div>
-          <CopyLinkButton url={pageUrl} />
+          <div className="flex items-center gap-2 shrink-0">
+            <a
+              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(`${data.title ?? (name ? `${name}のお気に入りリスト` : 'お気に入りリスト')} | 性癖ラボ`)}&url=${encodeURIComponent(pageUrl)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-[#161b22] border border-[#30363d] hover:border-[#8b949e] text-[#8b949e] hover:text-[#e6edf3] text-xs font-semibold transition-colors"
+            >
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.258 5.63 5.906-5.63zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+              </svg>
+              シェア
+            </a>
+            <CopyLinkButton url={pageUrl} />
+          </div>
         </div>
 
         {/* 作者のリスト一覧へ */}

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -116,9 +116,6 @@ export async function generateMetadata(
 
   const listTitle = data.title ?? `${name}のお気に入りリスト`;
 
-  // 先頭作品のサムネイルをOGP画像に使用
-  const ogImage = data.videos[0]?.thumbnail_url ?? null;
-
   return {
     title: `${listTitle} | 性癖ラボ`,
     description,
@@ -128,13 +125,11 @@ export async function generateMetadata(
       url: `${SITE_URL}/list/${token}`,
       siteName: '性癖ラボ',
       type: 'website',
-      ...(ogImage ? { images: [{ url: ogImage, width: 800, height: 450, alt: listTitle }] } : {}),
     },
     twitter: {
-      card: ogImage ? 'summary_large_image' : 'summary',
+      card: 'summary_large_image',
       title: `${listTitle} | 性癖ラボ`,
       description,
-      ...(ogImage ? { images: [ogImage] } : {}),
     },
     robots: { index: true, follow: true },
   };

--- a/frontend/src/app/u/[username]/page.tsx
+++ b/frontend/src/app/u/[username]/page.tsx
@@ -31,17 +31,29 @@ export async function generateMetadata(
   const data = await fetchUserLists(username);
   if (!data) return { title: 'ユーザーが見つかりません | 性癖ラボ' };
 
+  const description = data.bio
+    ? `${data.bio} | ${data.lists.length}件のリスト`
+    : `${data.display_name}が作成した${data.lists.length}件のリスト`;
+  const ogImage = data.avatar_url ?? data.lists[0]?.thumbnails?.[0] ?? null;
+
   return {
     title: `${data.display_name}のリスト一覧 | 性癖ラボ`,
-    description: `${data.display_name}が作成した${data.lists.length}件のリスト`,
+    description,
     openGraph: {
       title: `${data.display_name}のリスト一覧 | 性癖ラボ`,
-      description: `${data.display_name}が作成した${data.lists.length}件のリスト`,
+      description,
       url: `${SITE_URL}/u/${username}`,
       siteName: '性癖ラボ',
-      type: 'website',
+      type: 'profile',
+      ...(ogImage ? { images: [{ url: ogImage, width: 400, height: 400, alt: data.display_name }] } : {}),
     },
-    robots: { index: false, follow: false },
+    twitter: {
+      card: ogImage ? 'summary' : 'summary',
+      title: `${data.display_name}のリスト一覧 | 性癖ラボ`,
+      description,
+      ...(ogImage ? { images: [ogImage] } : {}),
+    },
+    robots: { index: true, follow: true },
   };
 }
 


### PR DESCRIPTION
## 変更内容

### OGP改善
- リスト詳細ページ: 先頭作品のサムネイルをOGP画像に設定
- プロフィールページ: アバターまたはリストサムネイルをOGP画像に設定
- `robots: index: false` → `index: true` に変更（検索・SNS流入を有効化）
- Twitter Card を `summary_large_image` に設定

### Xシェアボタン追加
- リスト詳細ページにXシェアボタンを追加
- ツイート文にリストタイトルとURLが自動入力される

## 効果
XでリストURLをシェアしたとき、作品サムネイルがカード展開されるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)