### PR TITLE
fix: FANZA_AMATEUR サムネイル低画質問題を修正

### DIFF
--- a/frontend/src/utils/thumbnail.ts
+++ b/frontend/src/utils/thumbnail.ts
@@ -9,9 +9,19 @@ function toAmateurLargeUrl(jsUrl: string): string {
 }
 
 /**
+ * FANZA_AMATEUR の thumbnail_url（jm.jpg）を jp-001.jpg（大サイズ）に変換する。
+ * image_urls が未取得の場合のフォールバック。
+ */
+function amateurThumbToLarge(thumbnailUrl: string): string {
+  // gerk657jm.jpg → gerk657jp-001.jpg
+  return thumbnailUrl.replace(/([^/]+)jm\.jpg$/, '$1jp-001.jpg');
+}
+
+/**
  * 動画データから表示用サムネイルURLを返す。
  * FANZA_AMATEUR は thumbnail_url が now_printing にリダイレクトされるケースが多いため、
  * image_urls[0] から生成した大サイズ（jp）URLを primary、元の js URL を fallback として返す。
+ * image_urls が null の場合は thumbnail_url の jm→jp-001 変換を試みる。
  */
 export function resolveThumbnail(params: {
   source?: string | null;
@@ -20,12 +30,21 @@ export function resolveThumbnail(params: {
 }): { primary: string | null; fallback: string | null } {
   const { source, thumbnail_url, image_urls } = params;
 
-  if (source === 'FANZA_AMATEUR' && image_urls?.[0]) {
-    const jsUrl = image_urls[0];
-    return {
-      primary: toAmateurLargeUrl(jsUrl),
-      fallback: jsUrl,
-    };
+  if (source === 'FANZA_AMATEUR') {
+    if (image_urls?.[0]) {
+      const jsUrl = image_urls[0];
+      return {
+        primary: toAmateurLargeUrl(jsUrl),
+        fallback: jsUrl,
+      };
+    }
+    // image_urls が未取得の場合、thumbnail_url の jm→jp-001 変換を試みる
+    if (thumbnail_url?.includes('jm.jpg')) {
+      return {
+        primary: amateurThumbToLarge(thumbnail_url),
+        fallback: thumbnail_url,
+      };
+    }
   }
 
   return { primary: thumbnail_url ?? null, fallback: null };

--- a/scripts/ingest_fanza/index.ts
+++ b/scripts/ingest_fanza/index.ts
@@ -487,10 +487,16 @@ async function ingestSource(
         sm.size_476_306
       );
 
-      const imageUrls: string[] | null = coalesce(
+      let imageUrls: string[] | null = coalesce(
         item.sampleImageURL?.sample_l?.image,
         item.sampleImageURL?.sample_s?.image
       );
+      // FANZA_AMATEUR は sampleImageURL が返らないケースがある。
+      // thumbnail_url から js-001〜js-005 を生成してフォールバックとする。
+      if (!imageUrls && source === 'FANZA_AMATEUR' && item.imageURL?.list) {
+        const base = (item.imageURL.list as string).replace(/jm\.jpg$/, '');
+        imageUrls = [1, 2, 3, 4, 5].map((n) => `${base}js-${String(n).padStart(3, '0')}.jpg`);
+      }
       const horizontalThumbnail: string | null = coalesce(
         item.imageURL?.large,
         item.imageURL?.list,

--- a/supabase/migrations/20260612250000_backfill_fanza_amateur_image_urls.sql
+++ b/supabase/migrations/20260612250000_backfill_fanza_amateur_image_urls.sql
@@ -1,0 +1,14 @@
+-- FANZA_AMATEUR の image_urls が null のレコードを thumbnail_url から生成して補完する。
+-- thumbnail_url パターン: https://pics.dmm.co.jp/digital/amateur/<code>/<code>jm.jpg
+-- → js-001〜js-005 の配列を image_urls に設定する。
+UPDATE public.videos
+SET image_urls = ARRAY[
+  regexp_replace(thumbnail_url, 'jm\.jpg$', 'js-001.jpg'),
+  regexp_replace(thumbnail_url, 'jm\.jpg$', 'js-002.jpg'),
+  regexp_replace(thumbnail_url, 'jm\.jpg$', 'js-003.jpg'),
+  regexp_replace(thumbnail_url, 'jm\.jpg$', 'js-004.jpg'),
+  regexp_replace(thumbnail_url, 'jm\.jpg$', 'js-005.jpg')
+]
+WHERE source = 'FANZA_AMATEUR'
+  AND image_urls IS NULL
+  AND thumbnail_url LIKE '%jm.jpg';


### PR DESCRIPTION
## Summary

- `thumbnail.ts`: `image_urls` が null の FANZA_AMATEUR に対し、`thumbnail_url` の `jm.jpg` → `jp-001.jpg` 変換フォールバックを追加
- `ingest_fanza`: `sampleImageURL` が返らない FANZA_AMATEUR の場合、`imageURL.list` から `js-001〜005` を生成して `image_urls` に保存するよう修正
- migration: 既存の `image_urls=null` だった全 7,695 件を `thumbnail_url` から補完するバックフィル（リモート適用済み）

## Test plan

- [ ] 「さがす」画面で FANZA_AMATEUR の画像が高画質になっていることを確認
- [ ] LikedVideosDrawer（いいねした作品）でも高画質になっていることを確認
- [ ] 通常 FANZA の画像に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)