### PR TITLE
fix: Supabase CLI バージョンを固定してCIのタイムアウトを解消

### DIFF
--- a/.github/workflows/apprelease-release.yml
+++ b/.github/workflows/apprelease-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: latest
+          version: 2.23.4
 
       - name: Link project
         working-directory: supabase
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: latest
+          version: 2.23.4
 
       - name: Link project
         working-directory: supabase

--- a/.github/workflows/cicd-deploy-db.yml
+++ b/.github/workflows/cicd-deploy-db.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: latest
+          version: 2.23.4
 
       - name: Link project
         working-directory: supabase

--- a/.github/workflows/cicd-deploy-functions.yml
+++ b/.github/workflows/cicd-deploy-functions.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: latest
+          version: 2.23.4
 
       - name: Link project
         working-directory: supabase


### PR DESCRIPTION
## Summary

- `supabase/setup-cli@v2` で `version: latest` を指定していたため、毎回 GitHub API からバージョンを取得しようとしてタイムアウトが頻発していた
- 4箇所すべて `version: 2.23.4` に固定

## 対象ファイル

- `.github/workflows/cicd-deploy-db.yml`
- `.github/workflows/cicd-deploy-functions.yml`
- `.github/workflows/apprelease-release.yml`（2箇所）

🤖 Generated with [Claude Code](https://claude.com/claude-code)