### PR TITLE
fix: 20260615150310 のリモートマイグレーション stub 追加

### DIFF
--- a/supabase/migrations/20260615150310_remote_only_stub.sql
+++ b/supabase/migrations/20260615150310_remote_only_stub.sql
@@ -1,0 +1,1 @@
+-- Remote-only migration stub (applied directly to remote)


### PR DESCRIPTION
## Summary
- CI の `db push` でバージョン `20260615150310` が見つからないエラーが発生
- stub ファイルを追加（auto-detect 方式で repair に対応）

## Test plan
- [ ] CI の Deploy DB Migrations が正常完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)