### PR TITLE
feat: リストセクション基盤とランキング表示を実装

### DIFF
--- a/frontend/src/app/list/[token]/ListReorderMode.tsx
+++ b/frontend/src/app/list/[token]/ListReorderMode.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { GripVertical, ChevronUp, ChevronDown, Save, X, Plus, Trash2, Loader2 } from 'lucide-react';
+import { supabase } from '@/lib/supabase';
+
+type Video = {
+  id: string;
+  title: string | null;
+  thumbnail_url: string | null;
+  sort_order: number | null;
+  section_id: string | null;
+};
+
+type Section = {
+  id: string;
+  title: string | null;
+  display_mode: 'ranked' | 'plain';
+  sort_order: number;
+};
+
+interface Props {
+  ownerUserId: string;
+  listId: string;
+  videos: Video[];
+  sections: Section[];
+  token: string;
+}
+
+export default function ListReorderMode({ ownerUserId, listId, videos, sections: initialSections, token }: Props) {
+  const router = useRouter();
+  const [isOwner, setIsOwner] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // 編集中の状態
+  const [orderedVideos, setOrderedVideos] = useState<Video[]>([]);
+  const [sections, setSections] = useState<Section[]>([]);
+  const [newSectionTitle, setNewSectionTitle] = useState('');
+  const [addingSection, setAddingSection] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setIsOwner(!!user && user.id === ownerUserId);
+    });
+  }, [ownerUserId]);
+
+  const openReorder = useCallback(() => {
+    // sort_order でソートして編集バッファに読み込む
+    const sorted = [...videos].sort((a, b) => {
+      if (a.sort_order === null && b.sort_order === null) return 0;
+      if (a.sort_order === null) return 1;
+      if (b.sort_order === null) return -1;
+      return a.sort_order - b.sort_order;
+    });
+    setOrderedVideos(sorted);
+    setSections([...initialSections].sort((a, b) => a.sort_order - b.sort_order));
+    setIsOpen(true);
+  }, [videos, initialSections]);
+
+  const moveVideo = useCallback((index: number, dir: -1 | 1) => {
+    setOrderedVideos(prev => {
+      const next = [...prev];
+      const target = index + dir;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  }, []);
+
+  const assignSection = useCallback((videoId: string, sectionId: string | null) => {
+    setOrderedVideos(prev => prev.map(v => v.id === videoId ? { ...v, section_id: sectionId } : v));
+  }, []);
+
+  const addSection = useCallback(async () => {
+    if (!newSectionTitle.trim()) return;
+    setAddingSection(true);
+    const { data, error } = await supabase.rpc('upsert_list_section', {
+      p_list_id: listId,
+      p_section_id: null,
+      p_title: newSectionTitle.trim(),
+      p_sort_order: sections.length,
+    });
+    setAddingSection(false);
+    if (error) { alert('セクション作成に失敗しました: ' + error.message); return; }
+    setSections(prev => [...prev, {
+      id: data as string,
+      title: newSectionTitle.trim(),
+      display_mode: 'ranked',
+      sort_order: prev.length,
+    }]);
+    setNewSectionTitle('');
+  }, [newSectionTitle, listId, sections.length]);
+
+  const deleteSection = useCallback(async (sectionId: string) => {
+    const { error } = await supabase.rpc('delete_list_section', { p_section_id: sectionId });
+    if (error) { alert('セクション削除に失敗しました: ' + error.message); return; }
+    setSections(prev => prev.filter(s => s.id !== sectionId));
+    // そのセクションに属していた動画を未分類に戻す
+    setOrderedVideos(prev => prev.map(v => v.section_id === sectionId ? { ...v, section_id: null } : v));
+  }, []);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    try {
+      // 並び順を保存
+      const videoIds = orderedVideos.map(v => v.id);
+      const { error: reorderErr } = await supabase.rpc('reorder_list_videos', {
+        p_list_id: listId,
+        p_video_ids: videoIds,
+      });
+      if (reorderErr) throw reorderErr;
+
+      // セクション割り当てを保存
+      for (const video of orderedVideos) {
+        const original = videos.find(v => v.id === video.id);
+        if (original?.section_id !== video.section_id) {
+          const { error } = await supabase.rpc('assign_video_section', {
+            p_list_id: listId,
+            p_video_id: video.id,
+            p_section_id: video.section_id,
+          });
+          if (error) throw error;
+        }
+      }
+
+      setIsOpen(false);
+      router.refresh();
+    } catch (err: unknown) {
+      alert('保存に失敗しました: ' + (err instanceof Error ? err.message : String(err)));
+    } finally {
+      setSaving(false);
+    }
+  }, [orderedVideos, listId, videos, router]);
+
+  if (!isOwner) return null;
+
+  if (!isOpen) {
+    return (
+      <div className="mb-4 flex justify-end">
+        <button
+          onClick={openReorder}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-[#30363d] hover:border-[#8b949e] text-[#8b949e] hover:text-[#e6edf3] text-xs font-semibold transition-colors"
+        >
+          <GripVertical size={13} />
+          並べ替え・セクション
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6 rounded-xl border border-violet-500/40 bg-[#0d1117] overflow-hidden">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between px-4 py-3 bg-violet-500/10 border-b border-violet-500/30">
+        <span className="text-sm font-bold text-violet-300">並べ替え・セクション管理</span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={save}
+            disabled={saving}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-600 hover:bg-violet-500 disabled:opacity-60 text-white text-xs font-bold transition-colors"
+          >
+            {saving ? <Loader2 size={12} className="animate-spin" /> : <Save size={12} />}
+            保存
+          </button>
+          <button
+            onClick={() => setIsOpen(false)}
+            className="p-1.5 rounded-lg hover:bg-[#21262d] text-[#656d76] hover:text-[#e6edf3] transition-colors"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="p-4 space-y-6">
+        {/* セクション管理 */}
+        <div>
+          <p className="text-xs font-semibold text-[#656d76] uppercase tracking-wider mb-3">セクション</p>
+          <div className="space-y-2 mb-3">
+            {sections.length === 0 && (
+              <p className="text-xs text-[#484f58]">セクションなし（フラットなランキング）</p>
+            )}
+            {sections.map(section => (
+              <div key={section.id} className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[#161b22] border border-[#30363d]">
+                <span className="text-sm text-[#e6edf3] flex-1">{section.title ?? '無題'}</span>
+                <span className="text-xs text-[#484f58]">{section.display_mode === 'ranked' ? 'ランキング' : 'プレーン'}</span>
+                <button
+                  onClick={() => deleteSection(section.id)}
+                  className="p-1 rounded hover:bg-red-500/20 text-[#656d76] hover:text-red-400 transition-colors"
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            ))}
+          </div>
+          {/* 新規セクション追加 */}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={newSectionTitle}
+              onChange={e => setNewSectionTitle(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && addSection()}
+              placeholder="新しいセクション名"
+              className="flex-1 px-3 py-1.5 rounded-lg bg-[#161b22] border border-[#30363d] focus:border-violet-500/60 outline-none text-xs text-[#e6edf3] placeholder-[#484f58]"
+            />
+            <button
+              onClick={addSection}
+              disabled={addingSection || !newSectionTitle.trim()}
+              className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-violet-300 disabled:opacity-40 text-xs font-semibold transition-colors"
+            >
+              {addingSection ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+              追加
+            </button>
+          </div>
+        </div>
+
+        {/* 動画の並べ替え */}
+        <div>
+          <p className="text-xs font-semibold text-[#656d76] uppercase tracking-wider mb-3">動画の順序</p>
+          <div className="space-y-1.5 max-h-[60vh] overflow-y-auto pr-1">
+            {orderedVideos.map((video, i) => (
+              <div key={video.id} className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[#161b22] border border-[#21262d]">
+                {/* ランク番号 */}
+                <span className="text-xs font-black text-violet-400 w-6 text-right shrink-0">#{i + 1}</span>
+
+                {/* タイトル */}
+                <span className="text-xs text-[#8b949e] flex-1 line-clamp-1 min-w-0">
+                  {video.title ?? '(タイトルなし)'}
+                </span>
+
+                {/* セクション割り当て */}
+                {sections.length > 0 && (
+                  <select
+                    value={video.section_id ?? ''}
+                    onChange={e => assignSection(video.id, e.target.value || null)}
+                    className="text-xs bg-[#0d1117] border border-[#30363d] rounded px-1.5 py-0.5 text-[#8b949e] max-w-[100px]"
+                  >
+                    <option value="">未分類</option>
+                    {sections.map(s => (
+                      <option key={s.id} value={s.id}>{s.title ?? '無題'}</option>
+                    ))}
+                  </select>
+                )}
+
+                {/* 上下ボタン */}
+                <div className="flex flex-col gap-0.5 shrink-0">
+                  <button
+                    onClick={() => moveVideo(i, -1)}
+                    disabled={i === 0}
+                    className="p-0.5 rounded hover:bg-[#30363d] text-[#484f58] hover:text-[#e6edf3] disabled:opacity-20 transition-colors"
+                  >
+                    <ChevronUp size={13} />
+                  </button>
+                  <button
+                    onClick={() => moveVideo(i, 1)}
+                    disabled={i === orderedVideos.length - 1}
+                    className="p-0.5 rounded hover:bg-[#30363d] text-[#484f58] hover:text-[#e6edf3] disabled:opacity-20 transition-colors"
+                  >
+                    <ChevronDown size={13} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/list/[token]/page.tsx
+++ b/frontend/src/app/list/[token]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { supabase } from '@/lib/supabase';
 import CopyLinkButton from './CopyLinkButton';
 import ListEditMode, { VideoDeleteButton } from './ListEditMode';
+import ListReorderMode from './ListReorderMode';
 import ListStats from './ListStats';
 import { resolveThumbnail } from '@/utils/thumbnail';
 
@@ -22,6 +23,15 @@ type Video = {
   liked_at: string;
   source?: string | null;
   image_urls?: string[] | null;
+  sort_order: number | null;
+  section_id: string | null;
+};
+
+type Section = {
+  id: string;
+  title: string | null;
+  display_mode: 'ranked' | 'plain';
+  sort_order: number;
 };
 
 type TagStat = { tag_name: string; cnt: number };
@@ -41,6 +51,7 @@ type ListData = {
   videos: Video[];
   tags: TagStat[];
   performers: PerformerStat[];
+  sections: Section[];
 };
 
 function toAffiliateUrl(raw?: string | null, source?: string | null, curatorFanzaId?: string | null, curatorMgsId?: string | null): string {
@@ -115,7 +126,6 @@ export async function generateMetadata(
     : `${data.videos.length}作品のいいねリスト。`;
 
   const listTitle = data.title ?? `${name}のお気に入りリスト`;
-  // OGタイトル: {リスト名} | {キュレーター名}
   const ogTitle = name ? `${listTitle} | ${name}` : `${listTitle} | 性癖ラボ`;
 
   return {
@@ -137,6 +147,68 @@ export async function generateMetadata(
   };
 }
 
+function VideoCard({
+  video,
+  affiliateUrl,
+  rank,
+  ownerUserId,
+  listId,
+  listType,
+}: {
+  video: Video;
+  affiliateUrl: string;
+  rank: number | null;
+  ownerUserId: string;
+  listId: string;
+  listType: 'liked' | 'custom';
+}) {
+  const { primary: resolvedThumb } = resolveThumbnail({ source: video.source, thumbnail_url: video.thumbnail_url, image_urls: video.image_urls });
+  const thumb = resolvedThumb ?? toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
+  return (
+    <div className="group relative mb-3 break-inside-avoid">
+      <a
+        href={affiliateUrl || '#'}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22]"
+      >
+        <div className="relative">
+          {thumb ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={thumb}
+              alt={video.title ?? ''}
+              className="w-full h-auto group-hover:opacity-90 transition-opacity"
+              loading="lazy"
+            />
+          ) : (
+            <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
+              <span className="text-[#484f58] text-xs">No Image</span>
+            </div>
+          )}
+          {rank !== null && (
+            <div className="absolute top-1.5 left-1.5 min-w-[22px] h-[22px] px-1.5 rounded-md bg-black/70 backdrop-blur flex items-center justify-center">
+              <span className="text-[11px] font-black text-violet-300">#{rank}</span>
+            </div>
+          )}
+        </div>
+        <div className="p-2">
+          <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
+            {video.title ?? ''}
+          </p>
+        </div>
+      </a>
+      {listType === 'custom' && (
+        <VideoDeleteButton
+          ownerUserId={ownerUserId}
+          listId={listId}
+          videoId={video.id}
+        />
+      )}
+    </div>
+  );
+}
+
 export default async function PublicListPage(
   { params }: { params: Promise<{ token: string }> }
 ) {
@@ -147,6 +219,24 @@ export default async function PublicListPage(
   const name = data.display_name;
   const pageUrl = `${SITE_URL}/list/${token}`;
   const filteredTags = filterTags(data.tags);
+  const sections = data.sections ?? [];
+
+  // セクションIDで動画をグループ化（section_id=null は「未分類」）
+  const sectionMap = new Map<string | null, Video[]>();
+  sectionMap.set(null, []);
+  for (const s of sections) sectionMap.set(s.id, []);
+  for (const v of data.videos) {
+    const key = v.section_id ?? null;
+    if (!sectionMap.has(key)) sectionMap.set(key, []);
+    sectionMap.get(key)!.push(v);
+  }
+
+  // セクションなし（liked リストまたはまだセクション未作成）はフラット表示
+  const isFlat = sections.length === 0;
+
+  // フラット時：sort_order が設定されていればランキング表示
+  const flatVideos = data.videos;
+  const flatIsRanked = data.list_type === 'custom' && flatVideos.some(v => v.sort_order !== null);
 
   return (
     <div className="min-h-screen bg-[#0d1117] text-[#e6edf3]">
@@ -212,7 +302,7 @@ export default async function PublicListPage(
           </Link>
         )}
 
-        {/* 編集モードバナー＋動画追加ボタン（オーナーのみ表示） */}
+        {/* 編集モード（オーナーのみ） */}
         <ListEditMode
           ownerUserId={data.user_id}
           listId={data.list_id}
@@ -220,6 +310,17 @@ export default async function PublicListPage(
           listTitle={data.title}
           token={token}
         />
+
+        {/* 並べ替え＆セクション管理（オーナー＆カスタムリストのみ） */}
+        {data.list_type === 'custom' && (
+          <ListReorderMode
+            ownerUserId={data.user_id}
+            listId={data.list_id}
+            videos={data.videos}
+            sections={sections}
+            token={token}
+          />
+        )}
 
         {/* 好きなジャンルランキング */}
         {filteredTags.length > 0 && (
@@ -266,50 +367,72 @@ export default async function PublicListPage(
         {/* 作品グリッド */}
         {data.videos.length === 0 ? (
           <p className="text-center text-[#656d76] py-20">まだ作品がありません。</p>
-        ) : (
+        ) : isFlat ? (
+          /* セクションなし：フラット表示（ランキングバッジ付き） */
           <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
-            {data.videos.map((video) => {
-              const affiliateUrl = toAffiliateUrl(video.product_url, video.source, data.affiliate_fanza_id, data.affiliate_mgs_id);
-              const { primary: resolvedThumb } = resolveThumbnail({ source: video.source, thumbnail_url: video.thumbnail_url, image_urls: video.image_urls });
-              const thumb = resolvedThumb ?? toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
+            {flatVideos.map((video, i) => (
+              <VideoCard
+                key={video.id}
+                video={video}
+                affiliateUrl={toAffiliateUrl(video.product_url, video.source, data.affiliate_fanza_id, data.affiliate_mgs_id)}
+                rank={flatIsRanked ? i + 1 : null}
+                ownerUserId={data.user_id}
+                listId={data.list_id}
+                listType={data.list_type}
+              />
+            ))}
+          </div>
+        ) : (
+          /* セクションあり：セクション別に表示 */
+          <div className="space-y-10">
+            {sections.map((section) => {
+              const sectionVideos = sectionMap.get(section.id) ?? [];
+              const isRanked = section.display_mode === 'ranked';
+              if (sectionVideos.length === 0) return null;
               return (
-                <div key={video.id} className="group relative mb-3 break-inside-avoid">
-                  <a
-                    href={affiliateUrl || '#'}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="block rounded-lg overflow-hidden border border-[#21262d] hover:border-violet-500/50 transition-colors bg-[#161b22]"
-                  >
-                    {thumb ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={thumb}
-                        alt={video.title ?? ''}
-                        className="w-full h-auto group-hover:opacity-90 transition-opacity"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
-                        <span className="text-[#484f58] text-xs">No Image</span>
-                      </div>
-                    )}
-                    <div className="p-2">
-                      <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
-                        {video.title ?? ''}
-                      </p>
-                    </div>
-                  </a>
-                  {/* 削除ボタン（オーナー＆カスタムリストのみ） */}
-                  {data.list_type === 'custom' && (
-                    <VideoDeleteButton
-                      ownerUserId={data.user_id}
-                      listId={data.list_id}
-                      videoId={video.id}
-                    />
+                <div key={section.id}>
+                  {section.title && (
+                    <h2 className="text-sm font-bold text-[#8b949e] uppercase tracking-wider mb-4 pb-2 border-b border-[#21262d]">
+                      {section.title}
+                    </h2>
                   )}
+                  <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
+                    {sectionVideos.map((video, i) => (
+                      <VideoCard
+                        key={video.id}
+                        video={video}
+                        affiliateUrl={toAffiliateUrl(video.product_url, video.source, data.affiliate_fanza_id, data.affiliate_mgs_id)}
+                        rank={isRanked ? i + 1 : null}
+                        ownerUserId={data.user_id}
+                        listId={data.list_id}
+                        listType={data.list_type}
+                      />
+                    ))}
+                  </div>
                 </div>
               );
             })}
+            {/* 未分類（どのセクションにも属さない動画） */}
+            {(sectionMap.get(null) ?? []).length > 0 && (
+              <div>
+                <h2 className="text-sm font-bold text-[#484f58] uppercase tracking-wider mb-4 pb-2 border-b border-[#21262d]">
+                  未分類
+                </h2>
+                <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
+                  {(sectionMap.get(null) ?? []).map((video) => (
+                    <VideoCard
+                      key={video.id}
+                      video={video}
+                      affiliateUrl={toAffiliateUrl(video.product_url, video.source, data.affiliate_fanza_id, data.affiliate_mgs_id)}
+                      rank={null}
+                      ownerUserId={data.user_id}
+                      listId={data.list_id}
+                      listType={data.list_type}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
 

--- a/supabase/migrations/20260615100000_add_list_sections.sql
+++ b/supabase/migrations/20260615100000_add_list_sections.sql
@@ -1,0 +1,36 @@
+-- =============================================
+-- リストセクション機能
+-- ランキングはセクションの1表示形態（display_mode='ranked'）
+-- =============================================
+
+CREATE TABLE IF NOT EXISTS public.public_list_sections (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  list_id      uuid        NOT NULL REFERENCES public.public_lists(id) ON DELETE CASCADE,
+  title        text,
+  display_mode text        NOT NULL DEFAULT 'ranked'
+                           CHECK (display_mode IN ('ranked', 'plain')),
+  sort_order   integer     NOT NULL DEFAULT 0,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_public_list_sections_list
+  ON public.public_list_sections(list_id, sort_order);
+
+ALTER TABLE public.public_list_videos
+  ADD COLUMN IF NOT EXISTS section_id uuid
+  REFERENCES public.public_list_sections(id) ON DELETE SET NULL;
+
+ALTER TABLE public.public_list_sections ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "sections_select" ON public.public_list_sections FOR SELECT USING (
+  EXISTS (SELECT 1 FROM public.public_lists pl WHERE pl.id = list_id AND pl.is_active = true)
+);
+CREATE POLICY "sections_insert" ON public.public_list_sections FOR INSERT WITH CHECK (
+  EXISTS (SELECT 1 FROM public.public_lists pl WHERE pl.id = list_id AND pl.user_id = auth.uid())
+);
+CREATE POLICY "sections_update" ON public.public_list_sections FOR UPDATE USING (
+  EXISTS (SELECT 1 FROM public.public_lists pl WHERE pl.id = list_id AND pl.user_id = auth.uid())
+);
+CREATE POLICY "sections_delete" ON public.public_list_sections FOR DELETE USING (
+  EXISTS (SELECT 1 FROM public.public_lists pl WHERE pl.id = list_id AND pl.user_id = auth.uid())
+);

--- a/supabase/migrations/20260615110000_add_list_section_rpcs.sql
+++ b/supabase/migrations/20260615110000_add_list_section_rpcs.sql
@@ -1,0 +1,101 @@
+-- =============================================
+-- セクション管理 & 並べ替え RPC
+-- =============================================
+
+-- セクション作成・更新
+CREATE OR REPLACE FUNCTION public.upsert_list_section(
+  p_list_id    uuid,
+  p_section_id uuid,    -- NULL で新規作成
+  p_title      text,
+  p_sort_order integer
+) RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_owner_id uuid;
+  v_id       uuid;
+BEGIN
+  SELECT user_id INTO v_owner_id FROM public.public_lists WHERE id = p_list_id;
+  IF v_owner_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'permission_denied';
+  END IF;
+
+  IF p_section_id IS NULL THEN
+    INSERT INTO public.public_list_sections(list_id, title, sort_order)
+    VALUES (p_list_id, p_title, p_sort_order)
+    RETURNING id INTO v_id;
+  ELSE
+    UPDATE public.public_list_sections
+    SET title = p_title, sort_order = p_sort_order
+    WHERE id = p_section_id AND list_id = p_list_id
+    RETURNING id INTO v_id;
+  END IF;
+
+  RETURN v_id;
+END;
+$$;
+
+-- セクション削除（動画の section_id は ON DELETE SET NULL で自動 NULL 化）
+CREATE OR REPLACE FUNCTION public.delete_list_section(
+  p_section_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_owner_id uuid;
+BEGIN
+  SELECT pl.user_id INTO v_owner_id
+  FROM public.public_list_sections s
+  JOIN public.public_lists pl ON pl.id = s.list_id
+  WHERE s.id = p_section_id;
+
+  IF v_owner_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'permission_denied';
+  END IF;
+
+  DELETE FROM public.public_list_sections WHERE id = p_section_id;
+END;
+$$;
+
+-- セクション内の動画を一括並べ替え
+-- p_video_ids: 新しい順序の video_id 配列（先頭が sort_order=0）
+CREATE OR REPLACE FUNCTION public.reorder_list_videos(
+  p_list_id   uuid,
+  p_video_ids uuid[]
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_owner_id uuid;
+  i          integer;
+BEGIN
+  SELECT user_id INTO v_owner_id FROM public.public_lists WHERE id = p_list_id;
+  IF v_owner_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'permission_denied';
+  END IF;
+
+  FOR i IN 1..array_length(p_video_ids, 1) LOOP
+    UPDATE public.public_list_videos
+    SET sort_order = i - 1
+    WHERE list_id = p_list_id AND video_id = p_video_ids[i];
+  END LOOP;
+END;
+$$;
+
+-- 動画をセクションに割り当て
+CREATE OR REPLACE FUNCTION public.assign_video_section(
+  p_list_id    uuid,
+  p_video_id   uuid,
+  p_section_id uuid   -- NULL で未分類に戻す
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_owner_id uuid;
+BEGIN
+  SELECT user_id INTO v_owner_id FROM public.public_lists WHERE id = p_list_id;
+  IF v_owner_id IS DISTINCT FROM auth.uid() THEN
+    RAISE EXCEPTION 'permission_denied';
+  END IF;
+
+  UPDATE public.public_list_videos
+  SET section_id = p_section_id
+  WHERE list_id = p_list_id AND video_id = p_video_id;
+END;
+$$;

--- a/supabase/migrations/20260615120000_update_get_public_list_data_add_sections.sql
+++ b/supabase/migrations/20260615120000_update_get_public_list_data_add_sections.sql
@@ -1,0 +1,149 @@
+-- get_public_list_data に sections と sort_order/section_id を追加
+CREATE OR REPLACE FUNCTION public.get_public_list_data(p_token text)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_list_id            uuid;
+  v_user_id            uuid;
+  v_title              text;
+  v_desc               text;
+  v_list_type          text;
+  v_view_count         bigint;
+  v_display_name       text;
+  v_username           text;
+  v_affiliate_fanza_id text;
+  v_affiliate_fc2_id   text;
+  v_affiliate_mgs_id   text;
+  v_like_count         bigint;
+  v_videos             json;
+  v_tags               json;
+  v_performers         json;
+  v_sections           json;
+BEGIN
+  SELECT id, user_id, title, description, list_type, view_count
+  INTO v_list_id, v_user_id, v_title, v_desc, v_list_type, v_view_count
+  FROM public.public_lists
+  WHERE token = p_token AND is_active = true;
+
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('error', 'not_found');
+  END IF;
+
+  SELECT
+    COALESCE(u.raw_user_meta_data->>'display_name', ''),
+    u.raw_user_meta_data->>'username',
+    up.affiliate_fanza_id,
+    up.affiliate_fc2_id,
+    up.affiliate_mgs_id
+  INTO v_display_name, v_username, v_affiliate_fanza_id, v_affiliate_fc2_id, v_affiliate_mgs_id
+  FROM auth.users u
+  LEFT JOIN public.user_profiles up ON up.user_id = u.id
+  WHERE u.id = v_user_id;
+
+  SELECT COUNT(*) INTO v_like_count FROM public.list_likes WHERE list_id = v_list_id;
+
+  -- セクション一覧
+  SELECT json_agg(row_to_json(s) ORDER BY s.sort_order) INTO v_sections
+  FROM (
+    SELECT id, title, display_mode, sort_order
+    FROM public.public_list_sections
+    WHERE list_id = v_list_id
+  ) s;
+
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(v)) INTO v_videos
+    FROM (
+      SELECT vi.id, vi.title, vi.external_id, vi.thumbnail_url,
+             vi.thumbnail_vertical_url, vi.product_url, vi.source, vi.image_urls,
+             plv.added_at AS liked_at,
+             plv.sort_order,
+             plv.section_id
+      FROM public.public_list_videos plv
+      JOIN public.videos vi ON vi.id = plv.video_id
+      WHERE plv.list_id = v_list_id AND vi.external_id IS NOT NULL
+      ORDER BY plv.section_id NULLS LAST, plv.sort_order, plv.added_at DESC
+      LIMIT 200
+    ) v;
+  ELSE
+    SELECT json_agg(row_to_json(v)) INTO v_videos
+    FROM (
+      SELECT vi.id, vi.title, vi.external_id, vi.thumbnail_url,
+             vi.thumbnail_vertical_url, vi.product_url, vi.source, vi.image_urls,
+             uvd.created_at AS liked_at,
+             NULL::integer AS sort_order,
+             NULL::uuid AS section_id
+      FROM public.user_video_decisions uvd
+      JOIN public.videos vi ON vi.id = uvd.video_id
+      WHERE uvd.user_id = v_user_id
+        AND uvd.decision_type IN ('swipe_like', 'grid_like')
+        AND vi.external_id IS NOT NULL
+      ORDER BY uvd.created_at DESC
+    ) v;
+  END IF;
+
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(t)) INTO v_tags
+    FROM (
+      SELECT tg.name AS tag_name, COUNT(*) AS cnt
+      FROM public.public_list_videos plv
+      JOIN public.video_tags vt ON vt.video_id = plv.video_id
+      JOIN public.tags tg ON tg.id = vt.tag_id
+      WHERE plv.list_id = v_list_id
+      GROUP BY tg.name ORDER BY cnt DESC LIMIT 12
+    ) t;
+  ELSE
+    SELECT json_agg(row_to_json(t)) INTO v_tags
+    FROM (
+      SELECT tg.name AS tag_name, COUNT(*) AS cnt
+      FROM public.user_video_decisions uvd
+      JOIN public.video_tags vt ON vt.video_id = uvd.video_id
+      JOIN public.tags tg ON tg.id = vt.tag_id
+      WHERE uvd.user_id = v_user_id AND uvd.decision_type IN ('swipe_like', 'grid_like')
+      GROUP BY tg.name ORDER BY cnt DESC LIMIT 12
+    ) t;
+  END IF;
+
+  IF v_list_type = 'custom' THEN
+    SELECT json_agg(row_to_json(p)) INTO v_performers
+    FROM (
+      SELECT pf.name AS performer_name, COUNT(*) AS cnt
+      FROM public.public_list_videos plv
+      JOIN public.video_performers vp ON vp.video_id = plv.video_id
+      JOIN public.performers pf ON pf.id = vp.performer_id
+      WHERE plv.list_id = v_list_id
+      GROUP BY pf.name ORDER BY cnt DESC LIMIT 10
+    ) p;
+  ELSE
+    SELECT json_agg(row_to_json(p)) INTO v_performers
+    FROM (
+      SELECT pf.name AS performer_name, COUNT(*) AS cnt
+      FROM public.user_video_decisions uvd
+      JOIN public.video_performers vp ON vp.video_id = uvd.video_id
+      JOIN public.performers pf ON pf.id = vp.performer_id
+      WHERE uvd.user_id = v_user_id AND uvd.decision_type IN ('swipe_like', 'grid_like')
+      GROUP BY pf.name ORDER BY cnt DESC LIMIT 10
+    ) p;
+  END IF;
+
+  RETURN json_build_object(
+    'list_id',             v_list_id,
+    'user_id',             v_user_id,
+    'display_name',        v_display_name,
+    'username',            v_username,
+    'affiliate_fanza_id',  v_affiliate_fanza_id,
+    'affiliate_fc2_id',    v_affiliate_fc2_id,
+    'affiliate_mgs_id',    v_affiliate_mgs_id,
+    'title',               v_title,
+    'description',         v_desc,
+    'list_type',           v_list_type,
+    'view_count',          COALESCE(v_view_count, 0),
+    'like_count',          v_like_count,
+    'videos',              COALESCE(v_videos,    '[]'::json),
+    'tags',                COALESCE(v_tags,      '[]'::json),
+    'performers',          COALESCE(v_performers,'[]'::json),
+    'sections',            COALESCE(v_sections,  '[]'::json)
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary

- `public_list_sections` テーブルを追加。セクションを第一級構造として設計し、ランキングは `display_mode='ranked'` という表示形態の一種として実装
- `public_list_videos` に `section_id` カラムを追加し、動画をセクションに所属させる構造を確立
- セクション管理・並べ替え用RPCを4つ追加（`upsert_list_section` / `delete_list_section` / `reorder_list_videos` / `assign_video_section`）
- `get_public_list_data` を更新し `sections` / `sort_order` / `section_id` を返却するように変更
- リスト詳細ページ: セクション別グループ表示・ランキングバッジ（#1, #2...）対応
- `ListReorderMode` コンポーネント追加: オーナーが上下ボタンで並べ替え・セクション管理できるUI

## 設計方針

「セクションが土台、ランキングはセクションの1表示形態」として設計。現状はセクションなし＝フラットなランキング表示から始め、後からセクションを増やすだけで二軸（横の意味分類 × 縦の価値序列）に育てられる。

## Test plan

- [ ] カスタムリストの詳細ページで「並べ替え・セクション」ボタンが表示される（オーナーのみ）
- [ ] 上下ボタンで動画を並べ替え、保存後にページが更新される
- [ ] セクションを作成・削除できる
- [ ] 動画をセクションに割り当て、保存後にセクション別表示になる
- [ ] ランキングバッジ（#1, #2...）が正しく表示される
- [ ] いいねリスト（liked）では並べ替えUIが非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)