### PR TITLE
feat: 編集モードをセクション別グループ化・コンパクトカードD&Dに刷新

### DIFF
--- a/frontend/src/app/list/[token]/VideoListSection.tsx
+++ b/frontend/src/app/list/[token]/VideoListSection.tsx
@@ -42,6 +42,15 @@ function toLgThumb(url: string | null | undefined): string | null {
   return url.replace('ps.jpg', 'pl.jpg');
 }
 
+function getThumb(video: Video): string | null {
+  const { primary } = resolveThumbnail({
+    source: video.source,
+    thumbnail_url: video.thumbnail_url,
+    image_urls: video.image_urls,
+  });
+  return primary ?? toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
+}
+
 export default function VideoListSection({
   ownerUserId,
   listId,
@@ -56,7 +65,8 @@ export default function VideoListSection({
   const [saving, setSaving] = useState(false);
   const [addingSection, setAddingSection] = useState(false);
 
-  const [orderedVideos, setOrderedVideos] = useState<Video[]>([]);
+  // セクション別に動画を管理（null = 未分類）
+  const [videosBySection, setVideosBySection] = useState<Map<string | null, Video[]>>(new Map());
   const [sections, setSections] = useState<Section[]>([]);
   const [newSectionTitle, setNewSectionTitle] = useState('');
 
@@ -73,27 +83,54 @@ export default function VideoListSection({
       if (b.sort_order === null) return -1;
       return a.sort_order - b.sort_order;
     });
-    setOrderedVideos(sorted);
-    setSections([...initialSections].sort((a, b) => a.sort_order - b.sort_order));
+    const secs = [...initialSections].sort((a, b) => a.sort_order - b.sort_order);
+
+    const map = new Map<string | null, Video[]>();
+    map.set(null, []);
+    for (const s of secs) map.set(s.id, []);
+    for (const v of sorted) {
+      const key = v.section_id && map.has(v.section_id) ? v.section_id : null;
+      map.get(key)!.push(v);
+    }
+
+    setVideosBySection(map);
+    setSections(secs);
     setEditMode(true);
   }, [videos, initialSections]);
 
-  const onVideoDragEnd = useCallback((result: DropResult) => {
+  // セクション並べ替え・動画D&Dを1つのhandlerで処理
+  const onDragEnd = useCallback((result: DropResult) => {
     if (!result.destination) return;
-    setOrderedVideos(prev => {
-      const next = [...prev];
-      const [moved] = next.splice(result.source.index, 1);
-      next.splice(result.destination!.index, 0, moved);
-      return next;
-    });
-  }, []);
 
-  const onSectionDragEnd = useCallback((result: DropResult) => {
-    if (!result.destination) return;
-    setSections(prev => {
-      const next = [...prev];
-      const [moved] = next.splice(result.source.index, 1);
-      next.splice(result.destination!.index, 0, moved);
+    if (result.type === 'SECTION') {
+      setSections(prev => {
+        const next = [...prev];
+        const [moved] = next.splice(result.source.index, 1);
+        next.splice(result.destination!.index, 0, moved);
+        return next;
+      });
+      return;
+    }
+
+    // type === 'VIDEO'
+    const srcKey = result.source.droppableId === 'uncategorized' ? null : result.source.droppableId;
+    const dstKey = result.destination.droppableId === 'uncategorized' ? null : result.destination.droppableId;
+
+    setVideosBySection(prev => {
+      const next = new Map(prev);
+      if (srcKey === dstKey) {
+        const list = [...(next.get(srcKey) ?? [])];
+        const [moved] = list.splice(result.source.index, 1);
+        list.splice(result.destination!.index, 0, moved);
+        next.set(srcKey, list);
+      } else {
+        const srcList = [...(next.get(srcKey) ?? [])];
+        const [moved] = srcList.splice(result.source.index, 1);
+        next.set(srcKey, srcList);
+        const dstList = [...(next.get(dstKey) ?? [])];
+        dstList.splice(result.destination!.index, 0, { ...moved, section_id: dstKey });
+        next.set(dstKey, dstList);
+      }
       return next;
     });
   }, []);
@@ -108,12 +145,6 @@ export default function VideoListSection({
     );
   }, []);
 
-  const assignSection = useCallback((videoId: string, sectionId: string | null) => {
-    setOrderedVideos(prev =>
-      prev.map(v => v.id === videoId ? { ...v, section_id: sectionId } : v)
-    );
-  }, []);
-
   const addSection = useCallback(async () => {
     if (!newSectionTitle.trim()) return;
     setAddingSection(true);
@@ -125,12 +156,9 @@ export default function VideoListSection({
     });
     setAddingSection(false);
     if (error) { alert('セクション作成に失敗しました: ' + error.message); return; }
-    setSections(prev => [...prev, {
-      id: data as string,
-      title: newSectionTitle.trim(),
-      display_mode: 'ranked',
-      sort_order: prev.length,
-    }]);
+    const newId = data as string;
+    setSections(prev => [...prev, { id: newId, title: newSectionTitle.trim(), display_mode: 'ranked', sort_order: prev.length }]);
+    setVideosBySection(prev => { const next = new Map(prev); next.set(newId, []); return next; });
     setNewSectionTitle('');
   }, [newSectionTitle, listId, sections.length]);
 
@@ -138,42 +166,56 @@ export default function VideoListSection({
     const { error } = await supabase.rpc('delete_list_section', { p_section_id: sectionId });
     if (error) { alert('セクション削除に失敗しました: ' + error.message); return; }
     setSections(prev => prev.filter(s => s.id !== sectionId));
-    setOrderedVideos(prev => prev.map(v => v.section_id === sectionId ? { ...v, section_id: null } : v));
+    setVideosBySection(prev => {
+      const next = new Map(prev);
+      const moved = (next.get(sectionId) ?? []).map(v => ({ ...v, section_id: null }));
+      next.delete(sectionId);
+      next.set(null, [...(next.get(null) ?? []), ...moved]);
+      return next;
+    });
   }, []);
 
   const save = useCallback(async () => {
     setSaving(true);
     try {
-      // 動画並べ替え
+      // フラットな順序リストを構築（セクション順 → 未分類）
+      const flatVideos: Video[] = [];
+      for (const section of sections) {
+        for (const v of videosBySection.get(section.id) ?? []) flatVideos.push(v);
+      }
+      for (const v of videosBySection.get(null) ?? []) flatVideos.push(v);
+
       const { error: reorderErr } = await supabase.rpc('reorder_list_videos', {
         p_list_id: listId,
-        p_video_ids: orderedVideos.map(v => v.id),
+        p_video_ids: flatVideos.map(v => v.id),
       });
       if (reorderErr) throw reorderErr;
 
-      // 動画セクション割り当て
-      for (const video of orderedVideos) {
-        const original = videos.find(v => v.id === video.id);
-        if (original?.section_id !== video.section_id) {
-          const { error } = await supabase.rpc('assign_video_section', {
-            p_list_id: listId,
-            p_video_id: video.id,
-            p_section_id: video.section_id,
-          });
-          if (error) throw error;
+      // セクション割り当て変更分を保存
+      for (const [sectionId, vids] of videosBySection) {
+        for (const video of vids) {
+          const original = videos.find(v => v.id === video.id);
+          if (original?.section_id !== sectionId) {
+            const { error } = await supabase.rpc('assign_video_section', {
+              p_list_id: listId,
+              p_video_id: video.id,
+              p_section_id: sectionId,
+            });
+            if (error) throw error;
+          }
         }
       }
 
       // セクション並べ替え
       if (sections.length > 0) {
-        const { error: secReorderErr } = await supabase.rpc('reorder_list_sections', {
+        const { error } = await supabase.rpc('reorder_list_sections', {
           p_list_id: listId,
           p_section_ids: sections.map(s => s.id),
         });
-        if (secReorderErr) throw secReorderErr;
+        if (error) throw error;
       }
 
-      // display_mode 更新（変更があったセクションのみ）
+      // display_mode 変更分を保存
       for (const section of sections) {
         const original = initialSections.find(s => s.id === section.id);
         if (original && original.display_mode !== section.display_mode) {
@@ -195,19 +237,17 @@ export default function VideoListSection({
     } finally {
       setSaving(false);
     }
-  }, [orderedVideos, sections, initialSections, listId, videos, router]);
+  }, [videosBySection, sections, initialSections, listId, videos, router]);
 
   // ---- 通常表示（閲覧モード） ----
   if (!editMode) {
-    const flatVideos = videos;
-    const sectionsArr = initialSections;
-    const isFlat = sectionsArr.length === 0;
-    const flatIsRanked = listType === 'custom' && flatVideos.some(v => v.sort_order !== null);
+    const isFlat = initialSections.length === 0;
+    const flatIsRanked = listType === 'custom' && videos.some(v => v.sort_order !== null);
 
     const sectionMap = new Map<string | null, Video[]>();
     sectionMap.set(null, []);
-    for (const s of sectionsArr) sectionMap.set(s.id, []);
-    for (const v of flatVideos) {
+    for (const s of initialSections) sectionMap.set(s.id, []);
+    for (const v of videos) {
       const key = v.section_id ?? null;
       if (!sectionMap.has(key)) sectionMap.set(key, []);
       sectionMap.get(key)!.push(v);
@@ -227,11 +267,11 @@ export default function VideoListSection({
           </div>
         )}
 
-        {flatVideos.length === 0 ? (
+        {videos.length === 0 ? (
           <p className="text-center text-[#656d76] py-20">まだ作品がありません。</p>
         ) : isFlat ? (
           <div className="[column-count:2] sm:[column-count:3] [column-gap:12px]">
-            {flatVideos.map((video, i) => (
+            {videos.map((video, i) => (
               <NormalCard
                 key={video.id}
                 video={video}
@@ -242,9 +282,8 @@ export default function VideoListSection({
           </div>
         ) : (
           <div className="space-y-10">
-            {sectionsArr.map(section => {
+            {initialSections.map(section => {
               const sv = sectionMap.get(section.id) ?? [];
-              const isRanked = section.display_mode === 'ranked';
               if (sv.length === 0) return null;
               return (
                 <div key={section.id}>
@@ -259,7 +298,7 @@ export default function VideoListSection({
                         key={video.id}
                         video={video}
                         affiliateUrl={affiliateUrls[video.id] ?? ''}
-                        rank={isRanked ? i + 1 : null}
+                        rank={section.display_mode === 'ranked' ? i + 1 : null}
                       />
                     ))}
                   </div>
@@ -289,10 +328,12 @@ export default function VideoListSection({
     );
   }
 
-  // ---- 編集モード（D&D） ----
+  // ---- 編集モード ----
+  const uncategorized = videosBySection.get(null) ?? [];
+
   return (
-    <div>
-      {/* 編集モードヘッダー */}
+    <DragDropContext onDragEnd={onDragEnd}>
+      {/* ヘッダー */}
       <div className="sticky top-0 z-10 mb-4 flex items-center justify-between gap-3 px-4 py-3 rounded-xl bg-violet-500/10 border border-violet-500/40 backdrop-blur">
         <span className="text-sm font-bold text-violet-300">並べ替え・セクション編集</span>
         <div className="flex items-center gap-2">
@@ -313,163 +354,163 @@ export default function VideoListSection({
         </div>
       </div>
 
-      {/* セクション管理 */}
-      <div className="mb-5 space-y-2">
-        <DragDropContext onDragEnd={onSectionDragEnd}>
-          <Droppable droppableId="section-list" direction="vertical">
-            {provided => (
-              <div ref={provided.innerRef} {...provided.droppableProps} className="space-y-1.5">
-                {sections.map((section, i) => (
-                  <Draggable key={section.id} draggableId={`sec-${section.id}`} index={i}>
-                    {(provided, snapshot) => (
-                      <div
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        className={`flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-[#161b22] border text-xs transition-shadow ${
-                          snapshot.isDragging ? 'border-violet-500/50 shadow-md' : 'border-[#30363d]'
-                        }`}
-                      >
-                        <div {...provided.dragHandleProps} className="text-[#484f58] hover:text-[#8b949e] cursor-grab">
-                          <GripVertical size={13} />
+      {/* セクション（D&D対応） */}
+      <Droppable droppableId="sections" type="SECTION">
+        {provided => (
+          <div ref={provided.innerRef} {...provided.droppableProps} className="space-y-4 mb-4">
+            {sections.map((section, sIdx) => {
+              const sectionVideos = videosBySection.get(section.id) ?? [];
+              return (
+                <Draggable key={section.id} draggableId={`sec-${section.id}`} index={sIdx}>
+                  {(provided, snapshot) => (
+                    <div
+                      ref={provided.innerRef}
+                      {...provided.draggableProps}
+                      className={`rounded-xl border bg-[#0d1117] transition-shadow ${
+                        snapshot.isDragging ? 'border-violet-500/50 shadow-lg' : 'border-[#21262d]'
+                      }`}
+                    >
+                      {/* セクションヘッダー */}
+                      <div className="flex items-center gap-2 px-3 py-2 border-b border-[#21262d]">
+                        <div {...provided.dragHandleProps} className="text-[#484f58] hover:text-[#8b949e] cursor-grab shrink-0">
+                          <GripVertical size={14} />
                         </div>
-                        <span className="text-[#e6edf3] flex-1">{section.title ?? '無題'}</span>
-                        {/* display_mode トグル */}
+                        <span className="text-xs font-bold text-[#e6edf3] flex-1">{section.title ?? '無題'}</span>
                         <button
                           onClick={() => toggleDisplayMode(section.id)}
-                          title={section.display_mode === 'ranked' ? 'ランキング表示（クリックでプレーンに変更）' : 'プレーン表示（クリックでランキングに変更）'}
+                          title={section.display_mode === 'ranked' ? 'ランキング表示' : 'プレーン表示'}
                           className={`flex items-center gap-1 px-2 py-0.5 rounded-full border text-[10px] font-bold transition-colors ${
                             section.display_mode === 'ranked'
                               ? 'border-amber-500/40 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20'
                               : 'border-[#30363d] bg-[#0d1117] text-[#656d76] hover:border-[#8b949e] hover:text-[#8b949e]'
                           }`}
                         >
-                          {section.display_mode === 'ranked'
-                            ? <><Trophy size={9} />ランク</>
-                            : <><List size={9} />プレーン</>
-                          }
+                          {section.display_mode === 'ranked' ? <><Trophy size={9} />ランク</> : <><List size={9} />プレーン</>}
                         </button>
-                        <button
-                          onClick={() => deleteSection(section.id)}
-                          className="text-[#484f58] hover:text-red-400 transition-colors"
-                        >
+                        <button onClick={() => deleteSection(section.id)} className="text-[#484f58] hover:text-red-400 transition-colors shrink-0">
                           <X size={12} />
                         </button>
                       </div>
-                    )}
-                  </Draggable>
-                ))}
-                {provided.placeholder}
-              </div>
-            )}
-          </Droppable>
-        </DragDropContext>
-        {/* 新規セクション追加 */}
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={newSectionTitle}
-            onChange={e => setNewSectionTitle(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && addSection()}
-            placeholder="新しいセクション名を追加..."
-            className="flex-1 px-3 py-1.5 rounded-lg bg-[#161b22] border border-[#30363d] focus:border-violet-500/60 outline-none text-xs text-[#e6edf3] placeholder-[#484f58]"
-          />
-          <button
-            onClick={addSection}
-            disabled={addingSection || !newSectionTitle.trim()}
-            className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-violet-300 disabled:opacity-40 text-xs font-semibold transition-colors"
-          >
-            {addingSection ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
-            追加
-          </button>
-        </div>
+
+                      {/* セクション内動画 */}
+                      <Droppable droppableId={section.id} type="VIDEO" direction="horizontal">
+                        {(provided, snapshot) => (
+                          <div
+                            ref={provided.innerRef}
+                            {...provided.droppableProps}
+                            className={`p-2 min-h-[80px] grid grid-cols-4 sm:grid-cols-6 gap-1.5 content-start transition-colors rounded-b-xl ${
+                              snapshot.isDraggingOver ? 'bg-violet-500/5' : ''
+                            }`}
+                          >
+                            {sectionVideos.map((video, vIdx) => (
+                              <CompactCard
+                                key={video.id}
+                                video={video}
+                                index={vIdx}
+                                isRanked={section.display_mode === 'ranked'}
+                              />
+                            ))}
+                            {provided.placeholder}
+                            {sectionVideos.length === 0 && !snapshot.isDraggingOver && (
+                              <p className="col-span-4 sm:col-span-6 text-[10px] text-[#484f58] py-2 text-center">ここにドラッグして追加</p>
+                            )}
+                          </div>
+                        )}
+                      </Droppable>
+                    </div>
+                  )}
+                </Draggable>
+              );
+            })}
+            {provided.placeholder}
+          </div>
+        )}
+      </Droppable>
+
+      {/* セクション追加 */}
+      <div className="flex gap-2 mb-6">
+        <input
+          type="text"
+          value={newSectionTitle}
+          onChange={e => setNewSectionTitle(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && addSection()}
+          placeholder="新しいセクション名を追加..."
+          className="flex-1 px-3 py-1.5 rounded-lg bg-[#161b22] border border-[#30363d] focus:border-violet-500/60 outline-none text-xs text-[#e6edf3] placeholder-[#484f58]"
+        />
+        <button
+          onClick={addSection}
+          disabled={addingSection || !newSectionTitle.trim()}
+          className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-[#161b22] border border-[#30363d] hover:border-violet-500/50 text-[#8b949e] hover:text-violet-300 disabled:opacity-40 text-xs font-semibold transition-colors"
+        >
+          {addingSection ? <Loader2 size={12} className="animate-spin" /> : <Plus size={12} />}
+          追加
+        </button>
       </div>
 
-      {/* 動画 D&D リスト */}
-      <DragDropContext onDragEnd={onVideoDragEnd}>
-        <Droppable droppableId="video-list">
-          {provided => (
+      {/* 未分類 */}
+      <div className="rounded-xl border border-[#21262d] bg-[#0d1117]">
+        <div className="px-3 py-2 border-b border-[#21262d]">
+          <span className="text-xs font-bold text-[#484f58]">未分類</span>
+        </div>
+        <Droppable droppableId="uncategorized" type="VIDEO" direction="horizontal">
+          {(provided, snapshot) => (
             <div
               ref={provided.innerRef}
               {...provided.droppableProps}
-              className="grid grid-cols-2 sm:grid-cols-3 gap-3"
+              className={`p-2 min-h-[80px] grid grid-cols-4 sm:grid-cols-6 gap-1.5 content-start transition-colors rounded-b-xl ${
+                snapshot.isDraggingOver ? 'bg-violet-500/5' : ''
+              }`}
             >
-              {orderedVideos.map((video, i) => {
-                const { primary: resolvedThumb } = resolveThumbnail({
-                  source: video.source,
-                  thumbnail_url: video.thumbnail_url,
-                  image_urls: video.image_urls,
-                });
-                const thumb = resolvedThumb ?? toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
-
-                return (
-                  <Draggable key={video.id} draggableId={video.id} index={i}>
-                    {(provided, snapshot) => (
-                      <div
-                        ref={provided.innerRef}
-                        {...provided.draggableProps}
-                        className={`relative rounded-lg overflow-hidden border bg-[#161b22] transition-shadow ${
-                          snapshot.isDragging
-                            ? 'border-violet-500/60 shadow-lg shadow-violet-500/20 rotate-1'
-                            : 'border-[#30363d]'
-                        }`}
-                      >
-                        {/* ドラッグハンドル */}
-                        <div
-                          {...provided.dragHandleProps}
-                          className="absolute top-1.5 right-1.5 z-10 p-1 rounded bg-black/60 backdrop-blur cursor-grab active:cursor-grabbing text-[#8b949e] hover:text-white transition-colors"
-                        >
-                          <GripVertical size={14} />
-                        </div>
-
-                        {/* ランク番号 */}
-                        <div className="absolute top-1.5 left-1.5 z-10 min-w-[20px] h-[20px] px-1 rounded bg-black/70 backdrop-blur flex items-center justify-center">
-                          <span className="text-[10px] font-black text-violet-300">#{i + 1}</span>
-                        </div>
-
-                        {/* サムネイル */}
-                        {thumb ? (
-                          // eslint-disable-next-line @next/next/no-img-element
-                          <img
-                            src={thumb}
-                            alt={video.title ?? ''}
-                            className="w-full h-auto"
-                            loading="lazy"
-                          />
-                        ) : (
-                          <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
-                            <span className="text-[#484f58] text-xs">No Image</span>
-                          </div>
-                        )}
-
-                        {/* タイトル + セクション選択 */}
-                        <div className="p-2 space-y-1.5">
-                          <p className="text-[11px] text-[#8b949e] leading-tight line-clamp-2">
-                            {video.title ?? ''}
-                          </p>
-                          {sections.length > 0 && (
-                            <select
-                              value={video.section_id ?? ''}
-                              onChange={e => assignSection(video.id, e.target.value || null)}
-                              className="w-full text-[11px] bg-[#0d1117] border border-[#30363d] rounded px-1.5 py-0.5 text-[#8b949e]"
-                            >
-                              <option value="">未分類</option>
-                              {sections.map(s => (
-                                <option key={s.id} value={s.id}>{s.title ?? '無題'}</option>
-                              ))}
-                            </select>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </Draggable>
-                );
-              })}
+              {uncategorized.map((video, vIdx) => (
+                <CompactCard key={video.id} video={video} index={vIdx} isRanked={false} />
+              ))}
               {provided.placeholder}
+              {uncategorized.length === 0 && !snapshot.isDraggingOver && (
+                <p className="col-span-4 sm:col-span-6 text-[10px] text-[#484f58] py-2 text-center">未分類の作品はありません</p>
+              )}
             </div>
           )}
         </Droppable>
-      </DragDropContext>
-    </div>
+      </div>
+    </DragDropContext>
+  );
+}
+
+function CompactCard({ video, index, isRanked }: { video: Video; index: number; isRanked: boolean }) {
+  const thumb = getThumb(video);
+  return (
+    <Draggable draggableId={video.id} index={index}>
+      {(provided, snapshot) => (
+        <div
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          title={video.title ?? ''}
+          className={`relative rounded overflow-hidden border bg-[#161b22] cursor-grab active:cursor-grabbing transition-all ${
+            snapshot.isDragging
+              ? 'border-violet-500/60 shadow-lg shadow-violet-500/20 rotate-1 scale-105'
+              : 'border-[#30363d] hover:border-[#8b949e]'
+          }`}
+        >
+          {thumb ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={thumb} alt="" className="w-full aspect-[2/3] object-cover" loading="lazy" />
+          ) : (
+            <div className="w-full aspect-[2/3] bg-[#21262d] flex items-center justify-center">
+              <span className="text-[#484f58] text-[9px]">No Image</span>
+            </div>
+          )}
+          {isRanked && (
+            <div className="absolute top-0.5 left-0.5 min-w-[16px] h-[16px] px-0.5 rounded bg-black/70 flex items-center justify-center">
+              <span className="text-[9px] font-black text-violet-300">#{index + 1}</span>
+            </div>
+          )}
+          <div className="absolute top-0.5 right-0.5 text-[#8b949e]/60">
+            <GripVertical size={10} />
+          </div>
+        </div>
+      )}
+    </Draggable>
   );
 }
 
@@ -478,13 +519,7 @@ function NormalCard({ video, affiliateUrl, rank }: {
   affiliateUrl: string;
   rank: number | null;
 }) {
-  const { primary: resolvedThumb } = resolveThumbnail({
-    source: video.source,
-    thumbnail_url: video.thumbnail_url,
-    image_urls: video.image_urls,
-  });
-  const thumb = resolvedThumb ?? toLgThumb(video.thumbnail_url) ?? toLgThumb(video.thumbnail_vertical_url);
-
+  const thumb = getThumb(video);
   return (
     <div className="group relative mb-3 break-inside-avoid">
       <a
@@ -496,12 +531,7 @@ function NormalCard({ video, affiliateUrl, rank }: {
         <div className="relative">
           {thumb ? (
             // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={thumb}
-              alt={video.title ?? ''}
-              className="w-full h-auto group-hover:opacity-90 transition-opacity"
-              loading="lazy"
-            />
+            <img src={thumb} alt={video.title ?? ''} className="w-full h-auto group-hover:opacity-90 transition-opacity" loading="lazy" />
           ) : (
             <div className="w-full aspect-video bg-[#21262d] flex items-center justify-center">
               <span className="text-[#484f58] text-xs">No Image</span>
@@ -514,9 +544,7 @@ function NormalCard({ video, affiliateUrl, rank }: {
           )}
         </div>
         <div className="p-2">
-          <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">
-            {video.title ?? ''}
-          </p>
+          <p className="text-xs text-[#8b949e] leading-tight line-clamp-2">{video.title ?? ''}</p>
         </div>
       </a>
     </div>


### PR DESCRIPTION
## Summary
- 編集モードの動画表示をセクション別グループに変更（フラットリストから改善）
- ランク番号がセクション内での順位を正しく反映するように
- 動画カードをコンパクト（4〜6列）なサムネのみ表示に変更し、セクション間ドラッグをしやすく
- セクション間の動画移動をドラッグ&ドロップで直接操作可能に
- セクション自体のD&D並べ替え・display_modeトグルも引き続き対応

## Test plan
- [ ] 編集モードでセクションごとにグループ表示される
- [ ] セクション内でドラッグして順序変更できる
- [ ] 別セクションへドラッグして移動できる（section_idが更新される）
- [ ] 未分類エリアへ/からドラッグできる
- [ ] セクション自体をドラッグして順序変更できる
- [ ] ランク/プレーンのトグルが反映される
- [ ] 保存後に閲覧モードで正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)