### PR TITLE
fix: Supabase CLI を 2.106.0 に更新

### DIFF
--- a/.github/workflows/apprelease-release.yml
+++ b/.github/workflows/apprelease-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.23.4
+          version: 2.106.0
 
       - name: Link project
         working-directory: supabase
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.23.4
+          version: 2.106.0
 
       - name: Link project
         working-directory: supabase

--- a/.github/workflows/cicd-deploy-db.yml
+++ b/.github/workflows/cicd-deploy-db.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.23.4
+          version: 2.106.0
 
       - name: Link project
         working-directory: supabase

--- a/.github/workflows/cicd-deploy-functions.yml
+++ b/.github/workflows/cicd-deploy-functions.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v2
         with:
-          version: 2.23.4
+          version: 2.106.0
 
       - name: Link project
         working-directory: supabase


### PR DESCRIPTION
## Summary

- 前回 2.23.4 に固定したが、`supabase/config.toml` に含まれる新しいキー（`db.migrations.enabled`, `db.network_restrictions`, `auth.rate_limit.web3`, `auth.web3`）を古いCLIが認識できず `supabase link` がエラーになっていた
- 安定版最新の `2.106.0` に更新して解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)